### PR TITLE
feat: apply shadowJar whenever shade feature is present

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -30,10 +30,10 @@ plugins {
 @if (features.contains("azure-function")) {
     id "com.microsoft.azure.azurefunctions" version "1.1.0"
 }
-@if (features.application() != null) {
-    @if (features.contains("shade")) {
+@if (features.contains("shade")) {
     id "com.github.johnrengelman.shadow" version "5.2.0"
-    }
+}
+@if (features.application() != null) {
     id "application"
 }
 @if (features.contains("grpc")) {
@@ -458,12 +458,13 @@ tasks.withType(GroovyCompile) {
 }
 
 
-@if (features.application() != null) {
 @if (features.contains("shade")) {
 shadowJar {
     mergeServiceFiles()
 }
 }
+
+@if (features.application() != null) {
 
 @if (features.contains("jrebel")) {
 run.dependsOn(generateRebel)


### PR DESCRIPTION
I want the shadowJar applied when I do for example: 

`./gradlew starter-cli:run --args="create-function example.micronaut.demoawslambda --lang=kotlin --features=aws-lambda"`

I want to generate a JAT FAR and upload that to AWS Lambda. 

That it is to say. I think we should apply the shadow Jar plugin not only when we are in an application. 