### PR TITLE
feat: Make features toggeable

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/BaseAvailableFeatures.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/BaseAvailableFeatures.java
@@ -32,6 +32,7 @@ public class BaseAvailableFeatures implements AvailableFeatures {
 
     public BaseAvailableFeatures(List<Feature> features, ApplicationType applicationType) {
         this.features = features.stream()
+                .filter(Feature::isEnabled)
                 .filter(f -> f.supports(applicationType))
                 .collect(Collectors.toMap(
                         Feature::getName,

--- a/starter-core/src/main/java/io/micronaut/starter/feature/Feature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/Feature.java
@@ -18,6 +18,7 @@ package io.micronaut.starter.feature;
 import io.micronaut.core.naming.Described;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.order.Ordered;
+import io.micronaut.core.util.Toggleable;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.options.Language;
@@ -31,7 +32,7 @@ import java.util.Optional;
  * @author James Kleeh
  * @since 2.0.0
  */
-public interface Feature extends Named, Ordered, Described {
+public interface Feature extends Named, Ordered, Described, Toggleable {
 
     /**
      * @return The title of the feature


### PR DESCRIPTION
This will be useful in scenarios such as forking the cli and you want only a set of features to be enabled. 

Specially useful if you drive feature configuration via a yaml file. 

see: 

https://github.com/micronaut-projects/micronaut-starter/pull/106