### PR TITLE
feat: apply gradle java-library plugin when not app

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -35,6 +35,8 @@ plugins {
     id "com.github.johnrengelman.shadow" version "5.2.0"
     }
     id "application"
+} else {
+    id "java-library"
 }
 @if (features.contains("grpc")) {
     id "com.google.protobuf" version "0.8.10"

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -36,8 +36,13 @@ plugins {
 @if (features.application() != null) {
     id "application"
 } else {
+@if (features.language().isKotlin()) {
+    id "java"
+} else {
     id "java-library"
 }
+}
+
 @if (features.contains("grpc")) {
     id "com.google.protobuf" version "0.8.10"
 }


### PR DESCRIPTION
When we don't apply the `application` Gradle plugin, I think when should apply the `java-library`