### PR TITLE
refactor: parenthesis for gradle impl dependencies

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -74,260 +74,260 @@ dependencies {
     compileOnly "org.graalvm.nativeimage:svm"
 }
     implementation platform("io.micronaut:micronaut-bom:$micronautVersion")
-    implementation "io.micronaut:micronaut-inject"
-    implementation "io.micronaut:micronaut-validation"
+    implementation("io.micronaut:micronaut-inject")
+    implementation("io.micronaut:micronaut-validation")
 @if (features.language().isKotlin()) {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
 }
 @if (features.language().isGroovy()) {
-    implementation "io.micronaut:micronaut-runtime-groovy"
+    implementation("io.micronaut:micronaut-runtime-groovy")
 } else {
-    implementation "io.micronaut:micronaut-runtime"
+    implementation("io.micronaut:micronaut-runtime")
 }
 @if (features.contains("grpc")) {
-    implementation "io.micronaut.grpc:micronaut-grpc-runtime"
+    implementation("io.micronaut.grpc:micronaut-grpc-runtime")
 }
 @if (features.contains("picocli")) {
-    implementation "info.picocli:picocli"
-    implementation "io.micronaut.configuration:micronaut-picocli"
+    implementation("info.picocli:picocli")
+    implementation("io.micronaut.configuration:micronaut-picocli")
 }
 @if (features.contains("annotation-api")) {
-    implementation "javax.annotation:javax.annotation-api"
+    implementation("javax.annotation:javax.annotation-api")
 }
 @if (features.contains("netty-server")) {
-    implementation "io.micronaut:micronaut-http-server-netty"
+    implementation("io.micronaut:micronaut-http-server-netty")
 }
 @if (features.contains("jetty-server")) {
-    implementation "io.micronaut.servlet:micronaut-http-server-jetty"
+    implementation("io.micronaut.servlet:micronaut-http-server-jetty")
 }
 @if (features.contains("undertow-server")) {
-    implementation "io.micronaut.servlet:micronaut-http-server-undertow"
+    implementation("io.micronaut.servlet:micronaut-http-server-undertow")
 }
 @if (features.contains("tomcat-server")) {
-    implementation "io.micronaut.servlet:micronaut-http-server-tomcat"
+    implementation("io.micronaut.servlet:micronaut-http-server-tomcat")
 }
 @if (features.contains("http-client")) {
-    implementation "io.micronaut:micronaut-http-client"
+    implementation("io.micronaut:micronaut-http-client")
 }
 @if (features.contains("swagger")) {
-    implementation "io.swagger.core.v3:swagger-annotations"
+    implementation("io.swagger.core.v3:swagger-annotations")
 }
 @if (features.contains("management")) {
-    implementation "io.micronaut:micronaut-management"
+    implementation("io.micronaut:micronaut-management")
 }
 @if (features.contains("discovery-consul") || features.contains("discovery-eureka")) {
-    implementation "io.micronaut:micronaut-discovery-client"
+    implementation("io.micronaut:micronaut-discovery-client")
 }
 @if (features.contains("config-consul") && features.stream().noneMatch( f -> f.startsWith("discovery-"))) {
-    implementation "io.micronaut:micronaut-discovery-client"
+    implementation("io.micronaut:micronaut-discovery-client")
 }
 @if (features.contains("kubernetes")) {
-    implementation "io.micronaut.kubernetes:micronaut-kubernetes-discovery-client"
+    implementation("io.micronaut.kubernetes:micronaut-kubernetes-discovery-client")
 }
 @if (features.contains("micrometer")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-core"
+    implementation("io.micronaut.configuration:micronaut-micrometer-core")
 }
 @if (features.contains("micrometer-appoptics")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-appoptics"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-appoptics")
 }
 @if (features.contains("micrometer-atlas")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-atlas"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-atlas")
 }
 @if (features.contains("micrometer-azure-monitor")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-azure-monitor"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-azure-monitor")
 }
 @if (features.contains("micrometer-cloudwatch")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-cloudwatch"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-cloudwatch")
 }
 @if (features.contains("micrometer-datadog")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-datadog"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-datadog")
 }
 @if (features.contains("micrometer-dynatrace")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-dynatrace"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-dynatrace")
 }
 @if (features.contains("micrometer-elastic")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-elastic"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-elastic")
 }
 @if (features.contains("micrometer-ganglia")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-ganglia"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-ganglia")
 }
 @if (features.contains("micrometer-graphite")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-graphite"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-graphite")
 }
 @if (features.contains("micrometer-humio")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-humio"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-humio")
 }
 @if (features.contains("micrometer-influx")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-influx"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-influx")
 }
 @if (features.contains("micrometer-jmx")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-jmx"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-jmx")
 }
 @if (features.contains("micrometer-kairos")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-kairos"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-kairos")
 }
 @if (features.contains("micrometer-new-relic")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-new-relic"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-new-relic")
 }
 @if (features.contains("micrometer-prometheus")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-prometheus"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-prometheus")
 }
 @if (features.contains("micrometer-signalfx")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-signalfx"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-signalfx")
 }
 @if (features.contains("micrometer-stackdriver")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-stackdriver"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-stackdriver")
 }
 @if (features.contains("micrometer-statsd")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-statsd"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-statsd")
 }
 @if (features.contains("micrometer-wavefront")) {
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-wavefront"
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-wavefront")
 }
 @if (features.contains("netflix-archaius")) {
-    implementation "io.micronaut.configuration:micronaut-netflix-archaius"
+    implementation("io.micronaut.configuration:micronaut-netflix-archaius")
 }
 @if (features.contains("netflix-hystrix")) {
-    implementation "io.micronaut.configuration:micronaut-netflix-hystrix"
+    implementation("io.micronaut.configuration:micronaut-netflix-hystrix")
 }
 @if (features.contains("netflix-ribbon")) {
-    implementation "io.micronaut.configuration:micronaut-netflix-ribbon"
+    implementation("io.micronaut.configuration:micronaut-netflix-ribbon")
 }
 @if (features.contains("tracing-zipkin")) {
-    implementation "io.micronaut:micronaut-tracing"
-    implementation "io.opentracing.brave:brave-opentracing"
+    implementation("io.micronaut:micronaut-tracing")
+    implementation("io.opentracing.brave:brave-opentracing")
     runtimeOnly "io.zipkin.brave:brave-instrumentation-http"
     runtimeOnly "io.zipkin.reporter2:zipkin-reporter"
 }
 @if (features.contains("tracing-jaeger")) {
-    implementation "io.micronaut:micronaut-tracing"
+    implementation("io.micronaut:micronaut-tracing")
     runtimeOnly "io.jaegertracing:jaeger-thrift"
 }
 @if (features.contains("flyway")) {
-    implementation "io.micronaut.configuration:micronaut-flyway"
+    implementation("io.micronaut.configuration:micronaut-flyway")
 }
 @if (features.contains("liquibase")) {
-    implementation "io.micronaut.configuration:micronaut-liquibase"
+    implementation("io.micronaut.configuration:micronaut-liquibase")
 }
 @if (features.contains("jdbc-dbcp")) {
-    implementation "io.micronaut.configuration:micronaut-jdbc-dbcp"
+    implementation("io.micronaut.configuration:micronaut-jdbc-dbcp")
 }
 @if (features.contains("jdbc-tomcat")) {
-    implementation "io.micronaut.configuration:micronaut-jdbc-tomcat"
+    implementation("io.micronaut.configuration:micronaut-jdbc-tomcat")
 }
 @if (features.contains("jdbc-hikari")) {
-    implementation "io.micronaut.configuration:micronaut-jdbc-hikari"
+    implementation("io.micronaut.configuration:micronaut-jdbc-hikari")
 }
 @if (features.contains("data-jpa")) {
-    implementation "io.micronaut.data:micronaut-data-jpa"
+    implementation("io.micronaut.data:micronaut-data-jpa")
 }
 @if (features.contains("data-jdbc")) {
-    implementation "io.micronaut.data:micronaut-data-jdbc"
+    implementation("io.micronaut.data:micronaut-data-jdbc")
 }
 @if (features.contains("hibernate-validator")) {
-    implementation "io.micronaut.configuration:micronaut-hibernate-validator"
+    implementation("io.micronaut.configuration:micronaut-hibernate-validator")
 }
 @if (features.contains("hibernate-gorm")) {
-    implementation "io.micronaut.configuration:micronaut-hibernate-gorm"
+    implementation("io.micronaut.configuration:micronaut-hibernate-gorm")
 }
 @if (features.contains("hibernate-jpa")) {
-    implementation "io.micronaut.configuration:micronaut-hibernate-jpa"
+    implementation("io.micronaut.configuration:micronaut-hibernate-jpa")
 }
 @if (features.contains("mongo-reactive")) {
-    implementation "io.micronaut.configuration:micronaut-mongo-reactive"
+    implementation("io.micronaut.configuration:micronaut-mongo-reactive")
 }
 @if (features.contains("mongo-gorm")) {
-    implementation "io.micronaut.configuration:micronaut-mongo-gorm"
+    implementation("io.micronaut.configuration:micronaut-mongo-gorm")
 }
 @if (features.contains("neo4j-bolt")) {
-    implementation "io.micronaut.configuration:micronaut-neo4j-bolt"
+    implementation("io.micronaut.configuration:micronaut-neo4j-bolt")
 }
 @if (features.contains("neo4j-gorm")) {
-    implementation "io.micronaut.configuration:micronaut-neo4j-gorm"
+    implementation("io.micronaut.configuration:micronaut-neo4j-gorm")
 }
 @if (features.contains("security-jwt")) {
-    implementation "io.micronaut:micronaut-security-jwt"
+    implementation("io.micronaut:micronaut-security-jwt")
 }
 @if (features.contains("security-session")) {
-    implementation "io.micronaut:micronaut-security-session"
+    implementation("io.micronaut:micronaut-security-session")
 }
 @if (features.contains("cassandra")) {
-    implementation "io.micronaut.configuration:micronaut-cassandra"
+    implementation("io.micronaut.configuration:micronaut-cassandra")
 }
 @if (features.contains("elasticsearch")) {
-    implementation "io.micronaut.configuration:micronaut-elasticsearch"
+    implementation("io.micronaut.configuration:micronaut-elasticsearch")
 }
 @if (features.contains("graphql")) {
-    implementation "io.micronaut.graphql:micronaut-graphql"
+    implementation("io.micronaut.graphql:micronaut-graphql")
 }
 @if (features.contains("postgres-reactive")) {
-    implementation "io.micronaut.configuration:micronaut-postgres-reactive"
+    implementation("io.micronaut.configuration:micronaut-postgres-reactive")
 }
 @if (features.contains("redis-lettuce")) {
-    implementation "io.micronaut.configuration:micronaut-redis-lettuce"
+    implementation("io.micronaut.configuration:micronaut-redis-lettuce")
 }
 @if (features.contains("vertx-pg-client")) {
-    implementation "io.micronaut.configuration:micronaut-vertx-pg-client"
+    implementation("io.micronaut.configuration:micronaut-vertx-pg-client")
 }
 @if (features.contains("vertx-mysql-client")) {
-    implementation "io.micronaut.configuration:micronaut-vertx-mysql-client"
+    implementation("io.micronaut.configuration:micronaut-vertx-mysql-client")
 }
 @if (features.contains("cache-caffeine")) {
-    implementation "io.micronaut.cache:micronaut-cache-caffeine"
+    implementation("io.micronaut.cache:micronaut-cache-caffeine")
 }
 @if (features.contains("cache-ehcache")) {
-    implementation "io.micronaut.cache:micronaut-cache-ehcache"
+    implementation("io.micronaut.cache:micronaut-cache-ehcache")
 }
 @if (features.contains("cache-hazelcast")) {
-    implementation "io.micronaut.cache:micronaut-cache-hazelcast"
+    implementation("io.micronaut.cache:micronaut-cache-hazelcast")
 }
 @if (features.contains("cache-infinispan")) {
-    implementation "io.micronaut.cache:micronaut-cache-infinispan"
+    implementation("io.micronaut.cache:micronaut-cache-infinispan")
 }
 @if (features.contains("kafka")) {
-    implementation "io.micronaut.kafka:micronaut-kafka"
+    implementation("io.micronaut.kafka:micronaut-kafka")
 }
 @if (features.contains("rabbitmq")) {
-    implementation "io.micronaut.configuration:micronaut-rabbitmq"
+    implementation("io.micronaut.configuration:micronaut-rabbitmq")
 }
 @if (features.contains("file-watch-osx")) {
     developmentOnly "io.micronaut:micronaut-runtime-osx:@VersionInfo.getMicronautVersion()"
 }
 @if (features.contains("alexa-http-server")) {
-    implementation "io.micronaut.aws:micronaut-aws-alexa-httpserver"
+    implementation("io.micronaut.aws:micronaut-aws-alexa-httpserver")
 }
 @if (features.contains("views-thymeleaf")) {
-    implementation "io.micronaut:micronaut-views-thymeleaf"
+    implementation("io.micronaut:micronaut-views-thymeleaf")
     runtime "org.thymeleaf:thymeleaf:3.0.11.RELEASE"
 }
 @if (features.contains("views-handlebars")) {
-    implementation "io.micronaut:micronaut-views-handlebars"
+    implementation("io.micronaut:micronaut-views-handlebars")
     runtime "com.github.jknack:handlebars:4.1.2"
 }
 @if (features.contains("views-velocity")) {
-    implementation "io.micronaut:micronaut-views-velocity"
+    implementation("io.micronaut:micronaut-views-velocity")
     runtime "org.apache.velocity:velocity-engine-core:2.0"
 }
 @if (features.contains("views-freemarker")) {
-    implementation "io.micronaut:micronaut-views-freemarker"
+    implementation("io.micronaut:micronaut-views-freemarker")
     runtime "org.freemarker:freemarker:2.3.28"
 }
 @if (features.contains("views-rocker")) {
-    implementation "io.micronaut:micronaut-views-rocker"
+    implementation("io.micronaut:micronaut-views-rocker")
 }
 @if (features.contains("views-soy")) {
-    implementation "io.micronaut:micronaut-views-soy"
-    implementation "com.google.template:soy:2019-09-03"
+    implementation("io.micronaut:micronaut-views-soy")
+    implementation("com.google.template:soy:2019-09-03")
 }
 @if (features.contains("rss")) {
-    implementation "io.micronaut.configuration:micronaut-rss"
+    implementation("io.micronaut.configuration:micronaut-rss")
 }
 @if (features.contains("rss-itunes-podcast")) {
-    implementation "io.micronaut.configuration:micronaut-itunespodcast"
+    implementation("io.micronaut.configuration:micronaut-itunespodcast")
 }
 @if (features.contains("log4j2")) {
-    implementation "org.apache.logging.log4j:log4j-core:2.12.1"
+    implementation("org.apache.logging.log4j:log4j-core:2.12.1")
     runtimeOnly "org.apache.logging.log4j:log4j-api:2.12.1"
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:2.12.1"
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/alexa/AlexaHttpServerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/alexa/AlexaHttpServerSpec.groovy
@@ -14,7 +14,7 @@ class AlexaHttpServerSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['alexa-http-server'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.aws:micronaut-aws-alexa-httpserver"')
+        template.contains('implementation("io.micronaut.aws:micronaut-aws-alexa-httpserver")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/CaffeineSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/CaffeineSpec.groovy
@@ -14,7 +14,7 @@ class CaffeineSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['cache-caffeine'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.cache:micronaut-cache-caffeine"')
+        template.contains('implementation("io.micronaut.cache:micronaut-cache-caffeine")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/EHCacheSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/EHCacheSpec.groovy
@@ -15,7 +15,7 @@ class EHCacheSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['cache-ehcache'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.cache:micronaut-cache-ehcache"')
+        template.contains('implementation("io.micronaut.cache:micronaut-cache-ehcache")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/HazelcastSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/HazelcastSpec.groovy
@@ -15,7 +15,7 @@ class HazelcastSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['cache-hazelcast'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.cache:micronaut-cache-hazelcast"')
+        template.contains('implementation("io.micronaut.cache:micronaut-cache-hazelcast")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/InfinispanSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/InfinispanSpec.groovy
@@ -15,7 +15,7 @@ class InfinispanSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['cache-infinispan'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.cache:micronaut-cache-infinispan"')
+        template.contains('implementation("io.micronaut.cache:micronaut-cache-infinispan")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cassandra/CassandraSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cassandra/CassandraSpec.groovy
@@ -15,7 +15,7 @@ class CassandraSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['cassandra'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.configuration:micronaut-cassandra"')
+        template.contains('implementation("io.micronaut.configuration:micronaut-cassandra")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataJdbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataJdbcSpec.groovy
@@ -25,8 +25,8 @@ class DataJdbcSpec extends BeanContextSpec {
 
         then:
         template.contains("annotationProcessor \"io.micronaut.data:micronaut-data-processor\"")
-        template.contains("implementation \"io.micronaut.data:micronaut-data-jdbc\"")
-        template.contains("implementation \"io.micronaut.configuration:micronaut-jdbc-tomcat\"")
+        template.contains('implementation("io.micronaut.data:micronaut-data-jdbc")')
+        template.contains('implementation("io.micronaut.configuration:micronaut-jdbc-tomcat")')
         template.contains("runtimeOnly \"com.h2database:h2\"")
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataJpaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataJpaSpec.groovy
@@ -25,8 +25,8 @@ class DataJpaSpec extends BeanContextSpec {
 
         then:
         template.contains("annotationProcessor \"io.micronaut.data:micronaut-data-processor\"")
-        template.contains("implementation \"io.micronaut.data:micronaut-data-jpa\"")
-        template.contains("implementation \"io.micronaut.configuration:micronaut-jdbc-tomcat\"")
+        template.contains('implementation("io.micronaut.data:micronaut-data-jpa")')
+        template.contains('implementation("io.micronaut.configuration:micronaut-jdbc-tomcat")')
         template.contains("runtimeOnly \"com.h2database:h2\"")
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateGormSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateGormSpec.groovy
@@ -24,8 +24,8 @@ class HibernateGormSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(["hibernate-gorm"])).render().toString()
 
         then:
-        template.contains("implementation \"io.micronaut.configuration:micronaut-hibernate-gorm\"")
-        template.contains("implementation \"io.micronaut.configuration:micronaut-hibernate-validator\"")
+        template.contains('implementation("io.micronaut.configuration:micronaut-hibernate-gorm")')
+        template.contains('implementation("io.micronaut.configuration:micronaut-hibernate-validator")')
         template.contains("runtimeOnly \"com.h2database:h2\"")
         template.contains("runtimeOnly \"org.apache.tomcat:tomcat-jdbc\"")
     }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateJpaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateJpaSpec.groovy
@@ -24,7 +24,7 @@ class HibernateJpaSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(["hibernate-jpa"])).render().toString()
 
         then:
-        template.contains("implementation \"io.micronaut.configuration:micronaut-hibernate-jpa\"")
+        template.contains('implementation("io.micronaut.configuration:micronaut-hibernate-jpa")')
         template.contains("runtimeOnly \"com.h2database:h2\"")
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MongoGormSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MongoGormSpec.groovy
@@ -24,8 +24,8 @@ class MongoGormSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(["mongo-gorm"])).render().toString()
 
         then:
-        template.contains("implementation \"io.micronaut.configuration:micronaut-mongo-gorm\"")
-        template.contains("implementation \"io.micronaut.configuration:micronaut-mongo-reactive\"")
+        template.contains('implementation("io.micronaut.configuration:micronaut-mongo-gorm")')
+        template.contains('implementation("io.micronaut.configuration:micronaut-mongo-reactive")')
         template.contains("testImplementation \"de.flapdoodle.embed:de.flapdoodle.embed.mongo:2.0.1\"")
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MongoReactiveSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MongoReactiveSpec.groovy
@@ -21,7 +21,7 @@ class MongoReactiveSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(["mongo-reactive"])).render().toString()
 
         then:
-        template.contains("implementation \"io.micronaut.configuration:micronaut-mongo-reactive\"")
+        template.contains('implementation("io.micronaut.configuration:micronaut-mongo-reactive")')
         template.contains("testImplementation \"de.flapdoodle.embed:de.flapdoodle.embed.mongo:2.0.1\"")
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/Neo4jBoltSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/Neo4jBoltSpec.groovy
@@ -22,7 +22,7 @@ class Neo4jBoltSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(["neo4j-bolt"])).render().toString()
 
         then:
-        template.contains("implementation \"io.micronaut.configuration:micronaut-neo4j-bolt\"")
+        template.contains('implementation("io.micronaut.configuration:micronaut-neo4j-bolt")')
         template.contains("testRuntime \"org.neo4j.test:neo4j-harness\"")
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/Neo4jGormSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/Neo4jGormSpec.groovy
@@ -23,8 +23,8 @@ class Neo4jGormSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(["neo4j-gorm"])).render().toString()
 
         then:
-        template.contains("implementation \"io.micronaut.configuration:micronaut-neo4j-gorm\"")
-        template.contains("implementation \"io.micronaut.configuration:micronaut-neo4j-bolt\"")
+        template.contains('implementation("io.micronaut.configuration:micronaut-neo4j-gorm")')
+        template.contains('implementation("io.micronaut.configuration:micronaut-neo4j-bolt")')
         template.contains("testRuntime \"org.neo4j.test:neo4j-harness\"")
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/jdbc/JdbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/jdbc/JdbcSpec.groovy
@@ -14,7 +14,7 @@ class JdbcSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures([jdbcFeature])).render().toString()
 
         then:
-        template.contains("implementation \"io.micronaut.configuration:micronaut-${jdbcFeature}\"")
+        template.contains("implementation(\"io.micronaut.configuration:micronaut-${jdbcFeature}\")")
         template.contains("runtimeOnly \"com.h2database:h2\"")
 
         where:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryConsulSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryConsulSpec.groovy
@@ -15,7 +15,7 @@ class DiscoveryConsulSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['discovery-consul'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut:micronaut-discovery-client"')
+        template.contains('implementation("io.micronaut:micronaut-discovery-client")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryEurekaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryEurekaSpec.groovy
@@ -15,7 +15,7 @@ class DiscoveryEurekaSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['discovery-eureka'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut:micronaut-discovery-client"')
+        template.contains('implementation("io.micronaut:micronaut-discovery-client")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/elasticsearch/ElasticsearchSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/elasticsearch/ElasticsearchSpec.groovy
@@ -15,7 +15,7 @@ class ElasticsearchSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['elasticsearch'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.configuration:micronaut-elasticsearch"')
+        template.contains('implementation("io.micronaut.configuration:micronaut-elasticsearch")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/externalconfig/ConfigConsulSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/externalconfig/ConfigConsulSpec.groovy
@@ -15,7 +15,7 @@ class ConfigConsulSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['config-consul'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut:micronaut-discovery-client"')
+        template.contains('implementation("io.micronaut:micronaut-discovery-client")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]
@@ -26,7 +26,7 @@ class ConfigConsulSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['config-consul', 'discovery-consul'])).render().toString()
 
         then:
-        template.count('implementation "io.micronaut:micronaut-discovery-client"') == 1
+        template.count('implementation("io.micronaut:micronaut-discovery-client")') == 1
     }
 
     @Unroll

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/externalconfig/KubernetesSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/externalconfig/KubernetesSpec.groovy
@@ -15,8 +15,8 @@ class KubernetesSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['kubernetes'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.kubernetes:micronaut-kubernetes-discovery-client"')
-        template.contains('implementation "io.micronaut:micronaut-management"')
+        template.contains('implementation("io.micronaut.kubernetes:micronaut-kubernetes-discovery-client")')
+        template.contains('implementation("io.micronaut:micronaut-management")')
         template.contains('id "com.google.cloud.tools.jib" version "2.1.0"')
 
         where:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/graphql/GraphQLSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/graphql/GraphQLSpec.groovy
@@ -15,7 +15,7 @@ class GraphQLSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['graphql'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.graphql:micronaut-graphql"')
+        template.contains('implementation("io.micronaut.graphql:micronaut-graphql")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/micrometer/MicrometerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/micrometer/MicrometerSpec.groovy
@@ -20,7 +20,7 @@ class MicrometerSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), features).render().toString()
 
         then:
-        template.contains("implementation \"io.micronaut.configuration:${dependency}\"")
+        template.contains("implementation(\"io.micronaut.configuration:${dependency}\")")
 
         where:
         micrometerFeature << beanContext.getBeansOfType(MicrometerFeature).iterator()
@@ -33,9 +33,9 @@ class MicrometerSpec extends BeanContextSpec {
 
         then:
         template.contains("""
-    implementation "io.micronaut.configuration:micronaut-micrometer-core"
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-atlas"
-    implementation "io.micronaut.configuration:micronaut-micrometer-registry-influx"
+    implementation("io.micronaut.configuration:micronaut-micrometer-core")
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-atlas")
+    implementation("io.micronaut.configuration:micronaut-micrometer-registry-influx")
 """)
         template.count("io.micronaut.configuration:micronaut-micrometer-core") == 1
     }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/FlywaySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/FlywaySpec.groovy
@@ -12,7 +12,7 @@ class FlywaySpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['flyway'])).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.configuration:micronaut-flyway"')
+        template.contains('implementation("io.micronaut.configuration:micronaut-flyway")')
     }
 
     void "test the dependency is added to the maven build"() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/LiquibaseSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/LiquibaseSpec.groovy
@@ -11,7 +11,7 @@ class LiquibaseSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['liquibase'])).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.configuration:micronaut-liquibase"')
+        template.contains('implementation("io.micronaut.configuration:micronaut-liquibase")')
     }
 
     void "test the dependency is added to the maven build"() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/ArchaiusSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/ArchaiusSpec.groovy
@@ -14,7 +14,7 @@ class ArchaiusSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['netflix-archaius'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.configuration:micronaut-netflix-archaius"')
+        template.contains('implementation("io.micronaut.configuration:micronaut-netflix-archaius")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/HystrixSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/HystrixSpec.groovy
@@ -15,7 +15,7 @@ class HystrixSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['netflix-hystrix'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.configuration:micronaut-netflix-hystrix"')
+        template.contains('implementation("io.micronaut.configuration:micronaut-netflix-hystrix")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/RibbonSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/RibbonSpec.groovy
@@ -15,7 +15,7 @@ class RibbonSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['netflix-ribbon'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.configuration:micronaut-netflix-ribbon"')
+        template.contains('implementation("io.micronaut.configuration:micronaut-netflix-ribbon")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/other/SwaggerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/other/SwaggerSpec.groovy
@@ -14,7 +14,7 @@ class SwaggerSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['swagger'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.swagger.core.v3:swagger-annotations"')
+        template.contains('implementation("io.swagger.core.v3:swagger-annotations")')
         template.contains("$scope \"io.micronaut.configuration:micronaut-openapi\"")
 
         where:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/postgres/PostgresReactiveSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/postgres/PostgresReactiveSpec.groovy
@@ -15,7 +15,7 @@ class PostgresReactiveSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['postgres-reactive'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.configuration:micronaut-postgres-reactive"')
+        template.contains('implementation("io.micronaut.configuration:micronaut-postgres-reactive")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/redis/RedisLettuceSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/redis/RedisLettuceSpec.groovy
@@ -15,7 +15,7 @@ class RedisLettuceSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['redis-lettuce'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.configuration:micronaut-redis-lettuce"')
+        template.contains('implementation("io.micronaut.configuration:micronaut-redis-lettuce")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/rss/RssItunesSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/rss/RssItunesSpec.groovy
@@ -14,7 +14,7 @@ class RssItunesSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['rss-itunes-podcast'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.configuration:micronaut-itunespodcast"')
+        template.contains('implementation("io.micronaut.configuration:micronaut-itunespodcast")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/rss/RssSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/rss/RssSpec.groovy
@@ -14,7 +14,7 @@ class RssSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['rss'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.configuration:micronaut-rss"')
+        template.contains('implementation("io.micronaut.configuration:micronaut-rss")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecurityJTWSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecurityJTWSpec.groovy
@@ -15,7 +15,7 @@ class SecurityJTWSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['security-jwt'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut:micronaut-security-jwt"')
+        template.contains('implementation("io.micronaut:micronaut-security-jwt")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecuritySessionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecuritySessionSpec.groovy
@@ -15,7 +15,7 @@ class SecuritySessionSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['security-session'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut:micronaut-security-session"')
+        template.contains('implementation("io.micronaut:micronaut-security-session")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/server/ServerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/server/ServerSpec.groovy
@@ -18,10 +18,10 @@ class ServerSpec extends BeanContextSpec {
 
         where:
         serverFeature     | dependency
-        "netty-server"    | 'implementation "io.micronaut:micronaut-http-server-netty"'
-        "jetty-server"    | 'implementation "io.micronaut.servlet:micronaut-http-server-jetty"'
-        "tomcat-server"   | 'implementation "io.micronaut.servlet:micronaut-http-server-tomcat"'
-        "undertow-server" | 'implementation "io.micronaut.servlet:micronaut-http-server-undertow"'
+        "netty-server"    | 'implementation("io.micronaut:micronaut-http-server-netty")'
+        "jetty-server"    | 'implementation("io.micronaut.servlet:micronaut-http-server-jetty")'
+        "tomcat-server"   | 'implementation("io.micronaut.servlet:micronaut-http-server-tomcat")'
+        "undertow-server" | 'implementation("io.micronaut.servlet:micronaut-http-server-undertow")'
     }
 
     @Unroll

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/JaegerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/JaegerSpec.groovy
@@ -15,7 +15,7 @@ class JaegerSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['tracing-jaeger'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut:micronaut-tracing"')
+        template.contains('implementation("io.micronaut:micronaut-tracing")')
         template.contains('runtimeOnly "io.jaegertracing:jaeger-thrift"')
 
         where:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/ZipkinSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/ZipkinSpec.groovy
@@ -15,8 +15,8 @@ class ZipkinSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['tracing-zipkin'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut:micronaut-tracing"')
-        template.contains('implementation "io.opentracing.brave:brave-opentracing"')
+        template.contains('implementation("io.micronaut:micronaut-tracing")')
+        template.contains('implementation("io.opentracing.brave:brave-opentracing")')
         template.contains('runtimeOnly "io.zipkin.brave:brave-instrumentation-http"')
         template.contains('runtimeOnly "io.zipkin.reporter2:zipkin-reporter"')
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/vertx/VertxClientSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/vertx/VertxClientSpec.groovy
@@ -15,7 +15,7 @@ class VertxClientSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['vertx-mysql-client'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.configuration:micronaut-vertx-mysql-client"')
+        template.contains('implementation("io.micronaut.configuration:micronaut-vertx-mysql-client")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/vertx/VertxPgSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/vertx/VertxPgSpec.groovy
@@ -15,7 +15,7 @@ class VertxPgSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['vertx-pg-client'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut.configuration:micronaut-vertx-pg-client"')
+        template.contains('implementation("io.micronaut.configuration:micronaut-vertx-pg-client")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/FreemarkerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/FreemarkerSpec.groovy
@@ -14,7 +14,7 @@ class FreemarkerSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['views-freemarker'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut:micronaut-views-freemarker"')
+        template.contains('implementation("io.micronaut:micronaut-views-freemarker")')
         template.contains('runtime "org.freemarker:freemarker:2.3.28"')
 
         where:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/HandlebarsSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/HandlebarsSpec.groovy
@@ -14,7 +14,7 @@ class HandlebarsSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['views-handlebars'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut:micronaut-views-handlebars"')
+        template.contains('implementation("io.micronaut:micronaut-views-handlebars")')
         template.contains('runtime "com.github.jknack:handlebars:4.1.2"')
 
         where:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/RockerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/RockerSpec.groovy
@@ -14,7 +14,7 @@ class RockerSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['views-rocker'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut:micronaut-views-rocker"')
+        template.contains('implementation("io.micronaut:micronaut-views-rocker")')
         template.contains('id "com.fizzed.rocker" version "1.2.3"')
         template.contains("""
 sourceSets {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/SoySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/SoySpec.groovy
@@ -14,8 +14,8 @@ class SoySpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['views-soy'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut:micronaut-views-soy"')
-        template.contains('implementation "com.google.template:soy:2019-09-03"')
+        template.contains('implementation("io.micronaut:micronaut-views-soy")')
+        template.contains('implementation("com.google.template:soy:2019-09-03")')
 
         where:
         language << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/ThymeleafSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/ThymeleafSpec.groovy
@@ -14,7 +14,7 @@ class ThymeleafSpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['views-thymeleaf'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut:micronaut-views-thymeleaf"')
+        template.contains('implementation("io.micronaut:micronaut-views-thymeleaf")')
         template.contains('runtime "org.thymeleaf:thymeleaf:3.0.11.RELEASE"')
 
         where:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/VelocitySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/VelocitySpec.groovy
@@ -14,7 +14,7 @@ class VelocitySpec extends BeanContextSpec {
         String template = buildGradle.template(buildProject(), getFeatures(['views-velocity'], language)).render().toString()
 
         then:
-        template.contains('implementation "io.micronaut:micronaut-views-velocity"')
+        template.contains('implementation("io.micronaut:micronaut-views-velocity")')
         template.contains('runtime "org.apache.velocity:velocity-engine-core:2.0"')
 
         where:


### PR DESCRIPTION
Instead of

```groovy
dependencies {
    implementation "com.acme:example:1.0"
}
```

define dependencies as:

```groovy
dependencies {
    implementation("com.acme:example:1.0")
}
```

The latter is compatible with both Groovy and Kotlin Gradle DSL.

See:

https://guides.gradle.org/migrating-build-logic-from-groovy-to-kotlin/#prepare_your_groovy_scripts