### PR TITLE
Update Flyway group

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
-        run: ./gradlew check --continue -x test-core:test -x test-cli:test
+        run: ./gradlew check --refresh-dependencies --continue -x test-core:test -x test-cli:test
       - name: Verify CLI
         run: |
           ./gradlew micronaut-cli:assemble

--- a/starter-analytics-postgres/build.gradle
+++ b/starter-analytics-postgres/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'org.postgresql:postgresql:42.2.12'
     implementation 'com.google.cloud.sql:postgres-socket-factory:1.0.15'
     implementation "io.micronaut.configuration:micronaut-jdbc-hikari"
-    implementation 'io.micronaut.configuration:micronaut-flyway'
+    implementation 'io.micronaut.flyway:micronaut-flyway'
     testCompileOnly "io.micronaut:micronaut-inject-groovy"
     testImplementation "io.micronaut:micronaut-http-client"
     testImplementation "io.micronaut.test:micronaut-test-spock"

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -259,7 +259,7 @@ dependencies {
     @dependency.template("io.jaegertracing", "jaeger-thrift", "runtimeOnly", null)
 }
 @if (features.contains("flyway")) {
-    @dependency.template("io.micronaut.configuration", "micronaut-flyway", "implementation", null)
+    @dependency.template("io.micronaut.flyway", "micronaut-flyway", "implementation", null)
 }
 @if (features.contains("liquibase")) {
     @dependency.template("io.micronaut.configuration", "micronaut-liquibase", "implementation", null)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -234,7 +234,7 @@ List<Property> properties
 @dependency.template("io.jaegertracing", "jaeger-thrift", "runtime", null)
 }
 @if (features.contains("flyway")) {
-@dependency.template("io.micronaut.configuration", "micronaut-flyway", "compile", null)
+@dependency.template("io.micronaut.flyway", "micronaut-flyway", "compile", null)
 }
 @if (features.contains("liquibase")) {
 @dependency.template("io.micronaut.configuration", "micronaut-liquibase", "compile", null)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/FlywaySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/FlywaySpec.groovy
@@ -25,7 +25,7 @@ class FlywaySpec extends BeanContextSpec implements CommandOutputFixture {
         String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['flyway'])).render().toString()
 
         then:
-        template.contains('implementation("io.micronaut.configuration:micronaut-flyway")')
+        template.contains('implementation("io.micronaut.flyway:micronaut-flyway")')
     }
 
     void "test the dependency is added to the maven build"() {
@@ -35,7 +35,7 @@ class FlywaySpec extends BeanContextSpec implements CommandOutputFixture {
         then:
         template.contains("""
     <dependency>
-      <groupId>io.micronaut.configuration</groupId>
+      <groupId>io.micronaut.flyway</groupId>
       <artifactId>micronaut-flyway</artifactId>
       <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
The build on the branch keeps failing (https://github.com/micronaut-projects/micronaut-starter/runs/738000449#step:6:1828) with:

```
* What went wrong:
Execution failed for task ':starter-analytics-postgres:compileJava'.
> Could not resolve all files for configuration ':starter-analytics-postgres:compileClasspath'.
   > Could not find io.micronaut.flyway:micronaut-flyway:.
     Required by:
         project :starter-analytics-postgres
```

But I don't know why because in the latest BOM (http://oss.jfrog.org/oss-snapshot-local/io/micronaut/micronaut-bom/2.0.0.BUILD-SNAPSHOT/micronaut-bom-2.0.0.BUILD-20200604.061310-263.pom)

Everything seems properly updated to use the new coordinates:

```xml
    <micronaut.flyway.version>2.0.0.M1</micronaut.flyway.version>
    ...
    ...
      <dependency>
        <groupId>io.micronaut.flyway</groupId>
        <artifactId>micronaut-flyway</artifactId>
        <version>${micronaut.flyway.version}</version>
      </dependency>
```
