### PR TITLE
Use Gradle TestKit for integration tests / remove output polling

### DIFF
--- a/.github/workflows/gradle-func.yml
+++ b/.github/workflows/gradle-func.yml
@@ -11,15 +11,15 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          key: ${{ runner.os }}-gradle-functional-tests-${{ matrix.java }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
+            ${{ runner.os }}-gradle-functional-tests-
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-functional-tests-${{ matrix.java }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-maven-functional-tests-
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/gradle-func.yml
+++ b/.github/workflows/gradle-func.yml
@@ -11,15 +11,15 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-functional-tests-${{ matrix.java }}-${{ hashFiles('**/*.gradle') }}
+          key: ${{ runner.os }}-gradle-test-cli-tests-${{ matrix.java }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-functional-tests-
+            ${{ runner.os }}-gradle-test-cli-tests-
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-functional-tests-${{ matrix.java }}-${{ hashFiles('**/*.gradle') }}
+          key: ${{ runner.os }}-maven-test-cli-tests-${{ matrix.java }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
-            ${{ runner.os }}-maven-functional-tests-
+            ${{ runner.os }}-maven-test-cli-tests-
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
@@ -36,15 +36,15 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          key: ${{ runner.os }}-gradle-test-core-tests-${{ matrix.java }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
+            ${{ runner.os }}-gradle-test-core-tests-
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-test-core-tests-${{ matrix.java }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-maven-test-core-tests-
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
@@ -61,15 +61,15 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          key: ${{ runner.os }}-gradle-test-aws-tests-${{ matrix.java }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
+            ${{ runner.os }}-gradle-test-awstests-
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-test-aws-tests-${{ matrix.java }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-maven-test-aws-tests-
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,12 +14,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -62,11 +62,19 @@ subprojects { Project subproject ->
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'
 
-    if (project.name != 'test-cli') {
 
-        configurations.all {
-            resolutionStrategy {
-                eachDependency { DependencyResolveDetails details ->
+    configurations.all {
+        resolutionStrategy {
+            eachDependency { DependencyResolveDetails details ->
+                if (project.name.startsWith("test-")) {
+                    // Gradle TestKit needs Groovy 2.5
+                    if (details.requested.group == "org.codehaus.groovy") {
+                        details.useVersion("2.5.11")
+                    }
+                    if (details.requested.name == "spock-core") {
+                        details.useVersion("1.3-groovy-2.5")
+                    }
+                } else {
                     //multiple actions can be specified
                     if (details.requested.group == "org.codehaus.groovy") {
                         details.useVersion(groovyVersion)
@@ -80,11 +88,20 @@ subprojects { Project subproject ->
     }
 
     dependencies {
-        annotationProcessor enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion")
-        implementation enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion")
-        annotationProcessor "io.micronaut:micronaut-inject-java"
-        testAnnotationProcessor enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion")
-        testAnnotationProcessor "io.micronaut:micronaut-inject-java"
+        if (project.name.startsWith("test-")) {
+            implementation gradleTestKit()
+            implementation 'org.apache.maven:maven-embedder:3.0.5'
+            implementation 'org.sonatype.aether:aether-connector-wagon:1.13.1', {
+                exclude group:'org.apache.maven.wagon', module:'wagon-provider-api'
+            }
+            implementation 'org.apache.maven.wagon:wagon-http:2.5'
+        } else {
+            annotationProcessor enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion")
+            implementation enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion")
+            annotationProcessor "io.micronaut:micronaut-inject-java"
+            testAnnotationProcessor enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion")
+            testAnnotationProcessor "io.micronaut:micronaut-inject-java"
+        }
         testImplementation("org.codehaus.groovy:groovy:$groovyVersion")
         testImplementation("org.spockframework:spock-core:$spockVersion") {
             exclude group: "org.codehaus.groovy", module: "groovy-all"
@@ -104,7 +121,9 @@ subprojects { Project subproject ->
     }
 
     apply from: "${rootProject.projectDir}/gradle/checkstyle.gradle"
-    apply from: "${rootProject.projectDir}/gradle/test.gradle"
+    if (!project.name.startsWith("test-")) {
+        apply from: "${rootProject.projectDir}/gradle/test.gradle"
+    }
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -62,15 +62,18 @@ subprojects { Project subproject ->
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'
 
-    configurations.all {
-        resolutionStrategy {
-            eachDependency { DependencyResolveDetails details ->
-                //multiple actions can be specified
-                if (details.requested.group == "org.codehaus.groovy") {
-                    details.useVersion(groovyVersion)
-                }
-                if (details.requested.name == "spock-core") {
-                    details.useVersion(spockVersion)
+    if (project.name != 'test-cli') {
+
+        configurations.all {
+            resolutionStrategy {
+                eachDependency { DependencyResolveDetails details ->
+                    //multiple actions can be specified
+                    if (details.requested.group == "org.codehaus.groovy") {
+                        details.useVersion(groovyVersion)
+                    }
+                    if (details.requested.name == "spock-core") {
+                        details.useVersion(spockVersion)
+                    }
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -90,11 +90,6 @@ subprojects { Project subproject ->
     dependencies {
         if (project.name.startsWith("test-")) {
             implementation gradleTestKit()
-            implementation 'org.apache.maven:maven-embedder:3.0.5'
-            implementation 'org.sonatype.aether:aether-connector-wagon:1.13.1', {
-                exclude group:'org.apache.maven.wagon', module:'wagon-provider-api'
-            }
-            implementation 'org.apache.maven.wagon:wagon-http:2.5'
         } else {
             annotationProcessor enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion")
             implementation enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion")

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -8,7 +8,9 @@ testlogger {
 }
 
 tasks.withType(Test) {
-    useJUnitPlatform()
+    if (project.name != 'test-cli') {
+        useJUnitPlatform()
+    }
     jvmArgs '-Duser.country=US'
     jvmArgs '-Duser.language=en'
     testLogging {

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/project/test/CreateTestCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/project/test/CreateTestCommand.java
@@ -22,6 +22,7 @@ import io.micronaut.core.util.functional.ThrowingSupplier;
 import io.micronaut.starter.application.Project;
 import io.micronaut.starter.cli.CodeGenConfig;
 import io.micronaut.starter.cli.command.CodeGenCommand;
+import io.micronaut.starter.feature.test.template.*;
 import io.micronaut.starter.io.ConsoleOutput;
 import io.micronaut.starter.io.OutputHandler;
 import io.micronaut.starter.options.Language;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -47,10 +47,12 @@ List<Property> properties
       <id>jcenter.bintray.com</id>
       <url>https://jcenter.bintray.com</url>
     </repository>
+    @if (VersionInfo.getStarterVersion().endsWith("-SNAPSHOT")) {
     <repository>
         <id>central</id>
         <url>https://repo.maven.apache.org/maven2</url>
     </repository>
+    }
     @if (VersionInfo.getMicronautVersion().endsWith("-SNAPSHOT")) {
     <repository>
       <id>jfrog-snapshots</id>
@@ -1273,7 +1275,21 @@ List<Property> properties
         <enabled>false</enabled>
       </snapshots>
     </pluginRepository>
+    @if (VersionInfo.getStarterVersion().endsWith("-SNAPSHOT")) {
+    <pluginRepository>
+       <id>central</id>
+       <url>https://repo.maven.apache.org/maven2</url>
+    </pluginRepository>
+    }
   </pluginRepositories>
+} else if (VersionInfo.getStarterVersion().endsWith("-SNAPSHOT")) {
+    <pluginRepositories>
+       <pluginRepository>
+           <id>central</id>
+           <url>https://repo.maven.apache.org/maven2</url>
+       </pluginRepository>
+    </pluginRepositories>
 }
+
 
 </project>

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -47,13 +47,16 @@ List<Property> properties
       <id>jcenter.bintray.com</id>
       <url>https://jcenter.bintray.com</url>
     </repository>
+    <repository>
+        <id>central</id>
+        <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
     @if (VersionInfo.getMicronautVersion().endsWith("-SNAPSHOT")) {
     <repository>
       <id>jfrog-snapshots</id>
       <url>https://oss.jfrog.org/oss-snapshot-local</url>
     </repository>
     }
-
   </repositories>
 
   <dependencies>

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplication.java
@@ -21,6 +21,11 @@ import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.Features;
 import io.micronaut.starter.feature.function.awslambda.AwsLambda;
+import io.micronaut.starter.feature.test.template.groovyJunit;
+import io.micronaut.starter.feature.test.template.javaJunit;
+import io.micronaut.starter.feature.test.template.kotlinTest;
+import io.micronaut.starter.feature.test.template.spock;
+import io.micronaut.starter.options.TestFramework;
 import io.micronaut.starter.template.RockerTemplate;
 
 import javax.inject.Singleton;
@@ -54,6 +59,27 @@ public class GroovyApplication implements GroovyApplicationFeature {
         if (shouldGenerateApplicationFile(generatorContext)) {
             generatorContext.addTemplate("application", new RockerTemplate(getPath(),
                     application.template(generatorContext.getProject(), generatorContext.getFeatures())));
+            TestFramework testFramework = generatorContext.getTestFramework();
+            String testSourcePath = generatorContext.getTestSourcePath("/{packagePath}/{className}");
+            switch (testFramework) {
+                case JUNIT:
+                    generatorContext.addTemplate("applicationTest",
+                            new RockerTemplate(testSourcePath,
+                                    groovyJunit.template(generatorContext.getProject()))
+                    );
+                    break;
+                case SPOCK:
+                    generatorContext.addTemplate("applicationTest",
+                            new RockerTemplate(testSourcePath,
+                                    spock.template(generatorContext.getProject()))
+                    );
+                    break;
+                case KOTLINTEST:
+                    generatorContext.addTemplate("applicationTest",
+                            new RockerTemplate(testSourcePath,
+                                    kotlinTest.template(generatorContext.getProject()))
+                    );
+            }
         }
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplication.java
@@ -66,12 +66,13 @@ public class GroovyApplication implements GroovyApplicationFeature {
                             new RockerTemplate(testSourcePath,
                                     groovyJunit.template(generatorContext.getProject()))
                     );
-                    break;
+                break;
                 case KOTLINTEST:
                     generatorContext.addTemplate("applicationTest",
                             new RockerTemplate(testSourcePath,
                                     kotlinTest.template(generatorContext.getProject()))
                     );
+                break;
                 case SPOCK:
                 default:
                     generatorContext.addTemplate("applicationTest",

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplication.java
@@ -22,7 +22,6 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.Features;
 import io.micronaut.starter.feature.function.awslambda.AwsLambda;
 import io.micronaut.starter.feature.test.template.groovyJunit;
-import io.micronaut.starter.feature.test.template.javaJunit;
 import io.micronaut.starter.feature.test.template.kotlinTest;
 import io.micronaut.starter.feature.test.template.spock;
 import io.micronaut.starter.options.TestFramework;
@@ -68,17 +67,18 @@ public class GroovyApplication implements GroovyApplicationFeature {
                                     groovyJunit.template(generatorContext.getProject()))
                     );
                     break;
-                case SPOCK:
-                    generatorContext.addTemplate("applicationTest",
-                            new RockerTemplate(testSourcePath,
-                                    spock.template(generatorContext.getProject()))
-                    );
-                    break;
                 case KOTLINTEST:
                     generatorContext.addTemplate("applicationTest",
                             new RockerTemplate(testSourcePath,
                                     kotlinTest.template(generatorContext.getProject()))
                     );
+                case SPOCK:
+                default:
+                    generatorContext.addTemplate("applicationTest",
+                            new RockerTemplate(testSourcePath,
+                                    spock.template(generatorContext.getProject()))
+                    );
+                    break;
             }
         }
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplication.java
@@ -72,6 +72,7 @@ public class JavaApplication implements JavaApplicationFeature {
                             new RockerTemplate(testSourcePath,
                                     kotlinTest.template(generatorContext.getProject()))
                     );
+                break;
                 case JUNIT:
                 default:
                     generatorContext.addTemplate("applicationTest",

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplication.java
@@ -21,6 +21,10 @@ import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.Features;
 import io.micronaut.starter.feature.function.awslambda.AwsLambda;
+import io.micronaut.starter.feature.test.template.javaJunit;
+import io.micronaut.starter.feature.test.template.kotlinTest;
+import io.micronaut.starter.feature.test.template.spock;
+import io.micronaut.starter.options.TestFramework;
 import io.micronaut.starter.template.RockerTemplate;
 
 import javax.inject.Singleton;
@@ -54,6 +58,28 @@ public class JavaApplication implements JavaApplicationFeature {
         if (shouldGenerateApplicationFile(generatorContext)) {
             generatorContext.addTemplate("application", new RockerTemplate(getPath(),
                     application.template(generatorContext.getProject(), generatorContext.getFeatures())));
+            TestFramework testFramework = generatorContext.getTestFramework();
+            String testSourcePath = generatorContext.getTestSourcePath("/{packagePath}/{className}");
+            switch (testFramework) {
+                case JUNIT:
+                    generatorContext.addTemplate("applicationTest",
+                            new RockerTemplate(testSourcePath,
+                            javaJunit.template(generatorContext.getProject()))
+                    );
+                break;
+                case SPOCK:
+                    generatorContext.addTemplate("applicationTest",
+                            new RockerTemplate(testSourcePath,
+                                    spock.template(generatorContext.getProject()))
+                    );
+                break;
+                case KOTLINTEST:
+                    generatorContext.addTemplate("applicationTest",
+                            new RockerTemplate(testSourcePath,
+                                    kotlinTest.template(generatorContext.getProject()))
+                    );
+            }
+
         }
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplication.java
@@ -61,12 +61,6 @@ public class JavaApplication implements JavaApplicationFeature {
             TestFramework testFramework = generatorContext.getTestFramework();
             String testSourcePath = generatorContext.getTestSourcePath("/{packagePath}/{className}");
             switch (testFramework) {
-                case JUNIT:
-                    generatorContext.addTemplate("applicationTest",
-                            new RockerTemplate(testSourcePath,
-                            javaJunit.template(generatorContext.getProject()))
-                    );
-                break;
                 case SPOCK:
                     generatorContext.addTemplate("applicationTest",
                             new RockerTemplate(testSourcePath,
@@ -78,6 +72,13 @@ public class JavaApplication implements JavaApplicationFeature {
                             new RockerTemplate(testSourcePath,
                                     kotlinTest.template(generatorContext.getProject()))
                     );
+                case JUNIT:
+                default:
+                    generatorContext.addTemplate("applicationTest",
+                            new RockerTemplate(testSourcePath,
+                                    javaJunit.template(generatorContext.getProject()))
+                    );
+                    break;
             }
 
         }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplication.java
@@ -21,6 +21,11 @@ import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.Features;
 import io.micronaut.starter.feature.function.awslambda.AwsLambda;
+import io.micronaut.starter.feature.test.template.groovyJunit;
+import io.micronaut.starter.feature.test.template.kotlinJunit;
+import io.micronaut.starter.feature.test.template.kotlinTest;
+import io.micronaut.starter.feature.test.template.spock;
+import io.micronaut.starter.options.TestFramework;
 import io.micronaut.starter.template.RockerTemplate;
 
 import javax.inject.Singleton;
@@ -54,6 +59,27 @@ public class KotlinApplication implements KotlinApplicationFeature {
         if (shouldGenerateApplicationFile(generatorContext)) {
             generatorContext.addTemplate("application", new RockerTemplate(getPath(),
                     application.template(generatorContext.getProject(), generatorContext.getFeatures())));
+            TestFramework testFramework = generatorContext.getTestFramework();
+            String testSourcePath = generatorContext.getTestSourcePath("/{packagePath}/{className}");
+            switch (testFramework) {
+                case JUNIT:
+                    generatorContext.addTemplate("applicationTest",
+                            new RockerTemplate(testSourcePath,
+                                    kotlinJunit.template(generatorContext.getProject()))
+                    );
+                    break;
+                case SPOCK:
+                    generatorContext.addTemplate("applicationTest",
+                            new RockerTemplate(testSourcePath,
+                                    spock.template(generatorContext.getProject()))
+                    );
+                    break;
+                case KOTLINTEST:
+                    generatorContext.addTemplate("applicationTest",
+                            new RockerTemplate(testSourcePath,
+                                    kotlinTest.template(generatorContext.getProject()))
+                    );
+            }
         }
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplication.java
@@ -66,13 +66,13 @@ public class KotlinApplication implements KotlinApplicationFeature {
                             new RockerTemplate(testSourcePath,
                                     kotlinJunit.template(generatorContext.getProject()))
                     );
-                    break;
+                break;
                 case SPOCK:
                     generatorContext.addTemplate("applicationTest",
                             new RockerTemplate(testSourcePath,
                                     spock.template(generatorContext.getProject()))
                     );
-                    break;
+                break;
                 case KOTLINTEST:
                 default:
                     generatorContext.addTemplate("applicationTest",

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplication.java
@@ -21,7 +21,6 @@ import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.Features;
 import io.micronaut.starter.feature.function.awslambda.AwsLambda;
-import io.micronaut.starter.feature.test.template.groovyJunit;
 import io.micronaut.starter.feature.test.template.kotlinJunit;
 import io.micronaut.starter.feature.test.template.kotlinTest;
 import io.micronaut.starter.feature.test.template.spock;
@@ -75,6 +74,7 @@ public class KotlinApplication implements KotlinApplicationFeature {
                     );
                     break;
                 case KOTLINTEST:
+                default:
                     generatorContext.addTemplate("applicationTest",
                             new RockerTemplate(testSourcePath,
                                     kotlinTest.template(generatorContext.getProject()))

--- a/starter-core/src/main/java/io/micronaut/starter/feature/multitenancy/Multitenancy.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/multitenancy/Multitenancy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.starter.feature.multitenancy;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/multitenancy/MultitenancyGorm.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/multitenancy/MultitenancyGorm.java
@@ -22,7 +22,6 @@ import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.FeaturePredicate;
 import io.micronaut.starter.feature.LanguageSpecificFeature;
-import io.micronaut.starter.feature.kotlin.Ktor;
 import io.micronaut.starter.options.Language;
 
 import javax.inject.Singleton;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/multitenancy/MultitenancyGorm.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/multitenancy/MultitenancyGorm.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.starter.feature.multitenancy;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/template/groovyJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/template/groovyJunit.rocker.raw
@@ -8,9 +8,9 @@ Project project
 package @project.getPackageName()
 }
 
-import io.micronaut.runtime.server.EmbeddedServer
+
+import io.micronaut.runtime.EmbeddedApplication
 import io.micronaut.test.annotation.MicronautTest
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
@@ -18,11 +18,11 @@ import javax.inject.Inject
 class @project.getClassName()Test {
 
     @@Inject
-    lateinit var embeddedServer: EmbeddedServer
+    EmbeddedApplication application
 
     @@Test
-    fun testItWorks() {
-        Assertions.assertTrue(embeddedServer.isRunning)
+    void testItWorks() {
+        assert application.running == true
     }
 
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/template/javaJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/template/javaJunit.rocker.raw
@@ -9,7 +9,7 @@ package @project.getPackageName();
 }
 
 
-import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.runtime.EmbeddedApplication;
 import io.micronaut.test.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
@@ -20,11 +20,11 @@ import javax.inject.Inject;
 public class @project.getClassName()Test {
 
     @@Inject
-    EmbeddedServer embeddedServer;
+    EmbeddedApplication application;
 
     @@Test
     void testItWorks() {
-        Assertions.assertTrue(embeddedServer.isRunning());
+        Assertions.assertTrue(application.isRunning());
     }
 
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/template/kotlinJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/template/kotlinJunit.rocker.raw
@@ -8,23 +8,21 @@ Project project
 package @project.getPackageName()
 }
 
-
-import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.runtime.EmbeddedApplication
 import io.micronaut.test.annotation.MicronautTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-
 import javax.inject.Inject
 
 @@MicronautTest
 class @project.getClassName()Test {
 
     @@Inject
-    EmbeddedServer embeddedServer
+    lateinit var application: EmbeddedApplication<*>
 
     @@Test
-    void testItWorks() {
-        Assertions.assertTrue(embeddedServer.running)
+    fun testItWorks() {
+        Assertions.assertTrue(application.isRunning)
     }
 
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/template/kotlinTest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/template/kotlinTest.rocker.raw
@@ -11,13 +11,13 @@ package @project.getPackageName()
 
 import io.kotlintest.specs.StringSpec
 import io.micronaut.context.ApplicationContext
-import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.runtime.EmbeddedApplication
 import io.micronaut.test.annotation.MicronautTest
 
 @@MicronautTest
-class @project.getClassName()Test(private val embeddedServer: EmbeddedServer): StringSpec({
+class @project.getClassName()Test(private val application: EmbeddedApplication<*>): StringSpec({
 
     "test the server is running" {
-        assert(embeddedServer.isRunning())
+        assert(application.isRunning())
     }
 })

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/template/spock.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/template/spock.rocker.raw
@@ -9,7 +9,7 @@ package @project.getPackageName()
 }
 
 
-import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.runtime.EmbeddedApplication
 import io.micronaut.test.annotation.MicronautTest
 import spock.lang.Specification
 import javax.inject.Inject
@@ -18,11 +18,11 @@ import javax.inject.Inject
 class @project.getClassName()Spec extends Specification {
 
     @@Inject
-    EmbeddedServer embeddedServer
+    EmbeddedApplication application
 
     void 'test it works'() {
         expect:
-        embeddedServer.running
+        application.running
     }
 
 }

--- a/starter-core/src/main/java/io/micronaut/starter/util/VersionInfo.java
+++ b/starter-core/src/main/java/io/micronaut/starter/util/VersionInfo.java
@@ -40,6 +40,17 @@ public class VersionInfo {
         }
     }
 
+    /**
+     * @return The starter version
+     */
+    public static String getStarterVersion() {
+        Package aPackage = VersionInfo.class.getPackage();
+        if (aPackage != null) {
+            return aPackage.getImplementationVersion();
+        }
+        return getMicronautVersion();
+    }
+
     public static String getMicronautVersion() {
         Object micronautVersion = VERSIONS.get("micronaut.version");
         if (micronautVersion != null) {

--- a/starter-core/src/main/java/io/micronaut/starter/util/VersionInfo.java
+++ b/starter-core/src/main/java/io/micronaut/starter/util/VersionInfo.java
@@ -46,7 +46,10 @@ public class VersionInfo {
     public static String getStarterVersion() {
         Package aPackage = VersionInfo.class.getPackage();
         if (aPackage != null) {
-            return aPackage.getImplementationVersion();
+            String implementationVersion = aPackage.getImplementationVersion();
+            if (implementationVersion != null) {
+                return implementationVersion;
+            }
         }
         return getMicronautVersion();
     }

--- a/test-cli/build.gradle
+++ b/test-cli/build.gradle
@@ -1,6 +1,25 @@
+configurations.all {
+    resolutionStrategy {
+        eachDependency { DependencyResolveDetails details ->
+            //multiple actions can be specified
+            if (details.requested.group == "org.codehaus.groovy") {
+                details.useVersion("2.5.11")
+            }
+            if (details.requested.name == "spock-core") {
+                details.useVersion("1.3-groovy-2.5")
+            }
+        }
+    }
+}
 dependencies {
     testImplementation project(":test-utils")
     testImplementation project(":micronaut-cli")
+    testImplementation gradleTestKit()
+    testImplementation 'org.apache.maven:maven-embedder:3.0.5'
+    testImplementation 'org.sonatype.aether:aether-connector-wagon:1.13.1', {
+        exclude group:'org.apache.maven.wagon', module:'wagon-provider-api'
+    }
+    testImplementation 'org.apache.maven.wagon:wagon-http:2.5'
 }
 
 tasks.withType(Test) {

--- a/test-cli/build.gradle
+++ b/test-cli/build.gradle
@@ -14,12 +14,6 @@ configurations.all {
 dependencies {
     testImplementation project(":test-utils")
     testImplementation project(":micronaut-cli")
-    testImplementation gradleTestKit()
-    testImplementation 'org.apache.maven:maven-embedder:3.0.5'
-    testImplementation 'org.sonatype.aether:aether-connector-wagon:1.13.1', {
-        exclude group:'org.apache.maven.wagon', module:'wagon-provider-api'
-    }
-    testImplementation 'org.apache.maven.wagon:wagon-http:2.5'
 }
 
 tasks.withType(Test) {

--- a/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateBeanSpec.groovy
+++ b/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateBeanSpec.groovy
@@ -43,14 +43,15 @@ public class Application {
     }
 }
 """)
+        String output = null
         if (build == BuildTool.GRADLE) {
-            executeGradleCommand("run")
+            output = executeGradle("test")?.output
         } else if (build == BuildTool.MAVEN) {
-            executeMavenCommand("mn:run")
+            output = executeMavenEmbedded("compile test")
         }
 
         then:
-        testOutputContains("Startup completed")
+        output?.contains("BUILD SUCCESS")
 
         where:
         build << BuildToolCombinations.buildTools
@@ -88,14 +89,15 @@ class Application {
     }
 }
 """)
+        String output = null
         if (build == BuildTool.GRADLE) {
-            executeGradleCommand("run")
+            output = executeGradle("test")?.output
         } else if (build == BuildTool.MAVEN) {
-            executeMavenCommand("mn:run")
+            output = executeMavenEmbedded("compile test")
         }
 
         then:
-        testOutputContains("Startup completed")
+        output?.contains("BUILD SUCCESS")
 
         where:
         build << BuildToolCombinations.buildTools
@@ -131,14 +133,15 @@ fun main(args: Array<String>) {
     ctx.getBean(example.micronaut.Greeting::class.java)
 }
 """)
+        String output = null
         if (build == BuildTool.GRADLE) {
-            executeGradleCommand("run")
+            output = executeGradle("test")?.output
         } else if (build == BuildTool.MAVEN) {
-            executeMavenCommand("mn:run")
+            output = executeMavenEmbedded("compile test")
         }
 
         then:
-        testOutputContains("Startup completed")
+        output?.contains("BUILD SUCCESS")
 
         where:
         build << BuildToolCombinations.buildTools

--- a/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateBeanSpec.groovy
+++ b/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateBeanSpec.groovy
@@ -47,7 +47,7 @@ public class Application {
         if (build == BuildTool.GRADLE) {
             output = executeGradle("test")?.output
         } else if (build == BuildTool.MAVEN) {
-            output = executeMavenEmbedded("compile test")
+            output = executeMaven("compile test")
         }
 
         then:
@@ -93,7 +93,7 @@ class Application {
         if (build == BuildTool.GRADLE) {
             output = executeGradle("test")?.output
         } else if (build == BuildTool.MAVEN) {
-            output = executeMavenEmbedded("compile test")
+            output = executeMaven("compile test")
         }
 
         then:
@@ -137,7 +137,7 @@ fun main(args: Array<String>) {
         if (build == BuildTool.GRADLE) {
             output = executeGradle("test")?.output
         } else if (build == BuildTool.MAVEN) {
-            output = executeMavenEmbedded("compile test")
+            output = executeMaven("compile test")
         }
 
         then:

--- a/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateControllerSpec.groovy
+++ b/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateControllerSpec.groovy
@@ -3,23 +3,15 @@ package io.micronaut.starter.cli.test
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.cli.CodeGenConfig
 import io.micronaut.starter.cli.feature.server.controller.CreateControllerCommand
-import io.micronaut.starter.test.CommandSpec
-import io.micronaut.starter.test.LanguageBuildTestFrameworkCombinations
 import io.micronaut.starter.io.ConsoleOutput
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
-import org.apache.maven.cli.MavenCli
-import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.GradleRunner
-import spock.lang.Shared
+import io.micronaut.starter.test.CommandSpec
+import io.micronaut.starter.test.LanguageBuildTestFrameworkCombinations
 import spock.lang.Unroll
 
-import java.nio.charset.StandardCharsets
-
 class CreateControllerSpec extends CommandSpec {
-    @Shared GradleRunner gradleRunner = GradleRunner.create()
-    @Shared MavenCli cli = new MavenCli()
 
     @Unroll
     void "test creating a controller and running the test for #language and #testFramework and #buildTool"(Language language,
@@ -43,12 +35,7 @@ class CreateControllerSpec extends CommandSpec {
         1 * consoleOutput.out({ it.contains("Rendered test") })
 
         when:
-        String output = null
-        if (buildTool == BuildTool.GRADLE) {
-            output = executeGradle("test").getOutput()
-        } else if (buildTool == BuildTool.MAVEN) {
-            output = executeMaven("test")
-        }
+        String output = executeBuild(buildTool, "test")
 
         then:
         output?.contains("BUILD SUCCESS")
@@ -62,19 +49,5 @@ class CreateControllerSpec extends CommandSpec {
         "test-createcontroller-createcontrollergroovygradlejunitspec"
     }
 
-    BuildResult executeGradle(String command) {
-        BuildResult result =
-                gradleRunner.withProjectDir(dir)
-                            .withArguments(command)
-                            .build()
-        return result
-    }
 
-    String executeMaven(String command) {
-        System.setProperty("maven.multiModuleProjectDirectory", dir.absolutePath)
-        def bytesOut = new ByteArrayOutputStream()
-        PrintStream output = new PrintStream(bytesOut)
-        cli.doMain(command.split(' '), dir.absolutePath, output, output)
-        return new String(bytesOut.toByteArray(), StandardCharsets.UTF_8)
-    }
 }

--- a/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateControllerSpec.groovy
+++ b/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateControllerSpec.groovy
@@ -75,6 +75,6 @@ class CreateControllerSpec extends CommandSpec {
         def bytesOut = new ByteArrayOutputStream()
         PrintStream output = new PrintStream(bytesOut)
         cli.doMain(command.split(' '), dir.absolutePath, output, output)
-        return bytesOut.toString(StandardCharsets.UTF_8)
+        return new String(bytesOut.toByteArray(), StandardCharsets.UTF_8)
     }
 }

--- a/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateNatsListenerSpec.groovy
+++ b/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateNatsListenerSpec.groovy
@@ -32,14 +32,15 @@ class CreateNatsListenerSpec extends CommandSpec {
         1 * consoleOutput.out({ it.contains("Rendered Nats listener") })
 
         when:
+        String output = null
         if (buildTool == BuildTool.GRADLE) {
-            executeGradleCommand("classes")
+            output = executeGradle("classes")?.output
         } else if (buildTool == BuildTool.MAVEN) {
-            executeMavenCommand("compile")
+            output = executeMavenEmbedded("compile")
         }
 
         then:
-        testOutputContains("BUILD SUCCESS")
+        output?.contains("BUILD SUCCESS")
 
         where:
         [language, buildTool] << LanguageBuildCombinations.combinations()

--- a/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateNatsListenerSpec.groovy
+++ b/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateNatsListenerSpec.groovy
@@ -36,7 +36,7 @@ class CreateNatsListenerSpec extends CommandSpec {
         if (buildTool == BuildTool.GRADLE) {
             output = executeGradle("classes")?.output
         } else if (buildTool == BuildTool.MAVEN) {
-            output = executeMavenEmbedded("compile")
+            output = executeMaven("compile")
         }
 
         then:

--- a/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateNatsProducerSpec.groovy
+++ b/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateNatsProducerSpec.groovy
@@ -34,7 +34,7 @@ class CreateNatsProducerSpec extends CommandSpec {
         if (buildTool == BuildTool.GRADLE) {
             output = executeGradle("classes")?.output
         } else if (buildTool == BuildTool.MAVEN) {
-            output = executeMavenEmbedded("compile")
+            output = executeMaven("compile")
         }
 
         then:

--- a/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateNatsProducerSpec.groovy
+++ b/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateNatsProducerSpec.groovy
@@ -1,6 +1,5 @@
 package io.micronaut.starter.cli.test
 
-import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.cli.CodeGenConfig
 import io.micronaut.starter.cli.feature.messaging.nats.CreateNatsProducer
 import io.micronaut.starter.io.ConsoleOutput
@@ -31,14 +30,15 @@ class CreateNatsProducerSpec extends CommandSpec {
         1 * consoleOutput.out({ it.contains("Rendered Nats producer") })
 
         when:
+        String output = null
         if (buildTool == BuildTool.GRADLE) {
-            executeGradleCommand("classes")
+            output = executeGradle("classes")?.output
         } else if (buildTool == BuildTool.MAVEN) {
-            executeMavenCommand("compile")
+            output = executeMavenEmbedded("compile")
         }
 
         then:
-        testOutputContains("BUILD SUCCESS")
+        output?.contains("BUILD SUCCESS")
 
         where:
         [language, buildTool] << LanguageBuildCombinations.combinations()

--- a/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateTestSpec.groovy
+++ b/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateTestSpec.groovy
@@ -37,7 +37,7 @@ class CreateTestSpec extends CommandSpec {
         if (buildTool == BuildTool.GRADLE) {
             result = executeGradle("test")?.output
         } else if (buildTool == BuildTool.MAVEN) {
-            result = executeMavenEmbedded("compile test")
+            result = executeMaven("compile test")
         }
 
         then:

--- a/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateTestSpec.groovy
+++ b/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateTestSpec.groovy
@@ -33,14 +33,15 @@ class CreateTestSpec extends CommandSpec {
         1 * consoleOutput.out({ it.contains("Rendered test") })
 
         when:
+        String result = null
         if (buildTool == BuildTool.GRADLE) {
-            executeGradleCommand("test")
+            result = executeGradle("test")?.output
         } else if (buildTool == BuildTool.MAVEN) {
-            executeMavenCommand("compile test")
+            result = executeMavenEmbedded("compile test")
         }
 
         then:
-        testOutputContains("BUILD SUCCESS")
+        result?.contains("BUILD SUCCESS")
 
         where:
         [language, buildTool, testFramework] << LanguageBuildTestFrameworkCombinations.combinations()

--- a/test-core/build.gradle
+++ b/test-core/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    testCompileOnly("io.micronaut:micronaut-inject-groovy")
     testImplementation project(":test-utils")
     testImplementation project(":starter-core")
 }

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsAlexaSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsAlexaSpec.groovy
@@ -25,10 +25,10 @@ class CreateAwsAlexaSpec extends CommandSpec {
         generateProject(lang, build, features, applicationType, testFramework)
 
         when:
-        build == BuildTool.GRADLE ? executeGradleCommand('test') : executeMavenCommand("test")
+        String output = executeBuild(build, "test")
 
         then:
-        testOutputContains("BUILD SUCCESS")
+        output.contains("BUILD SUCCESS")
 
         where:
         [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.DEFAULT, ApplicationType.FUNCTION])

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaCustomRuntimeSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaCustomRuntimeSpec.groovy
@@ -24,10 +24,10 @@ class CreateAwsLambdaCustomRuntimeSpec extends CommandSpec {
         generateProject(lang, build, features, applicationType, testFramework)
 
         when:
-        build == BuildTool.GRADLE ? executeGradleCommand('test') : executeMavenCommand("test")
+        String output = executeBuild(build, "test")
 
         then:
-        testOutputContains("BUILD SUCCESS")
+        output.contains("BUILD SUCCESS")
 
         where:
         [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.DEFAULT, ApplicationType.FUNCTION])

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaGraalvmSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaGraalvmSpec.groovy
@@ -21,13 +21,13 @@ class CreateAwsLambdaGraalvmSpec extends CommandSpec {
         generateProject(lang, build, features, applicationType, testFramework)
 
         when:
-        build == BuildTool.GRADLE ? executeGradleCommand('test') : executeMavenCommand("test")
+        String output = executeBuild(build, "test")
 
         then:
-        testOutputContains("BUILD SUCCESS")
+        output.contains("BUILD SUCCESS")
 
         where:
-        [applicationType, lang, build, testFramework] << [[ApplicationType.DEFAULT, ApplicationType.FUNCTION], Language.values() as List<Language> - [Language.GROOVY], BuildToolCombinations.buildTools, TestFramework.values()].combinations()
+        [applicationType, lang, build, testFramework] << [[ApplicationType.DEFAULT, ApplicationType.FUNCTION], Language.values() - [Language.GROOVY], BuildToolCombinations.buildTools, TestFramework.values()].combinations()
 
     }
 

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaSpec.groovy
@@ -25,10 +25,10 @@ class CreateAwsLambdaSpec extends CommandSpec {
         generateProject(lang, build, features, applicationType, testFramework)
 
         when:
-        build == BuildTool.GRADLE ? executeGradleCommand('test') : executeMavenCommand("test")
+        String output = executeBuild(build, "test")
 
         then:
-        testOutputContains("BUILD SUCCESS")
+        output.contains("BUILD SUCCESS")
 
         where:
         [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.DEFAULT, ApplicationType.FUNCTION])

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateAppSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateAppSpec.groovy
@@ -14,10 +14,10 @@ class CreateAppSpec extends CommandSpec {
         generateProject(lang, buildTool, [])
 
         when:
-        String output = executeBuild(buildTool, buildTool == BuildTool.GRADLE ? "run" : "mn:run")
+        String output = executeBuild(buildTool, "test")
 
         then:
-        output.contains("Startup completed")
+        output.contains("BUILD SUCCESS")
 
         where:
         [lang, buildTool] << LanguageBuildCombinations.combinations()

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateAppSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateAppSpec.groovy
@@ -14,14 +14,10 @@ class CreateAppSpec extends CommandSpec {
         generateProject(lang, buildTool, [])
 
         when:
-        if (buildTool == BuildTool.GRADLE) {
-            executeGradleCommand('run')
-        } else {
-            executeMavenCommand("mn:run")
-        }
+        String output = executeBuild(buildTool, buildTool == BuildTool.GRADLE ? "run" : "mn:run")
 
         then:
-        testOutputContains("Startup completed")
+        output.contains("Startup completed")
 
         where:
         [lang, buildTool] << LanguageBuildCombinations.combinations()

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateAsciidoctorSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateAsciidoctorSpec.groovy
@@ -14,14 +14,15 @@ class CreateAsciidoctorSpec extends CommandSpec {
         generateProject(language, buildTool, ['asciidoctor'])
 
         when:
+        String output = null
         if (buildTool == BuildTool.GRADLE) {
-            executeGradleCommand('asciidoctor')
+            output = executeGradle('asciidoctor').output
         } else {
-            executeMavenCommand("generate-resources")
+            output = executeMaven("generate-resources")
         }
 
         then:
-        testOutputContains('BUILD SUCCESS')
+        output?.contains('BUILD SUCCESS')
 
         where:
         [language, buildTool] << LanguageBuildCombinations.combinations()

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateCliSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateCliSpec.groovy
@@ -21,14 +21,15 @@ class CreateCliSpec extends CommandSpec {
         generateProject(lang, buildTool, [], applicationType)
 
         when:
+        String output = null
         if (buildTool == BuildTool.GRADLE) {
-            executeGradleCommand('run --args="-v"')
+            output = executeGradle('run --args="-v"').output
         } else {
-            executeMavenCommand("mn:run -Dmn.appArgs=-v")
+            output = executeMaven("mn:run -Dmn.appArgs=-v")
         }
 
         then:
-        testOutputContains("Hi")
+        output?.contains("Hi")
 
         where:
         [lang, buildTool] << LanguageBuildCombinations.combinations()

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateGrpcSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateGrpcSpec.groovy
@@ -20,14 +20,10 @@ class CreateGrpcSpec extends CommandSpec {
         generateProject(lang, buildTool, [], applicationType)
 
         when:
-        if (buildTool == BuildTool.GRADLE) {
-            executeGradleCommand('run')
-        } else {
-            executeMavenCommand("mn:run")
-        }
+        String output = executeBuild(buildTool, "test")
 
         then:
-        testOutputContains("Startup completed")
+        output.contains("BUILD SUCCESS")
 
         where:
         [lang, buildTool] << LanguageBuildCombinations.combinations()

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateMessagingSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateMessagingSpec.groovy
@@ -26,14 +26,10 @@ class CreateMessagingSpec extends CommandSpec {
         generateProject(lang, buildTool, [feature], applicationType)
 
         when:
-        if (buildTool == BuildTool.GRADLE) {
-            executeGradleCommand('run')
-        } else {
-            executeMavenCommand("mn:run")
-        }
+        String output = executeBuild(buildTool, "test")
 
         then:
-        testOutputContains("Startup completed")
+        output.contains("BUILD SUCCESS")
 
         where:
         [lang, buildTool, feature] << LanguageBuildCombinations.combinations([Kafka.NAME, RabbitMQ.NAME, Nats.NAME])

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/KtorSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/KtorSpec.groovy
@@ -11,26 +11,16 @@ import spock.util.concurrent.PollingConditions
 
 class KtorSpec extends CommandSpec {
 
-    @Override
-    PollingConditions getDefaultPollingConditions() {
-        new PollingConditions(timeout: 15)
-    }
-
-    @PendingFeature(reason = "micronaut-kotlin is not in maven central")
     @Unroll
     void 'create-app with feature ktor for #lang and #buildTool starts successfully'(Language lang, BuildTool buildTool) {
         given:
         generateProject(lang, buildTool, ['ktor'] as List<String>, ApplicationType.DEFAULT)
 
         when:
-        if (buildTool == BuildTool.GRADLE) {
-            executeGradleCommand('run')
-        } else {
-            executeMavenCommand("mn:run")
-        }
+        String output = executeBuild(buildTool, "test")
 
         then:
-        testOutputContains("Startup completed")
+        output.contains("BUILD SUCCESS")
 
         where:
         [lang, buildTool] << [[Language.KOTLIN], BuildToolCombinations.buildTools].combinations()

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -1,26 +1,7 @@
-configurations.all {
-    resolutionStrategy {
-        eachDependency { DependencyResolveDetails details ->
-            //multiple actions can be specified
-            if (details.requested.group == "org.codehaus.groovy") {
-                details.useVersion("2.5.11")
-            }
-            if (details.requested.name == "spock-core") {
-                details.useVersion("1.3-groovy-2.5")
-            }
-        }
-    }
-}
 dependencies {
     implementation("org.codehaus.groovy:groovy:$groovyVersion")
     implementation("org.spockframework:spock-core:$spockVersion") {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }
     implementation project(":starter-core")
-    implementation gradleTestKit()
-    implementation 'org.apache.maven:maven-embedder:3.0.5'
-    implementation 'org.sonatype.aether:aether-connector-wagon:1.13.1', {
-        exclude group:'org.apache.maven.wagon', module:'wagon-provider-api'
-    }
-    implementation 'org.apache.maven.wagon:wagon-http:2.5'
 }

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -1,7 +1,26 @@
+configurations.all {
+    resolutionStrategy {
+        eachDependency { DependencyResolveDetails details ->
+            //multiple actions can be specified
+            if (details.requested.group == "org.codehaus.groovy") {
+                details.useVersion("2.5.11")
+            }
+            if (details.requested.name == "spock-core") {
+                details.useVersion("1.3-groovy-2.5")
+            }
+        }
+    }
+}
 dependencies {
     implementation("org.codehaus.groovy:groovy:$groovyVersion")
     implementation("org.spockframework:spock-core:$spockVersion") {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }
     implementation project(":starter-core")
+    implementation gradleTestKit()
+    implementation 'org.apache.maven:maven-embedder:3.0.5'
+    implementation 'org.sonatype.aether:aether-connector-wagon:1.13.1', {
+        exclude group:'org.apache.maven.wagon', module:'wagon-provider-api'
+    }
+    implementation 'org.apache.maven.wagon:wagon-http:2.5'
 }

--- a/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
+++ b/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
@@ -12,15 +12,12 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.util.NameUtils
-import org.apache.maven.cli.MavenCli
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.util.environment.OperatingSystem
-
-import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.time.Duration
 
@@ -30,7 +27,6 @@ abstract class CommandSpec extends Specification {
     @AutoCleanup
     BeanContext beanContext = BeanContext.run()
     @Shared GradleRunner gradleRunner = GradleRunner.create()
-    @Shared MavenCli cli = new MavenCli()
 
     abstract String getTempDirectoryPrefix()
 
@@ -49,7 +45,7 @@ abstract class CommandSpec extends Specification {
         if (buildTool == BuildTool.GRADLE) {
             output = executeGradle(command).getOutput()
         } else if (buildTool == BuildTool.MAVEN) {
-            output = executeMavenEmbedded(command)
+            output = executeMaven(command)
         }
         return output
     }
@@ -60,14 +56,6 @@ abstract class CommandSpec extends Specification {
                         .withArguments(command.split(' '))
                         .build()
         return result
-    }
-
-    String executeMavenEmbedded(String command) {
-        System.setProperty("maven.multiModuleProjectDirectory", dir.absolutePath)
-        def bytesOut = new ByteArrayOutputStream()
-        PrintStream output = new PrintStream(bytesOut)
-        cli.doMain(command.split(' '), dir.absolutePath, output, output)
-        return new String(bytesOut.toByteArray(), StandardCharsets.UTF_8)
     }
 
     String executeMaven(String command) {

--- a/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
+++ b/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
@@ -73,7 +73,7 @@ abstract class CommandSpec extends Specification {
         StringBuilder output = new StringBuilder()
         def thread = process.consumeProcessOutputStream(output)
         try {
-            thread.join(Duration.ofSeconds(30).toMillis())
+            thread.join(Duration.ofSeconds(120).toMillis())
         } catch (InterruptedException e) {
         }
 

--- a/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
+++ b/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
@@ -18,11 +18,11 @@ import org.gradle.testkit.runner.GradleRunner
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
-import spock.util.concurrent.PollingConditions
 import spock.util.environment.OperatingSystem
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.time.Duration
 
 abstract class CommandSpec extends Specification {
 
@@ -35,22 +35,13 @@ abstract class CommandSpec extends Specification {
     abstract String getTempDirectoryPrefix()
 
     File dir
-    StringBuilder output
-    Process process
-
-    void setupSpec() {
-        Thread shutdownHook = new Thread({ killProcess() } as Runnable)
-        Runtime.runtime.addShutdownHook(shutdownHook)
-    }
 
     void setup() {
         dir = Files.createTempDirectory(tempDirectoryPrefix).toFile()
-        output = new StringBuilder()
     }
 
     void cleanup() {
         dir.delete()
-        killProcess()
     }
 
     String executeBuild(BuildTool buildTool, String command) {
@@ -58,7 +49,7 @@ abstract class CommandSpec extends Specification {
         if (buildTool == BuildTool.GRADLE) {
             output = executeGradle(command).getOutput()
         } else if (buildTool == BuildTool.MAVEN) {
-            output = executeMaven(command)
+            output = executeMavenEmbedded(command)
         }
         return output
     }
@@ -66,12 +57,12 @@ abstract class CommandSpec extends Specification {
     BuildResult executeGradle(String command) {
         BuildResult result =
                 gradleRunner.withProjectDir(dir)
-                        .withArguments(command)
+                        .withArguments(command.split(' '))
                         .build()
         return result
     }
 
-    String executeMaven(String command) {
+    String executeMavenEmbedded(String command) {
         System.setProperty("maven.multiModuleProjectDirectory", dir.absolutePath)
         def bytesOut = new ByteArrayOutputStream()
         PrintStream output = new PrintStream(bytesOut)
@@ -79,55 +70,29 @@ abstract class CommandSpec extends Specification {
         return new String(bytesOut.toByteArray(), StandardCharsets.UTF_8)
     }
 
-    void executeGradleCommand(String command) {
-        StringBuilder gradleCommand = new StringBuilder()
+    String executeMaven(String command) {
         if (OperatingSystem.current.isWindows()) {
-            gradleCommand.append("gradlew.bat")
+            command = "mvnw.bat " + command
         } else {
-            gradleCommand.append("./gradlew")
+            command = "./mvnw " + command
         }
-        gradleCommand.append(" --no-daemon ").append(command)
-        executeCommand(gradleCommand)
-    }
-
-    PollingConditions getDefaultPollingConditions() {
-        new PollingConditions(timeout: 180, initialDelay: 3, delay: 1, factor: 1)
-    }
-
-    void testOutputContains(String value) {
-        defaultPollingConditions.eventually {
-            assert output.toString().contains(value)
-        }
-    }
-
-    void executeMavenCommand(String command) {
-        StringBuilder mavenCommand = new StringBuilder()
-        if (OperatingSystem.current.isWindows()) {
-            mavenCommand.append("mvnw.bat")
-        } else {
-            mavenCommand.append("./mvnw")
-        }
-        mavenCommand.append(" ").append(command)
-        executeCommand(mavenCommand)
-    }
-
-    private void executeCommand(StringBuilder builder) {
-        String[] args = builder.toString().split(" ")
+        String[] args = command.split(" ")
         ProcessBuilder pb = new ProcessBuilder(args)
         Map<String, String> env = pb.environment()
         env["JAVA_HOME"] = System.getenv("JAVA_HOME")
-        process = pb.directory(dir).start()
-        process.consumeProcessOutputStream(output)
-    }
+        Process process = pb.directory(dir).start()
 
-    void killProcess() {
-        if (process) {
+        StringBuilder output = new StringBuilder()
+        def thread = process.consumeProcessOutputStream(output)
+        try {
+            thread.join(Duration.ofSeconds(30).toMillis())
+        } catch (InterruptedException e) {
+        }
+
+        try {
+            return output.toString()
+        } finally {
             process.destroy()
-            try {
-                process.waitForOrKill(1000)
-            } catch(e) {
-                process.destroyForcibly()
-            }
         }
     }
 


### PR DESCRIPTION
This change uses Gradle TestKit to speed up the Gradle integration tests and for Maven removes the output polling.

Note that the tests that called `run` have been changed to call `test` and a test is included when you create a project. The tests that called `run` were failing intermittently anyway since they ran on port 8080 which was frequently causing port binding failures on Github Actions.