### PR TITLE
Use new MySql driver

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/MySQL.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/MySQL.java
@@ -49,7 +49,7 @@ public class MySQL extends DatabaseDriverFeature {
 
     @Override
     public String getDriverClass() {
-        return "com.mysql.jdbc.Driver";
+        return "com.mysql.cj.jdbc.Driver";
     }
 
     @Override


### PR DESCRIPTION
When using the old driver the following warning is displayed:

```
Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'
```