### PR TITLE
Temporarily use JUnit by default with Kotlin

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/picocli/test/junit/PicocliJunit.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/picocli/test/junit/PicocliJunit.java
@@ -23,6 +23,8 @@ import io.micronaut.starter.options.TestFramework;
 import io.micronaut.starter.template.RockerTemplate;
 
 import javax.inject.Singleton;
+import java.util.Arrays;
+import java.util.List;
 
 @Singleton
 public class PicocliJunit implements PicocliTestFeature {
@@ -43,8 +45,8 @@ public class PicocliJunit implements PicocliTestFeature {
     }
 
     @Override
-    public Language getDefaultLanguage() {
-        return Language.JAVA;
+    public List<Language> getDefaultLanguages() {
+        return Arrays.asList(Language.JAVA, Language.KOTLIN);
     }
 
     public RockerTemplate getTemplate(Language language, Project project) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/picocli/test/kotlintest/PicocliKotlinTest.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/picocli/test/kotlintest/PicocliKotlinTest.java
@@ -23,6 +23,8 @@ import io.micronaut.starter.options.TestFramework;
 import io.micronaut.starter.template.RockerTemplate;
 
 import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.List;
 
 @Singleton
 public class PicocliKotlinTest implements PicocliTestFeature {
@@ -43,8 +45,8 @@ public class PicocliKotlinTest implements PicocliTestFeature {
     }
 
     @Override
-    public Language getDefaultLanguage() {
-        return Language.KOTLIN;
+    public List<Language> getDefaultLanguages() {
+        return Collections.emptyList();
     }
 
     public RockerTemplate getTemplate(Project project) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/picocli/test/spock/PicocliSpock.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/picocli/test/spock/PicocliSpock.java
@@ -23,6 +23,8 @@ import io.micronaut.starter.options.TestFramework;
 import io.micronaut.starter.template.RockerTemplate;
 
 import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.List;
 
 @Singleton
 public class PicocliSpock implements PicocliTestFeature {
@@ -43,8 +45,8 @@ public class PicocliSpock implements PicocliTestFeature {
     }
 
     @Override
-    public Language getDefaultLanguage() {
-        return Language.GROOVY;
+    public List<Language> getDefaultLanguages() {
+        return Collections.singletonList(Language.GROOVY);
     }
 
     public RockerTemplate getTemplate(Project project) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/Junit.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/Junit.java
@@ -20,6 +20,8 @@ import io.micronaut.starter.options.Language;
 import io.micronaut.starter.options.TestFramework;
 
 import javax.inject.Singleton;
+import java.util.Arrays;
+import java.util.List;
 
 @Singleton
 public class Junit implements TestFeature {
@@ -40,8 +42,8 @@ public class Junit implements TestFeature {
     }
 
     @Override
-    public Language getDefaultLanguage() {
-        return Language.JAVA;
+    public List<Language> getDefaultLanguages() {
+        return Arrays.asList(Language.JAVA, Language.KOTLIN);
     }
 
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/KotlinTest.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/KotlinTest.java
@@ -21,6 +21,8 @@ import io.micronaut.starter.options.TestFramework;
 import io.micronaut.starter.template.URLTemplate;
 
 import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.List;
 
 @Singleton
 public class KotlinTest implements TestFeature {
@@ -44,8 +46,8 @@ public class KotlinTest implements TestFeature {
     }
 
     @Override
-    public Language getDefaultLanguage() {
-        return Language.KOTLIN;
+    public List<Language> getDefaultLanguages() {
+        return Collections.emptyList();
     }
 
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/Spock.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/Spock.java
@@ -20,7 +20,6 @@ import io.micronaut.starter.options.Language;
 import io.micronaut.starter.options.TestFramework;
 
 import javax.inject.Singleton;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/Spock.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/Spock.java
@@ -20,6 +20,9 @@ import io.micronaut.starter.options.Language;
 import io.micronaut.starter.options.TestFramework;
 
 import javax.inject.Singleton;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 @Singleton
 public class Spock implements TestFeature {
@@ -40,8 +43,8 @@ public class Spock implements TestFeature {
     }
 
     @Override
-    public Language getDefaultLanguage() {
-        return Language.GROOVY;
+    public List<Language> getDefaultLanguages() {
+        return Collections.singletonList(Language.GROOVY);
     }
 
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/TestFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/TestFeature.java
@@ -26,6 +26,7 @@ import io.micronaut.starter.options.Language;
 import io.micronaut.starter.options.Options;
 import io.micronaut.starter.options.TestFramework;
 
+import java.util.List;
 import java.util.Set;
 
 public interface TestFeature extends DefaultFeature {
@@ -54,7 +55,7 @@ public interface TestFeature extends DefaultFeature {
 
     TestFramework getTestFramework();
 
-    Language getDefaultLanguage();
+    List<Language> getDefaultLanguages();
 
     default boolean isJunit() {
         return getTestFramework() == TestFramework.JUNIT;
@@ -72,12 +73,8 @@ public interface TestFeature extends DefaultFeature {
     default boolean shouldApply(ApplicationType applicationType,
                                 Options options,
                                 Set<Feature> selectedFeatures) {
-        return supports(applicationType) &&
-                (
-                        options.getTestFramework() == getTestFramework() ||
-                        (options.getTestFramework() == null && options.getLanguage() == Language.KOTLIN && getTestFramework() == TestFramework.JUNIT) ||
-                        (options.getTestFramework() == null && options.getLanguage() != Language.KOTLIN && options.getLanguage() == getDefaultLanguage())
-                );
+        return supports(applicationType) && (options.getTestFramework() == getTestFramework() ||
+                (options.getTestFramework() == null && getDefaultLanguages().contains(options.getLanguage())));
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/TestFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/TestFeature.java
@@ -72,8 +72,12 @@ public interface TestFeature extends DefaultFeature {
     default boolean shouldApply(ApplicationType applicationType,
                                 Options options,
                                 Set<Feature> selectedFeatures) {
-        return supports(applicationType) && (options.getTestFramework() == getTestFramework() ||
-                (options.getTestFramework() == null && options.getLanguage() == getDefaultLanguage()));
+        return supports(applicationType) &&
+                (
+                        options.getTestFramework() == getTestFramework() ||
+                        (options.getTestFramework() == null && options.getLanguage() == Language.KOTLIN && getTestFramework() == TestFramework.JUNIT) ||
+                        (options.getTestFramework() == null && options.getLanguage() != Language.KOTLIN && options.getLanguage() == getDefaultLanguage())
+                );
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/FeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/FeatureSpec.groovy
@@ -36,16 +36,19 @@ class FeatureSpec extends BeanContextSpec {
     }
 
     @Unroll
-    void "test #feature does not add an unmodifiable map to config"(String feature) {
+    void "test #feature does not add an unmodifiable map to config"(Feature feature) {
         when:
-        Language lang = languageForFeature(feature)
-        JdkVersion javaVersion = javaVersionForFeature(feature)
-        Options options = new Options(lang, TestFramework.JUNIT, BuildTool.GRADLE, javaVersion)
+        JdkVersion javaVersion = javaVersionForFeature(feature.getName())
+        Language language = Language.JAVA
+        if (feature instanceof LanguageSpecificFeature) {
+            language = ((LanguageSpecificFeature) feature).getRequiredLanguage();
+        }
+        Options options = new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, javaVersion)
         def commandCtx = new GeneratorContext(buildProject(),
                                               ApplicationType.DEFAULT,
                                               options,
                                               OperatingSystem.LINUX,
-                                              getFeatures([feature], options).getFeatures()
+                                              getFeatures([feature.getName()], options).getFeatures()
         )
         commandCtx.applyFeatures()
 
@@ -65,18 +68,7 @@ class FeatureSpec extends BeanContextSpec {
         where:
         feature << beanContext.getBeansOfType(Feature).stream()
             .filter(f -> f.isVisible())
-            .map(f -> f.getName())
             .collect(Collectors.toList())
-    }
-
-    private Language languageForFeature(String feature) {
-        if (feature.endsWith('-gorm')) {
-            return Language.GROOVY
-        }
-        if (feature == 'ktor' || feature == 'kotlin-extension-functions' || feature == 'config4k') {
-            return Language.KOTLIN
-        }
-        Language.JAVA
     }
 
     private JdkVersion javaVersionForFeature(String feature) {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/picocli/PicocliSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/picocli/PicocliSpec.groovy
@@ -8,9 +8,14 @@ import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
+import spock.lang.Ignore
 
 class PicocliSpec extends BeanContextSpec {
 
+    @Ignore("""
+        We've switched to set automatically JUnit 5 for Kotlin projects if no test framework is selected.
+        Ignoring this test temporarily ignored until this is done https://github.com/micronaut-projects/micronaut-starter/issues/261
+""")
     void "test the test features are applied"() {
         when:
         Options options = new Options(Language.JAVA, null, BuildTool.GRADLE)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/picocli/PicocliSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/picocli/PicocliSpec.groovy
@@ -12,10 +12,6 @@ import spock.lang.Ignore
 
 class PicocliSpec extends BeanContextSpec {
 
-    @Ignore("""
-        We've switched to set automatically JUnit 5 for Kotlin projects if no test framework is selected.
-        Ignoring this test temporarily ignored until this is done https://github.com/micronaut-projects/micronaut-starter/issues/261
-""")
     void "test the test features are applied"() {
         when:
         Options options = new Options(Language.JAVA, null, BuildTool.GRADLE)
@@ -52,10 +48,10 @@ class PicocliSpec extends BeanContextSpec {
 
         then:
         features.contains("picocli")
-        features.contains("picocli-kotlintest")
-        features.contains("kotlintest")
-        generatorContext.getTemplates().containsKey("picocliKotlinTest")
-        !features.contains("picocli-junit")
+        features.contains("picocli-junit")
+        features.contains("junit")
+        generatorContext.getTemplates().containsKey("picocliJunitTest")
+        !features.contains("picocli-kotlintest")
         !features.contains("picocli-spock")
         !generatorContext.getTemplates().containsKey("testDir")
 


### PR DESCRIPTION
I've preferred to ignore one test instead of "fixing" it the wrong way, because this commit is only temporarily. Once we start working on #261 we need to revert this commit.