### PR TITLE
Remove '-H:IncludeResources' from GraalVM Dockerfile.

### DIFF
--- a/starter-aws-lambda/src/main/resources/META-INF/native-image/io.micronaut.starter.lambda/micronaut-starter-aws-lambda/native-image.properties
+++ b/starter-aws-lambda/src/main/resources/META-INF/native-image/io.micronaut.starter.lambda/micronaut-starter-aws-lambda/native-image.properties
@@ -1,4 +1,3 @@
 Args = --report-unsupported-elements-at-runtime \
-       -H:IncludeResources=logback.xml|application.yml \
        -H:Name=server \
        -H:Class=io.micronaut.function.aws.runtime.MicronautLambdaRuntime

--- a/starter-core/src/main/java/io/micronaut/starter/feature/graalvm/template/nativeImageProperties.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/graalvm/template/nativeImageProperties.rocker.raw
@@ -8,6 +8,5 @@ Project project,
 Features features
 )
 
-Args = -H:IncludeResources=logback.xml|application.yml|bootstrap.yml \
-       -H:Name=@project.getName() \
+Args = -H:Name=@project.getName() \
        -H:Class=@features.application().mainClassName(applicationType,project,features)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/graalvm/GraalVMSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/graalvm/GraalVMSpec.groovy
@@ -245,7 +245,6 @@ class GraalVMSpec extends BeanContextSpec implements CommandOutputFixture {
         then:
         nativeImageProperties
 
-        nativeImageProperties.contains('-H:IncludeResources=logback.xml|application.yml|bootstrap.yml')
         nativeImageProperties.contains('-H:Name=foo')
         nativeImageProperties.contains('-H:Class=example.micronaut.Application')
 
@@ -284,7 +283,6 @@ class GraalVMSpec extends BeanContextSpec implements CommandOutputFixture {
         then:
         nativeImageProperties
 
-        nativeImageProperties.contains('-H:IncludeResources=logback.xml|application.yml|bootstrap.yml')
         nativeImageProperties.contains('-H:Name=foo')
         nativeImageProperties.contains('-H:Class=io.micronaut.function.aws.runtime.MicronautLambdaRuntime')
 


### PR DESCRIPTION
It is not mandatory anymore because the GraalTypeElementVisitor
adds all the resources to the native-image.