### PR TITLE
refactor: Enum type's fields in uppercase letters

### DIFF
--- a/starter-api/src/main/java/io/micronaut/starter/api/create/AbstractCreateController.java
+++ b/starter-api/src/main/java/io/micronaut/starter/api/create/AbstractCreateController.java
@@ -75,7 +75,7 @@ public abstract class AbstractCreateController implements CreateOperation {
                 try {
                     projectGenerator.generate(type,
                             project,
-                            new Options(lang, testFramework, buildTool == null ? BuildTool.gradle : buildTool),
+                            new Options(lang, testFramework, buildTool == null ? BuildTool.GRADLE : buildTool),
                             features == null ? Collections.emptyList() : features,
                             new ZipOutputHandler(outputStream),
                             ConsoleOutput.NOOP);

--- a/starter-api/src/main/java/io/micronaut/starter/api/preview/PreviewController.java
+++ b/starter-api/src/main/java/io/micronaut/starter/api/preview/PreviewController.java
@@ -85,7 +85,7 @@ public class PreviewController extends AbstractCreateController implements Previ
             MapOutputHandler outputHandler = new MapOutputHandler();
             projectGenerator.generate(type,
                     project,
-                    new Options(lang, test, build == null ? BuildTool.gradle : build),
+                    new Options(lang, test, build == null ? BuildTool.GRADLE : build),
                     features == null ? Collections.emptyList() : features,
                     outputHandler,
                     ConsoleOutput.NOOP);

--- a/starter-api/src/test/groovy/io/micronaut/starter/api/CreateControllerSpec.groovy
+++ b/starter-api/src/test/groovy/io/micronaut/starter/api/CreateControllerSpec.groovy
@@ -37,7 +37,7 @@ class CreateControllerSpec extends Specification {
 
     void "test create app with kotlin"() {
         when:
-        def bytes = client.createApp("test", ['graalvm'], null, null, Language.kotlin)
+        def bytes = client.createApp("test", ['graalvm'], null, null, Language.KOTLIN)
 
         then:
         ZipUtil.containsFile(bytes, "Application.kt")
@@ -45,7 +45,7 @@ class CreateControllerSpec extends Specification {
 
     void "test create app with groovy"() {
         when:
-        def bytes = client.createApp("test", ['graalvm'], null, null, Language.groovy)
+        def bytes = client.createApp("test", ['graalvm'], null, null, Language.GROOVY)
 
         then:
         ZipUtil.containsFile(bytes, "Application.groovy")
@@ -53,7 +53,7 @@ class CreateControllerSpec extends Specification {
 
     void "test create app with maven"() {
         when:
-        def bytes = client.createApp("test", ['graalvm'], BuildTool.maven, null, Language.groovy)
+        def bytes = client.createApp("test", ['graalvm'], BuildTool.MAVEN, null, Language.GROOVY)
 
         then:
         ZipUtil.containsFile(bytes, "pom.xml")
@@ -61,7 +61,7 @@ class CreateControllerSpec extends Specification {
 
     void "test create app with spock"() {
         when:
-        def bytes = client.createApp("test", ['graalvm'], BuildTool.gradle, TestFramework.spock, Language.groovy)
+        def bytes = client.createApp("test", ['graalvm'], BuildTool.GRADLE, TestFramework.SPOCK, Language.GROOVY)
 
         then:
         ZipUtil.containsFileWithContents(bytes, "build.gradle", "spock-core")

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/CodeGenConfig.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/CodeGenConfig.java
@@ -152,9 +152,9 @@ public class CodeGenConfig {
             availableFeatures = beanContext.getBean(codeGenConfig.getApplicationType().getAvailableFeaturesClass());
 
             if (new File("build.gradle").exists()) {
-                codeGenConfig.setBuildTool(BuildTool.gradle);
+                codeGenConfig.setBuildTool(BuildTool.GRADLE);
             } else if (new File("pom.xml").exists()) {
-                codeGenConfig.setBuildTool(BuildTool.maven);
+                codeGenConfig.setBuildTool(BuildTool.MAVEN);
             } else {
                 return null;
             }

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/BuildToolCandidates.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/BuildToolCandidates.java
@@ -13,29 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.options;
+package io.micronaut.starter.cli.command;
 
-import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.options.BuildTool;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-public enum Language {
-    JAVA,
-    GROOVY,
-    KOTLIN;
-
-    public static Language infer(List<Feature> features) {
-        return features.stream()
-                .map(Feature::getRequiredLanguage)
-                .filter(Optional::isPresent)
-                .findFirst()
-                .map(Optional::get)
-                .orElse(null);
-    }
-
-    @Override
-    public String toString() {
-        return this.name().toLowerCase();
+public class BuildToolCandidates extends ArrayList<String> {
+    public BuildToolCandidates() {
+        super(Stream.of(BuildTool.values()).map(bt -> bt.toString().toLowerCase()).collect(Collectors.toList()));
     }
 }

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/BuildToolConverter.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/BuildToolConverter.java
@@ -13,29 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.options;
+package io.micronaut.starter.cli.command;
 
-import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.options.BuildTool;
+import picocli.CommandLine;
 
-import java.util.List;
-import java.util.Optional;
+public class BuildToolConverter implements CommandLine.ITypeConverter<BuildTool> {
 
-public enum Language {
-    JAVA,
-    GROOVY,
-    KOTLIN;
-
-    public static Language infer(List<Feature> features) {
-        return features.stream()
-                .map(Feature::getRequiredLanguage)
-                .filter(Optional::isPresent)
-                .findFirst()
-                .map(Optional::get)
-                .orElse(null);
-    }
+    public static final BuildTool DEFAULT_BUILD_TOOL = BuildTool.GRADLE;
 
     @Override
-    public String toString() {
-        return this.name().toLowerCase();
+    public BuildTool convert(String value) throws Exception {
+        if (value == null) {
+            return DEFAULT_BUILD_TOOL;
+        }
+        for (BuildTool bt : BuildTool.values()) {
+            if (value.equalsIgnoreCase(bt.toString())) {
+                return bt;
+            }
+        }
+        return DEFAULT_BUILD_TOOL;
     }
 }

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateCommand.java
@@ -40,14 +40,14 @@ public abstract class CreateCommand extends BaseCommand implements Callable<Inte
     @CommandLine.Parameters(arity = "0..1", paramLabel = "NAME", description = "The name of the application to create.")
     String name;
 
-    @CommandLine.Option(names = {"-l", "--lang"}, paramLabel = "LANG", description = "Which language to use. Possible values: ${COMPLETION-CANDIDATES}.")
+    @CommandLine.Option(names = {"-l", "--lang"}, paramLabel = "LANG", description = "Which language to use. Possible values: ${COMPLETION-CANDIDATES}.", completionCandidates = LanguageCandidates.class, converter = LanguageConverter.class)
     Language lang;
 
-    @CommandLine.Option(names = {"-t", "--test"}, paramLabel = "TEST", description = "Which test framework to use. Possible values: ${COMPLETION-CANDIDATES}.")
+    @CommandLine.Option(names = {"-t", "--test"}, paramLabel = "TEST", description = "Which test framework to use. Possible values: ${COMPLETION-CANDIDATES}.", completionCandidates = TestFrameworkCandidates.class, converter = TestFrameworkConverter.class)
     TestFramework test;
 
-    @CommandLine.Option(names = {"-b", "--build"}, paramLabel = "BUILD-TOOL", description = "Which build tool to configure. Possible values: ${COMPLETION-CANDIDATES}.")
-    BuildTool build = BuildTool.gradle;
+    @CommandLine.Option(names = {"-b", "--build"}, paramLabel = "BUILD-TOOL", description = "Which build tool to configure. Possible values: ${COMPLETION-CANDIDATES}.", completionCandidates = BuildToolCandidates.class, converter = BuildToolConverter.class)
+    BuildTool build = BuildToolConverter.DEFAULT_BUILD_TOOL;
 
     @CommandLine.Option(names = {"-i", "--inplace"}, description = "Create a service using the current directory")
     boolean inplace;

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/LanguageCandidates.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/LanguageCandidates.java
@@ -13,29 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.options;
+package io.micronaut.starter.cli.command;
+import io.micronaut.starter.options.Language;
 
-import io.micronaut.starter.feature.Feature;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import java.util.List;
-import java.util.Optional;
-
-public enum Language {
-    JAVA,
-    GROOVY,
-    KOTLIN;
-
-    public static Language infer(List<Feature> features) {
-        return features.stream()
-                .map(Feature::getRequiredLanguage)
-                .filter(Optional::isPresent)
-                .findFirst()
-                .map(Optional::get)
-                .orElse(null);
-    }
-
-    @Override
-    public String toString() {
-        return this.name().toLowerCase();
+public class LanguageCandidates extends ArrayList<String> {
+    public LanguageCandidates() {
+        super(Stream.of(Language.values()).map(l -> l.toString().toLowerCase()).collect(Collectors.toList()));
     }
 }

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/LanguageConverter.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/LanguageConverter.java
@@ -13,29 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.options;
+package io.micronaut.starter.cli.command;
+import io.micronaut.starter.options.Language;
+import picocli.CommandLine;
 
-import io.micronaut.starter.feature.Feature;
+public class LanguageConverter implements CommandLine.ITypeConverter<Language> {
 
-import java.util.List;
-import java.util.Optional;
-
-public enum Language {
-    JAVA,
-    GROOVY,
-    KOTLIN;
-
-    public static Language infer(List<Feature> features) {
-        return features.stream()
-                .map(Feature::getRequiredLanguage)
-                .filter(Optional::isPresent)
-                .findFirst()
-                .map(Optional::get)
-                .orElse(null);
-    }
+    public static final Language DEFAULT_LANGUAGE = Language.JAVA;
 
     @Override
-    public String toString() {
-        return this.name().toLowerCase();
+    public Language convert(String value) throws Exception {
+        if (value == null) {
+            return DEFAULT_LANGUAGE;
+        }
+        for (Language bt : Language.values()) {
+            if (value.equalsIgnoreCase(bt.toString())) {
+                return bt;
+            }
+        }
+        return DEFAULT_LANGUAGE;
     }
 }

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/TestFrameworkCandidates.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/TestFrameworkCandidates.java
@@ -13,29 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.options;
+package io.micronaut.starter.cli.command;
 
-import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.options.TestFramework;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-public enum Language {
-    JAVA,
-    GROOVY,
-    KOTLIN;
-
-    public static Language infer(List<Feature> features) {
-        return features.stream()
-                .map(Feature::getRequiredLanguage)
-                .filter(Optional::isPresent)
-                .findFirst()
-                .map(Optional::get)
-                .orElse(null);
-    }
-
-    @Override
-    public String toString() {
-        return this.name().toLowerCase();
+public class TestFrameworkCandidates extends ArrayList<String> {
+    public TestFrameworkCandidates() {
+        super(Stream.of(TestFramework.values()).map(tf -> tf.toString().toLowerCase()).collect(Collectors.toList()));
     }
 }

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/TestFrameworkConverter.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/TestFrameworkConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.cli.command;
+
+import io.micronaut.starter.options.TestFramework;
+import picocli.CommandLine;
+
+public class TestFrameworkConverter implements CommandLine.ITypeConverter<TestFramework> {
+
+    public static final TestFramework DEFAULT_TEST_FRAMEWORK = TestFramework.JUNIT;
+
+    @Override
+    public TestFramework convert(String value) throws Exception {
+        if (value == null) {
+            return DEFAULT_TEST_FRAMEWORK;
+        }
+        for (TestFramework bt : TestFramework.values()) {
+            if (value.equalsIgnoreCase(bt.toString())) {
+                return bt;
+            }
+        }
+        return DEFAULT_TEST_FRAMEWORK;
+    }
+}

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/feature/grpc/CreateGrpcServiceCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/feature/grpc/CreateGrpcServiceCommand.java
@@ -61,11 +61,11 @@ public class CreateGrpcServiceCommand extends CodeGenCommand {
         TemplateRenderer templateRenderer = getTemplateRenderer(project);
 
         RenderResult renderResult = null;
-        if (config.getSourceLanguage() == Language.java) {
+        if (config.getSourceLanguage() == Language.JAVA) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/java/{packagePath}/{className}.java", javaService.template(project)), overwrite);
-        } else if (config.getSourceLanguage() == Language.groovy) {
+        } else if (config.getSourceLanguage() == Language.GROOVY) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/groovy/{packagePath}/{className}.groovy", groovyService.template(project)), overwrite);
-        } else if (config.getSourceLanguage() == Language.kotlin) {
+        } else if (config.getSourceLanguage() == Language.KOTLIN) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/kotlin/{packagePath}/{className}.kt", kotlinService.template(project)), overwrite);
         }
 

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/feature/messaging/kafka/CreateKafkaListener.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/feature/messaging/kafka/CreateKafkaListener.java
@@ -52,11 +52,11 @@ public class CreateKafkaListener extends CodeGenCommand {
         TemplateRenderer templateRenderer = getTemplateRenderer(project);
 
         RenderResult renderResult = null;
-        if (config.getSourceLanguage() == Language.java) {
+        if (config.getSourceLanguage() == Language.JAVA) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/java/{packagePath}/{className}.java", javaListener.template(project)), overwrite);
-        } else if (config.getSourceLanguage() == Language.groovy) {
+        } else if (config.getSourceLanguage() == Language.GROOVY) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/groovy/{packagePath}/{className}.groovy", groovyListener.template(project)), overwrite);
-        } else if (config.getSourceLanguage() == Language.kotlin) {
+        } else if (config.getSourceLanguage() == Language.KOTLIN) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/kotlin/{packagePath}/{className}.kt", kotlinListener.template(project)), overwrite);
         }
 

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/feature/messaging/kafka/CreateKafkaProducer.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/feature/messaging/kafka/CreateKafkaProducer.java
@@ -52,11 +52,11 @@ public class CreateKafkaProducer extends CodeGenCommand {
         TemplateRenderer templateRenderer = getTemplateRenderer(project);
 
         RenderResult renderResult = null;
-        if (config.getSourceLanguage() == Language.java) {
+        if (config.getSourceLanguage() == Language.JAVA) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/java/{packagePath}/{className}.java", javaProducer.template(project)), overwrite);
-        } else if (config.getSourceLanguage() == Language.groovy) {
+        } else if (config.getSourceLanguage() == Language.GROOVY) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/groovy/{packagePath}/{className}.groovy", groovyProducer.template(project)), overwrite);
-        } else if (config.getSourceLanguage() == Language.kotlin) {
+        } else if (config.getSourceLanguage() == Language.KOTLIN) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/kotlin/{packagePath}/{className}.kt", kotlinProducer.template(project)), overwrite);
         }
 

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/feature/messaging/rabbitmq/CreateRabbitMQListener.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/feature/messaging/rabbitmq/CreateRabbitMQListener.java
@@ -52,11 +52,11 @@ public class CreateRabbitMQListener extends CodeGenCommand {
         TemplateRenderer templateRenderer = getTemplateRenderer(project);
 
         RenderResult renderResult = null;
-        if (config.getSourceLanguage() == Language.java) {
+        if (config.getSourceLanguage() == Language.JAVA) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/java/{packagePath}/{className}.java", javaListener.template(project)), overwrite);
-        } else if (config.getSourceLanguage() == Language.groovy) {
+        } else if (config.getSourceLanguage() == Language.GROOVY) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/groovy/{packagePath}/{className}.groovy", groovyListener.template(project)), overwrite);
-        } else if (config.getSourceLanguage() == Language.kotlin) {
+        } else if (config.getSourceLanguage() == Language.KOTLIN) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/kotlin/{packagePath}/{className}.kt", kotlinListener.template(project)), overwrite);
         }
 

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/feature/messaging/rabbitmq/CreateRabbitMQProducer.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/feature/messaging/rabbitmq/CreateRabbitMQProducer.java
@@ -52,11 +52,11 @@ public class CreateRabbitMQProducer extends CodeGenCommand {
         TemplateRenderer templateRenderer = getTemplateRenderer(project);
 
         RenderResult renderResult = null;
-        if (config.getSourceLanguage() == Language.java) {
+        if (config.getSourceLanguage() == Language.JAVA) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/java/{packagePath}/{className}.java", javaProducer.template(project)), overwrite);
-        } else if (config.getSourceLanguage() == Language.groovy) {
+        } else if (config.getSourceLanguage() == Language.GROOVY) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/groovy/{packagePath}/{className}.groovy", groovyProducer.template(project)), overwrite);
-        } else if (config.getSourceLanguage() == Language.kotlin) {
+        } else if (config.getSourceLanguage() == Language.KOTLIN) {
             renderResult = templateRenderer.render(new RockerTemplate("src/main/kotlin/{packagePath}/{className}.kt", kotlinProducer.template(project)), overwrite);
         }
 

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/feature/picocli/CreateCommandCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/feature/picocli/CreateCommandCommand.java
@@ -75,11 +75,11 @@ public class CreateCommandCommand extends CodeGenCommand {
         TemplateRenderer templateRenderer = getTemplateRenderer(project);
 
         RenderResult renderResult = null;
-        if (config.getSourceLanguage() == Language.java) {
+        if (config.getSourceLanguage() == Language.JAVA) {
             renderResult = templateRenderer.render(javaApplication.getTemplate(project), overwrite);
-        } else if (config.getSourceLanguage() == Language.groovy) {
+        } else if (config.getSourceLanguage() == Language.GROOVY) {
             renderResult = templateRenderer.render(groovyApplication.getTemplate(project), overwrite);
-        } else if (config.getSourceLanguage() == Language.kotlin) {
+        } else if (config.getSourceLanguage() == Language.KOTLIN) {
             renderResult = templateRenderer.render(kotlinApplication.getTemplate(project), overwrite);
         }
 
@@ -93,11 +93,11 @@ public class CreateCommandCommand extends CodeGenCommand {
             }
         }
 
-        if (config.getTestFramework() == TestFramework.junit) {
+        if (config.getTestFramework() == TestFramework.JUNIT) {
             renderResult = templateRenderer.render(junit.getTemplate(config.getSourceLanguage(), project), overwrite);
-        } else if (config.getTestFramework() == TestFramework.spock) {
+        } else if (config.getTestFramework() == TestFramework.SPOCK) {
             renderResult = templateRenderer.render(spock.getTemplate(project), overwrite);
-        } else if (config.getTestFramework() == TestFramework.kotlintest) {
+        } else if (config.getTestFramework() == TestFramework.KOTLINTEST) {
             renderResult = templateRenderer.render(kotlinTest.getTemplate(project), overwrite);
         }
 

--- a/starter-cli/src/test/groovy/io/micronaut/starter/CodeGenConfigSpec.groovy
+++ b/starter-cli/src/test/groovy/io/micronaut/starter/CodeGenConfigSpec.groovy
@@ -28,9 +28,9 @@ sourceLanguage: java
         then:
         config.applicationType == command
         config.defaultPackage == "micronaut.testing.keycloak"
-        config.testFramework == TestFramework.junit
-        config.sourceLanguage == Language.java
-        config.buildTool == BuildTool.gradle // picked up because starter is a gradle project
+        config.testFramework == TestFramework.JUNIT
+        config.sourceLanguage == Language.JAVA
+        config.buildTool == BuildTool.GRADLE // picked up because starter is a gradle project
         config.features.containsAll(["java", "junit", "gradle"])
 
         where:

--- a/starter-core/src/main/java/io/micronaut/starter/ContextFactory.java
+++ b/starter-core/src/main/java/io/micronaut/starter/ContextFactory.java
@@ -81,7 +81,7 @@ public class ContextFactory {
             language = Language.infer(features);
         }
         if (language == null) {
-            language = Language.java;
+            language = Language.JAVA;
         }
         return language;
     }

--- a/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
@@ -49,9 +49,9 @@ public class GeneratorContext {
         this.features = new Features(features);
         this.options = options;
         String micronautVersion = VersionInfo.getVersion();
-        if (options.getBuildTool() == BuildTool.gradle) {
+        if (options.getBuildTool() == BuildTool.GRADLE) {
             buildProperties.put("micronautVersion", micronautVersion);
-        } else if (options.getBuildTool() == BuildTool.maven) {
+        } else if (options.getBuildTool() == BuildTool.MAVEN) {
             buildProperties.put("micronaut.version", micronautVersion);
         }
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/ApplicationFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/ApplicationFeature.java
@@ -30,7 +30,7 @@ public interface ApplicationFeature extends Feature {
 
     @Override
     default void apply(GeneratorContext generatorContext) {
-        if (generatorContext.getBuildTool() == BuildTool.maven) {
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
             generatorContext.getBuildProperties().put("exec.mainClass", mainClassName(generatorContext.getProject()));
         }
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/asciidoctor/Asciidoctor.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/asciidoctor/Asciidoctor.java
@@ -45,9 +45,9 @@ public class Asciidoctor implements Feature {
     @Override
     public void apply(GeneratorContext generatorContext) {
 
-        if (generatorContext.getBuildTool() == BuildTool.gradle) {
+        if (generatorContext.getBuildTool() == BuildTool.GRADLE) {
             generatorContext.addTemplate("asciidocGradle", new RockerTemplate("gradle/asciidoc.gradle", asciidocGradle.template()));
-        } else if (generatorContext.getBuildTool() == BuildTool.maven) {
+        } else if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
             generatorContext.getBuildProperties().put("asciidoctor.maven.plugin.version", "2.0.0-RC.1");
             generatorContext.getBuildProperties().put("asciidoctorj.version", "2.2.0");
             generatorContext.getBuildProperties().put("asciidoctorj.diagram.version", "2.0.1");

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/Gradle.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/Gradle.java
@@ -75,6 +75,6 @@ public class Gradle implements BuildFeature {
     public boolean shouldApply(ApplicationType applicationType,
                                Options options,
                                List<Feature> selectedFeatures) {
-        return options.getBuildTool() == BuildTool.gradle;
+        return options.getBuildTool() == BuildTool.GRADLE;
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/Maven.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/Maven.java
@@ -74,6 +74,6 @@ public class Maven implements BuildFeature {
     public boolean shouldApply(ApplicationType applicationType,
                                Options options,
                                List<Feature> selectedFeatures) {
-        return options.getBuildTool() == BuildTool.maven;
+        return options.getBuildTool() == BuildTool.MAVEN;
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/Data.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/Data.java
@@ -46,7 +46,7 @@ public class Data implements Feature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        if (generatorContext.getBuildTool() == BuildTool.maven) {
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
             generatorContext.getBuildProperties().put("micronaut.data.version", "1.0.2");
         }
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/HibernateGorm.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/HibernateGorm.java
@@ -53,7 +53,7 @@ public class HibernateGorm implements Feature {
 
     @Override
     public Optional<Language> getRequiredLanguage() {
-        return Optional.of(Language.groovy);
+        return Optional.of(Language.GROOVY);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/MongoGorm.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/MongoGorm.java
@@ -48,7 +48,7 @@ public class MongoGorm implements Feature {
 
     @Override
     public Optional<Language> getRequiredLanguage() {
-        return Optional.of(Language.groovy);
+        return Optional.of(Language.GROOVY);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/Neo4jGorm.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/Neo4jGorm.java
@@ -48,7 +48,7 @@ public class Neo4jGorm implements Feature {
 
     @Override
     public Optional<Language> getRequiredLanguage() {
-        return Optional.of(Language.groovy);
+        return Optional.of(Language.GROOVY);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/graalvm/template/dockerfile.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/graalvm/template/dockerfile.rocker.raw
@@ -14,7 +14,7 @@ RUN gu install native-image
 COPY . /home/app/@project.getName()
 WORKDIR /home/app/@project.getName()
 
-@if (buildTool.equals(BuildTool.gradle)) {
+@if (buildTool.equals(BuildTool.GRADLE)) {
 RUN native-image --no-server -cp build/libs/@project.getName()-*-all.jar
 } else {
 RUN native-image --no-server -cp target/@project.getName()-*.jar

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/Groovy.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/Groovy.java
@@ -80,6 +80,6 @@ public class Groovy implements LanguageFeature {
 
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, List<Feature> selectedFeatures) {
-        return options.getLanguage() == Language.groovy;
+        return options.getLanguage() == Language.GROOVY;
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/Java.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/Java.java
@@ -84,6 +84,6 @@ public class Java implements LanguageFeature {
 
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, List<Feature> selectedFeatures) {
-        return options.getLanguage() == Language.java;
+        return options.getLanguage() == Language.JAVA;
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/Kotlin.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/Kotlin.java
@@ -86,6 +86,6 @@ public class Kotlin implements LanguageFeature {
 
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, List<Feature> selectedFeatures) {
-        return options.getLanguage() == Language.kotlin;
+        return options.getLanguage() == Language.KOTLIN;
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/picocli/Picocli.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/picocli/Picocli.java
@@ -70,18 +70,18 @@ public class Picocli implements DefaultFeature {
 
     @Override
     public void processSelectedFeatures(FeatureContext featureContext) {
-        if (featureContext.getTestFramework() == TestFramework.junit) {
+        if (featureContext.getTestFramework() == TestFramework.JUNIT) {
             featureContext.addFeature(junit);
-        } else if (featureContext.getTestFramework() == TestFramework.spock) {
+        } else if (featureContext.getTestFramework() == TestFramework.SPOCK) {
             featureContext.addFeature(spock);
-        } else if (featureContext.getTestFramework() == TestFramework.kotlintest) {
+        } else if (featureContext.getTestFramework() == TestFramework.KOTLINTEST) {
             featureContext.addFeature(kotlinTest);
         }
     }
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        if (generatorContext.getBuildTool() == BuildTool.maven) {
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
             generatorContext.getBuildProperties().put("micronaut.picocli.version", "1.2.1");
         }
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/picocli/test/junit/PicocliJunit.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/picocli/test/junit/PicocliJunit.java
@@ -49,11 +49,11 @@ public class PicocliJunit implements Feature {
     }
 
     public RockerTemplate getTemplate(Language language, Project project) {
-        if (language == Language.java) {
+        if (language == Language.JAVA) {
             return new RockerTemplate("src/test/java/{packagePath}/{className}CommandTest.java", picocliJunitTest.template(project));
-        } else if (language == Language.groovy) {
+        } else if (language == Language.GROOVY) {
             return new RockerTemplate("src/test/groovy/{packagePath}/{className}CommandSpec.groovy", picocliGroovyJunitTest.template(project));
-        } else if (language == Language.kotlin) {
+        } else if (language == Language.KOTLIN) {
             return new RockerTemplate("src/test/kotlin/{packagePath}/{className}CommandSpec.kt", picocliKotlinJunitTest.template(project));
         } else {
             return null;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/reloading/Jrebel.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/reloading/Jrebel.java
@@ -40,7 +40,7 @@ public class Jrebel implements ReloadingFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        if (generatorContext.getBuildTool() == BuildTool.gradle) {
+        if (generatorContext.getBuildTool() == BuildTool.GRADLE) {
             generatorContext.getBuildProperties().addComment("TODO: Replace with agent path from JRebel installation; see documentation");
             generatorContext.getBuildProperties().addComment("rebelAgent=-agentpath:~/bin/jrebel/lib/jrebel6/lib/libjrebel64.dylib");
         }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/Junit.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/Junit.java
@@ -38,12 +38,12 @@ public class Junit implements TestFeature {
 
     @Override
     public TestFramework getTestFramework() {
-        return TestFramework.junit;
+        return TestFramework.JUNIT;
     }
 
     @Override
     public Language getDefaultLanguage() {
-        return Language.java;
+        return Language.JAVA;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/KotlinTest.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/KotlinTest.java
@@ -41,12 +41,12 @@ public class KotlinTest implements TestFeature {
 
     @Override
     public TestFramework getTestFramework() {
-        return TestFramework.kotlintest;
+        return TestFramework.KOTLINTEST;
     }
 
     @Override
     public Language getDefaultLanguage() {
-        return Language.kotlin;
+        return Language.KOTLIN;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/Spock.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/Spock.java
@@ -38,12 +38,12 @@ public class Spock implements TestFeature {
 
     @Override
     public TestFramework getTestFramework() {
-        return TestFramework.spock;
+        return TestFramework.SPOCK;
     }
 
     @Override
     public Language getDefaultLanguage() {
-        return Language.groovy;
+        return Language.GROOVY;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/TestFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/TestFeature.java
@@ -42,7 +42,7 @@ public interface TestFeature extends DefaultFeature {
 
     @Override
     default void apply(GeneratorContext generatorContext) {
-        if (generatorContext.getBuildTool() == BuildTool.maven) {
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
             BuildProperties props = generatorContext.getBuildProperties();
             props.put("maven-surefire-plugin.version", "2.22.2");
             props.put("maven-failsafe-plugin.version", "2.22.2");
@@ -57,15 +57,15 @@ public interface TestFeature extends DefaultFeature {
     Language getDefaultLanguage();
 
     default boolean isJunit() {
-        return getTestFramework() == TestFramework.junit;
+        return getTestFramework() == TestFramework.JUNIT;
     }
 
     default boolean isSpock() {
-        return getTestFramework() == TestFramework.spock;
+        return getTestFramework() == TestFramework.SPOCK;
     }
 
     default boolean isKotlinTest() {
-        return getTestFramework() == TestFramework.kotlintest;
+        return getTestFramework() == TestFramework.KOTLINTEST;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/options/BuildTool.java
+++ b/starter-core/src/main/java/io/micronaut/starter/options/BuildTool.java
@@ -16,6 +16,11 @@
 package io.micronaut.starter.options;
 
 public enum BuildTool {
-    gradle,
-    maven
+    GRADLE,
+    MAVEN;
+
+    @Override
+    public String toString() {
+        return this.name().toLowerCase();
+    }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/options/TestFramework.java
+++ b/starter-core/src/main/java/io/micronaut/starter/options/TestFramework.java
@@ -16,7 +16,12 @@
 package io.micronaut.starter.options;
 
 public enum TestFramework {
-    junit,
-    spock,
-    kotlintest
+    JUNIT,
+    SPOCK,
+    KOTLINTEST;
+
+    @Override
+    public String toString() {
+        return this.name().toLowerCase();
+    }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/FeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/FeatureSpec.groovy
@@ -36,7 +36,7 @@ class FeatureSpec extends BeanContextSpec {
         when:
         def commandCtx = new GeneratorContext(buildProject(),
                                               ApplicationType.DEFAULT,
-                                              new Options(Language.java, TestFramework.junit, BuildTool.gradle),
+                                              new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE),
                                               [feature]
         )
         commandCtx.applyFeatures()

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/FeatureValidatorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/FeatureValidatorSpec.groovy
@@ -11,11 +11,11 @@ class FeatureValidatorSpec extends BeanContextSpec {
 
     void "test feature conflicts with language selection"() {
         when:
-        featureValidator.validate(new Options(Language.java, null, null), [new Feature() {
+        featureValidator.validate(new Options(Language.JAVA, null, null), [new Feature() {
             String name = "test-feature"
             String description = "test desc"
             String title = "test title"
-            Optional<Language> requiredLanguage = Optional.of(Language.groovy)
+            Optional<Language> requiredLanguage = Optional.of(Language.GROOVY)
         }])
 
         then:
@@ -25,16 +25,16 @@ class FeatureValidatorSpec extends BeanContextSpec {
 
     void "test conflicting features required language"() {
         when:
-        featureValidator.validate(new Options(Language.java, null, null), [new Feature() {
+        featureValidator.validate(new Options(Language.JAVA, null, null), [new Feature() {
             String name = "groovy-feature"
             String description = "groovy"
             String title = "groovy title"
-            Optional<Language> requiredLanguage = Optional.of(Language.groovy)
+            Optional<Language> requiredLanguage = Optional.of(Language.GROOVY)
         }, new Feature() {
             String name = "kotlin-feature"
             String description = "groovy"
             String title = "groovy title"
-            Optional<Language> requiredLanguage = Optional.of(Language.kotlin)
+            Optional<Language> requiredLanguage = Optional.of(Language.KOTLIN)
         }])
 
         then:
@@ -46,7 +46,7 @@ class FeatureValidatorSpec extends BeanContextSpec {
 
     void "test one of"() {
         when:
-        featureValidator.validate(new Options(Language.java, null, null), [new OneOfFeature() {
+        featureValidator.validate(new Options(Language.JAVA, null, null), [new OneOfFeature() {
             String name = "a"
             String description = "groovy"
             String title = "groovy title"

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/asciidoctor/AsciidoctorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/asciidoctor/AsciidoctorSpec.groovy
@@ -18,7 +18,7 @@ class AsciidoctorSpec extends BeanContextSpec {
         template.contains("apply from: 'gradle/asciidoc.gradle'")
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -46,7 +46,7 @@ class AsciidoctorSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/asciidoctor/CreateAsciidoctorAppSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/asciidoctor/CreateAsciidoctorAppSpec.groovy
@@ -18,7 +18,7 @@ class CreateAsciidoctorAppSpec extends CommandSpec implements CommandFixture {
     @Unroll
     void 'test gradle create-app for asciidoctor feature, language=#language'() {
         given:
-        generateDefaultProject(language, BuildTool.gradle, ['asciidoctor'])
+        generateDefaultProject(language, BuildTool.GRADLE, ['asciidoctor'])
 
         when:
         executeGradleCommand('asciidoctor')
@@ -27,13 +27,13 @@ class CreateAsciidoctorAppSpec extends CommandSpec implements CommandFixture {
         testOutputContains('BUILD SUCCESSFUL')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
     void 'test maven create-app for asciidoctor feature, language=#language'() {
         given:
-        generateDefaultProject(language, BuildTool.maven, ['asciidoctor'])
+        generateDefaultProject(language, BuildTool.MAVEN, ['asciidoctor'])
 
         when:
         executeMavenCommand('generate-resources')
@@ -42,7 +42,7 @@ class CreateAsciidoctorAppSpec extends CommandSpec implements CommandFixture {
         testOutputContains('BUILD SUCCESS')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/gradle/GradleSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/gradle/GradleSpec.groovy
@@ -40,7 +40,7 @@ class GradleSpec extends BeanContextSpec {
         template.contains('annotationProcessor "io.micronaut:micronaut-validation"')
 
         when:
-        template = annotationProcessors.template(getFeatures([], Language.kotlin)).render().toString()
+        template = annotationProcessors.template(getFeatures([], Language.KOTLIN)).render().toString()
 
         then:
         template.contains('kapt platform("io.micronaut:micronaut-bom:\$micronautVersion")')
@@ -48,7 +48,7 @@ class GradleSpec extends BeanContextSpec {
         template.contains('kapt "io.micronaut:micronaut-validation"')
 
         when:
-        template = annotationProcessors.template(getFeatures([], Language.groovy)).render().toString()
+        template = annotationProcessors.template(getFeatures([], Language.GROOVY)).render().toString()
 
         then:
         template.contains('compileOnly platform("io.micronaut:micronaut-bom:\$micronautVersion")')

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
@@ -10,7 +10,7 @@ class MavenSpec extends BeanContextSpec {
 
     void "test annotation processor dependencies"() {
         when:
-        Features features = getFeatures([], null, null, BuildTool.maven)
+        Features features = getFeatures([], null, null, BuildTool.MAVEN)
         String template = pom.template(buildProject(), features, []).render().toString()
 
         then:
@@ -30,7 +30,7 @@ class MavenSpec extends BeanContextSpec {
 """)
 
         when:
-        features = getFeatures([], Language.kotlin, null, BuildTool.maven)
+        features = getFeatures([], Language.KOTLIN, null, BuildTool.MAVEN)
         template = pom.template(buildProject(), features, []).render().toString()
 
         then:
@@ -50,7 +50,7 @@ class MavenSpec extends BeanContextSpec {
 """)
 
         when:
-        features = getFeatures([], Language.groovy, null, BuildTool.maven)
+        features = getFeatures([], Language.GROOVY, null, BuildTool.MAVEN)
         template = pom.template(buildProject(), features, []).render().toString()
 
         then:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/CaffeineSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/CaffeineSpec.groovy
@@ -17,7 +17,7 @@ class CaffeineSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.cache:micronaut-cache-caffeine"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -35,7 +35,7 @@ class CaffeineSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/EHCacheSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/EHCacheSpec.groovy
@@ -18,7 +18,7 @@ class EHCacheSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.cache:micronaut-cache-ehcache"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class EHCacheSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test cache-ehcache configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/HazelcastSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/HazelcastSpec.groovy
@@ -18,7 +18,7 @@ class HazelcastSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.cache:micronaut-cache-hazelcast"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class HazelcastSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test cache-hazelcast configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/InfinispanSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/InfinispanSpec.groovy
@@ -18,7 +18,7 @@ class InfinispanSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.cache:micronaut-cache-infinispan"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class InfinispanSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test cache-infinispan configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cassandra/CassandraSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cassandra/CassandraSpec.groovy
@@ -18,7 +18,7 @@ class CassandraSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.configuration:micronaut-cassandra"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class CassandraSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test cassandra configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryConsulSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryConsulSpec.groovy
@@ -18,7 +18,7 @@ class DiscoveryConsulSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut:micronaut-discovery-client"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class DiscoveryConsulSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test discovery-consul configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryEurekaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryEurekaSpec.groovy
@@ -18,7 +18,7 @@ class DiscoveryEurekaSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut:micronaut-discovery-client"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class DiscoveryEurekaSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test discovery-eureka configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/elasticsearch/ElasticsearchSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/elasticsearch/ElasticsearchSpec.groovy
@@ -18,7 +18,7 @@ class ElasticsearchSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.configuration:micronaut-elasticsearch"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class ElasticsearchSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test elasticsearch configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/externalconfig/ConfigConsulSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/externalconfig/ConfigConsulSpec.groovy
@@ -18,7 +18,7 @@ class ConfigConsulSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut:micronaut-discovery-client"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test gradle config-consul multiple features'() {
@@ -44,7 +44,7 @@ class ConfigConsulSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test maven config-consul multiple features'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/externalconfig/KubernetesSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/externalconfig/KubernetesSpec.groovy
@@ -20,7 +20,7 @@ class KubernetesSpec extends BeanContextSpec {
         template.contains('id "com.google.cloud.tools.jib" version "2.1.0"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -38,7 +38,7 @@ class KubernetesSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test kubernetes configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/filewatch/FileWatchSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/filewatch/FileWatchSpec.groovy
@@ -21,7 +21,7 @@ class FileWatchSpec extends BeanContextSpec {
         template.contains("developmentOnly \"io.micronaut:micronaut-runtime-osx:${VersionInfo.version}\"")
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Requires({ os.macOs })
@@ -41,7 +41,7 @@ class FileWatchSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test file-watch configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/graalvm/GraalNativeImageSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/graalvm/GraalNativeImageSpec.groovy
@@ -18,7 +18,7 @@ class GraalNativeImageSpec extends BeanContextSpec {
         template.contains('compileOnly "org.graalvm.nativeimage:svm"')
 
         when:
-        template = buildGradle.template(buildProject(), getFeatures(["graalvm"], Language.kotlin)).render().toString()
+        template = buildGradle.template(buildProject(), getFeatures(["graalvm"], Language.KOTLIN)).render().toString()
 
         then:
         template.contains('kapt platform("io.micronaut:micronaut-bom:\$micronautVersion")')
@@ -27,7 +27,7 @@ class GraalNativeImageSpec extends BeanContextSpec {
         template.contains('compileOnly "org.graalvm.nativeimage:svm"')
 
         when:
-        template = buildGradle.template(buildProject(), getFeatures(["graalvm"], Language.groovy)).render().toString()
+        template = buildGradle.template(buildProject(), getFeatures(["graalvm"], Language.GROOVY)).render().toString()
 
         then:
         template.count('compileOnly platform("io.micronaut:micronaut-bom:\$micronautVersion")') == 1
@@ -55,7 +55,7 @@ class GraalNativeImageSpec extends BeanContextSpec {
 """)
 
         when:
-        template = pom.template(buildProject(), getFeatures(["graalvm"], Language.kotlin), []).render().toString()
+        template = pom.template(buildProject(), getFeatures(["graalvm"], Language.KOTLIN), []).render().toString()
 
         then:
         template.contains("""
@@ -74,7 +74,7 @@ class GraalNativeImageSpec extends BeanContextSpec {
 """)
 
         when:
-        template = pom.template(buildProject(), getFeatures(["graalvm"], Language.groovy), []).render().toString()
+        template = pom.template(buildProject(), getFeatures(["graalvm"], Language.GROOVY), []).render().toString()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/graphql/GraphQLSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/graphql/GraphQLSpec.groovy
@@ -18,7 +18,7 @@ class GraphQLSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.graphql:micronaut-graphql"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class GraphQLSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test graphql configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/jib/JibSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/jib/JibSpec.groovy
@@ -18,7 +18,7 @@ class JibSpec extends BeanContextSpec {
         template.contains("jib.to.image = 'gcr.io/foo/jib-image")
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -40,7 +40,7 @@ class JibSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/micrometer/MicrometerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/micrometer/MicrometerSpec.groovy
@@ -44,7 +44,7 @@ class MicrometerSpec extends BeanContextSpec {
     void 'test maven micrometer feature #micrometerFeature.name'() {
         given:
         String dependency = "micronaut-micrometer-registry-${micrometerFeature.name - 'micrometer-'}"
-        Features features = getFeatures([micrometerFeature.name], null, null, BuildTool.maven)
+        Features features = getFeatures([micrometerFeature.name], null, null, BuildTool.MAVEN)
 
         when:
         String template = pom.template(buildProject(), features, []).render().toString()
@@ -64,7 +64,7 @@ class MicrometerSpec extends BeanContextSpec {
 
     void "test maven micrometer multiple features"() {
         when:
-        Features features = getFeatures(["micrometer-atlas", "micrometer-influx"], null, null, BuildTool.maven)
+        Features features = getFeatures(["micrometer-atlas", "micrometer-influx"], null, null, BuildTool.MAVEN)
         String template = pom.template(buildProject(), features, []).render().toString()
 
         then:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/ArchaiusSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/ArchaiusSpec.groovy
@@ -17,7 +17,7 @@ class ArchaiusSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.configuration:micronaut-netflix-archaius"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -35,7 +35,7 @@ class ArchaiusSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/HystrixSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/HystrixSpec.groovy
@@ -18,7 +18,7 @@ class HystrixSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.configuration:micronaut-netflix-hystrix"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class HystrixSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test netflix-hystrix configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/RibbonSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/RibbonSpec.groovy
@@ -18,7 +18,7 @@ class RibbonSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.configuration:micronaut-netflix-ribbon"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class RibbonSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test netflix-ribbon configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/postgres/PostgresReactiveSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/postgres/PostgresReactiveSpec.groovy
@@ -18,7 +18,7 @@ class PostgresReactiveSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.configuration:micronaut-postgres-reactive"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class PostgresReactiveSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test postgres-reactive configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/redis/RedisLettuceSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/redis/RedisLettuceSpec.groovy
@@ -18,7 +18,7 @@ class RedisLettuceSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.configuration:micronaut-redis-lettuce"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class RedisLettuceSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test redis-lettuce configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecurityJTWSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecurityJTWSpec.groovy
@@ -18,7 +18,7 @@ class SecurityJTWSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut:micronaut-security-jwt"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class SecurityJTWSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test security-jwt configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecuritySessionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecuritySessionSpec.groovy
@@ -18,7 +18,7 @@ class SecuritySessionSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut:micronaut-security-session"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class SecuritySessionSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test security-session configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/server/ServerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/server/ServerSpec.groovy
@@ -39,7 +39,7 @@ class ServerSpec extends BeanContextSpec {
 """)
 
         when:
-        template = pom.template(buildProject(), getFeatures([serverFeature], Language.kotlin), []).render().toString()
+        template = pom.template(buildProject(), getFeatures([serverFeature], Language.KOTLIN), []).render().toString()
 
         then:
         template.contains("""
@@ -51,7 +51,7 @@ class ServerSpec extends BeanContextSpec {
 """)
 
         when:
-        template = pom.template(buildProject(), getFeatures([serverFeature], Language.groovy), []).render().toString()
+        template = pom.template(buildProject(), getFeatures([serverFeature], Language.GROOVY), []).render().toString()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/JUnitSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/JUnitSpec.groovy
@@ -22,7 +22,7 @@ class JUnitSpec extends BeanContextSpec {
 """)
 
         when:
-        template = buildGradle.template(buildProject(), getFeatures([], Language.groovy, TestFramework.junit)).render().toString()
+        template = buildGradle.template(buildProject(), getFeatures([], Language.GROOVY, TestFramework.JUNIT)).render().toString()
 
         then:
         template.contains("""
@@ -35,7 +35,7 @@ class JUnitSpec extends BeanContextSpec {
         !template.contains("testAnnotationProcessor")
 
         when:
-        template = buildGradle.template(buildProject(), getFeatures([], Language.kotlin, TestFramework.junit)).render().toString()
+        template = buildGradle.template(buildProject(), getFeatures([], Language.KOTLIN, TestFramework.JUNIT)).render().toString()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/JaegerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/JaegerSpec.groovy
@@ -19,7 +19,7 @@ class JaegerSpec extends BeanContextSpec {
         template.contains('runtimeOnly "io.jaegertracing:jaeger-thrift"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -44,7 +44,7 @@ class JaegerSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test tracing-jaeger configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/ZipkinSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/ZipkinSpec.groovy
@@ -21,7 +21,7 @@ class ZipkinSpec extends BeanContextSpec {
         template.contains('runtimeOnly "io.zipkin.reporter2:zipkin-reporter"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -60,7 +60,7 @@ class ZipkinSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test tracing-zipkin configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/vertx/VertxClientSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/vertx/VertxClientSpec.groovy
@@ -18,7 +18,7 @@ class VertxClientSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.configuration:micronaut-vertx-mysql-client"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class VertxClientSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test vertx-mysql-client configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/vertx/VertxPgSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/vertx/VertxPgSpec.groovy
@@ -18,7 +18,7 @@ class VertxPgSpec extends BeanContextSpec {
         template.contains('implementation "io.micronaut.configuration:micronaut-vertx-pg-client"')
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     @Unroll
@@ -36,7 +36,7 @@ class VertxPgSpec extends BeanContextSpec {
 """)
 
         where:
-        language << [Language.java, Language.kotlin, Language.groovy]
+        language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
     }
 
     void 'test vertx-pg-client configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/fixture/CommandFixture.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/fixture/CommandFixture.groovy
@@ -16,7 +16,7 @@ trait CommandFixture {
 
     abstract File getDir()
 
-    void generateCliProject(Language lang, BuildTool buildTool = BuildTool.gradle, List <String> features = []) {
+    void generateCliProject(Language lang, BuildTool buildTool = BuildTool.GRADLE, List <String> features = []) {
         beanContext.getBean(ProjectGenerator).generate(ApplicationType.CLI,
                 NameUtils.parse("example.micronaut.foo"),
                 new Options(lang, null, buildTool),
@@ -26,7 +26,7 @@ trait CommandFixture {
         )
     }
 
-    void generateDefaultProject(Language lang, BuildTool buildTool = BuildTool.gradle, List <String> features = []) {
+    void generateDefaultProject(Language lang, BuildTool buildTool = BuildTool.GRADLE, List <String> features = []) {
         beanContext.getBean(ProjectGenerator).generate(ApplicationType.DEFAULT,
                 NameUtils.parse("example.micronaut.foo"),
                 new Options(lang, null, buildTool),
@@ -36,7 +36,7 @@ trait CommandFixture {
         )
     }
 
-    void generateGrpcProject(Language lang, BuildTool buildTool = BuildTool.gradle, List <String> features = []) {
+    void generateGrpcProject(Language lang, BuildTool buildTool = BuildTool.GRADLE, List <String> features = []) {
         beanContext.getBean(ProjectGenerator).generate(ApplicationType.GRPC,
                 NameUtils.parse("example.micronaut.foo"),
                 new Options(lang, null, buildTool),

--- a/starter-core/src/test/groovy/io/micronaut/starter/fixture/ContextFixture.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/fixture/ContextFixture.groovy
@@ -23,7 +23,7 @@ trait ContextFixture {
     Features getFeatures(List<String> features,
                          Language language = null,
                          TestFramework testFramework = null,
-                         BuildTool buildTool = BuildTool.gradle) {
+                         BuildTool buildTool = BuildTool.GRADLE) {
         FeatureContext featureContext = buildFeatureContext(features, new Options(language, testFramework, buildTool))
         featureContext.processSelectedFeatures()
         List<Feature> finalFeatures = featureContext.getFinalFeatures(ConsoleOutput.NOOP)
@@ -32,7 +32,7 @@ trait ContextFixture {
     }
 
     FeatureContext buildFeatureContext(List<String> selectedFeatures,
-                                       Options options = new Options(null, null, BuildTool.gradle)) {
+                                       Options options = new Options(null, null, BuildTool.GRADLE)) {
 
         AvailableFeatures availableFeatures = beanContext.getBean(DefaultAvailableFeatures)
         ContextFactory factory = beanContext.getBean(ContextFactory)
@@ -44,7 +44,7 @@ trait ContextFixture {
     }
 
     GeneratorContext buildCommandContext(List<String> selectedFeatures,
-                                         Options options = new Options(null, null, BuildTool.gradle)) {
+                                         Options options = new Options(null, null, BuildTool.GRADLE)) {
         if (this instanceof ProjectFixture) {
             ContextFactory factory = beanContext.getBean(ContextFactory)
             FeatureContext featureContext = buildFeatureContext(selectedFeatures, options)

--- a/starter-core/src/test/groovy/io/micronaut/starter/generator/CreateAppSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/generator/CreateAppSpec.groovy
@@ -24,13 +24,13 @@ class CreateAppSpec extends CommandSpec implements CommandFixture {
         testOutputContains("Startup completed")
 
         where:
-        lang << [Language.java, Language.groovy, Language.kotlin, null]
+        lang << [Language.JAVA, Language.GROOVY, Language.KOTLIN, null]
     }
 
     @Unroll
     void 'test basic create-app for lang=#lang and maven'() {
         given:
-        generateDefaultProject(lang, BuildTool.maven)
+        generateDefaultProject(lang, BuildTool.MAVEN)
 
         when:
         executeMavenCommand("mn:run")
@@ -39,7 +39,7 @@ class CreateAppSpec extends CommandSpec implements CommandFixture {
         testOutputContains("Startup completed")
 
         where:
-        lang << [Language.java, Language.groovy, Language.kotlin, null]
+        lang << [Language.JAVA, Language.GROOVY, Language.KOTLIN, null]
     }
 
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/generator/CreateCliSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/generator/CreateCliSpec.groovy
@@ -24,13 +24,13 @@ class CreateCliSpec extends CommandSpec implements CommandFixture {
         testOutputContains("Hi")
 
         where:
-        lang << [Language.java, Language.groovy, Language.kotlin, null]
+        lang << [Language.JAVA, Language.GROOVY, Language.KOTLIN, null]
     }
 
     @Unroll
     void 'test basic maven create-cli-app for lang=#lang'() {
         given:
-        generateCliProject(lang, BuildTool.maven)
+        generateCliProject(lang, BuildTool.MAVEN)
 
         when:
         executeMavenCommand("mn:run -Dmn.appArgs=-v")
@@ -39,7 +39,7 @@ class CreateCliSpec extends CommandSpec implements CommandFixture {
         testOutputContains("Hi")
 
         where:
-        lang << [Language.java, Language.groovy, Language.kotlin, null]
+        lang << [Language.JAVA, Language.GROOVY, Language.KOTLIN, null]
     }
 
     @Unroll
@@ -54,13 +54,13 @@ class CreateCliSpec extends CommandSpec implements CommandFixture {
         testOutputContains("BUILD SUCCESSFUL")
 
         where:
-        lang << [Language.java, Language.groovy, Language.kotlin, null]
+        lang << [Language.JAVA, Language.GROOVY, Language.KOTLIN, null]
     }
 
     @Unroll
     void 'test basic maven create-cli-app test for lang=#lang'() {
         given:
-        generateCliProject(lang, BuildTool.maven)
+        generateCliProject(lang, BuildTool.MAVEN)
 
         when:
         executeMavenCommand("compile test")
@@ -69,7 +69,7 @@ class CreateCliSpec extends CommandSpec implements CommandFixture {
         testOutputContains("BUILD SUCCESS")
 
         where:
-        lang << [Language.java, Language.groovy, Language.kotlin, null]
+        lang << [Language.JAVA, Language.GROOVY, Language.KOTLIN, null]
     }
 
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/generator/CreateGrpcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/generator/CreateGrpcSpec.groovy
@@ -24,13 +24,13 @@ class CreateGrpcSpec extends CommandSpec implements CommandFixture {
         testOutputContains("Startup completed")
 
         where:
-        lang << [Language.java, Language.groovy, Language.kotlin, null]
+        lang << [Language.JAVA, Language.GROOVY, Language.KOTLIN, null]
     }
 
     @Unroll
     void 'test basic create-grpc-app for lang=#lang and maven'() {
         given:
-        generateGrpcProject(lang, BuildTool.maven)
+        generateGrpcProject(lang, BuildTool.MAVEN)
 
         when:
         executeMavenCommand("mn:run")
@@ -39,7 +39,7 @@ class CreateGrpcSpec extends CommandSpec implements CommandFixture {
         testOutputContains("Startup completed")
 
         where:
-        lang << [Language.java, Language.groovy, Language.kotlin, null]
+        lang << [Language.JAVA, Language.GROOVY, Language.KOTLIN, null]
     }
 
 }

--- a/starter-web-netty/src/test/groovy/io/micronaut/starter/netty/CreateControllerSpec.groovy
+++ b/starter-web-netty/src/test/groovy/io/micronaut/starter/netty/CreateControllerSpec.groovy
@@ -38,7 +38,7 @@ class CreateControllerSpec extends Specification {
 
     void "test create app with kotlin"() {
         when:
-        def bytes = client.createApp("test", ['graalvm'], null, null, Language.kotlin)
+        def bytes = client.createApp("test", ['graalvm'], null, null, Language.KOTLIN)
 
         then:
         ZipUtil.containsFile(bytes, "Application.kt")
@@ -46,7 +46,7 @@ class CreateControllerSpec extends Specification {
 
     void "test create app with groovy"() {
         when:
-        def bytes = client.createApp("test", ['graalvm'], null, null, Language.groovy)
+        def bytes = client.createApp("test", ['graalvm'], null, null, Language.GROOVY)
 
         then:
         ZipUtil.containsFile(bytes, "Application.groovy")
@@ -54,7 +54,7 @@ class CreateControllerSpec extends Specification {
 
     void "test create app with maven"() {
         when:
-        def bytes = client.createApp("test", ['graalvm'], BuildTool.maven, null, Language.groovy)
+        def bytes = client.createApp("test", ['graalvm'], BuildTool.MAVEN, null, Language.GROOVY)
 
         then:
         ZipUtil.containsFile(bytes, "pom.xml")
@@ -62,7 +62,7 @@ class CreateControllerSpec extends Specification {
 
     void "test create app with spock"() {
         when:
-        def bytes = client.createApp("test", ['graalvm'], BuildTool.gradle, TestFramework.spock, Language.groovy)
+        def bytes = client.createApp("test", ['graalvm'], BuildTool.GRADLE, TestFramework.SPOCK, Language.GROOVY)
 
         then:
         ZipUtil.containsFileWithContents(bytes, "build.gradle", "spock-core")

--- a/starter-web-servlet/src/test/groovy/io/micronaut/starter/servlet/CreateControllerSpec.groovy
+++ b/starter-web-servlet/src/test/groovy/io/micronaut/starter/servlet/CreateControllerSpec.groovy
@@ -37,7 +37,7 @@ class CreateControllerSpec extends Specification {
 
     void "test create app with kotlin"() {
         when:
-        def bytes = client.createApp("test", ['graalvm'], null, null, Language.kotlin)
+        def bytes = client.createApp("test", ['graalvm'], null, null, Language.KOTLIN)
 
         then:
         ZipUtil.containsFile(bytes, "Application.kt")
@@ -45,7 +45,7 @@ class CreateControllerSpec extends Specification {
 
     void "test create app with groovy"() {
         when:
-        def bytes = client.createApp("test", ['graalvm'], null, null, Language.groovy)
+        def bytes = client.createApp("test", ['graalvm'], null, null, Language.GROOVY)
 
         then:
         ZipUtil.containsFile(bytes, "Application.groovy")
@@ -53,7 +53,7 @@ class CreateControllerSpec extends Specification {
 
     void "test create app with maven"() {
         when:
-        def bytes = client.createApp("test", ['graalvm'], BuildTool.maven, null, Language.groovy)
+        def bytes = client.createApp("test", ['graalvm'], BuildTool.MAVEN, null, Language.GROOVY)
 
         then:
         ZipUtil.containsFile(bytes, "pom.xml")
@@ -61,7 +61,7 @@ class CreateControllerSpec extends Specification {
 
     void "test create app with spock"() {
         when:
-        def bytes = client.createApp("test", ['graalvm'], BuildTool.gradle, TestFramework.spock, Language.groovy)
+        def bytes = client.createApp("test", ['graalvm'], BuildTool.GRADLE, TestFramework.SPOCK, Language.GROOVY)
 
         then:
         ZipUtil.containsFileWithContents(bytes, "build.gradle", "spock-core")


### PR DESCRIPTION
It uses [Picocli Type Converters](https://picocli.info/#_custom_type_converters) and completion candidates for `Language`, `TestFramework` and `BuildTool`.