### PR TITLE
Fix Native Image issues for new ACME commands

### DIFF
--- a/starter-cli/build.gradle
+++ b/starter-cli/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     generateConfig "info.picocli:picocli-codegen:${picocliVersion}"
 
     testImplementation "org.testcontainers:spock:1.13.0"
+    testImplementation 'org.reflections:reflections:0.9.12'
 }
 
 mainClassName = "io.micronaut.starter.cli.MicronautStarter"

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/MicronautStarter.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/MicronautStarter.java
@@ -19,6 +19,7 @@ import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.inject.BeanDefinition;
+import io.micronaut.starter.cli.feature.acme.AcmeServerOption;
 import io.micronaut.starter.io.ConsoleOutput;
 import io.micronaut.starter.cli.command.*;
 import picocli.CommandLine;
@@ -57,6 +58,7 @@ import java.util.function.BiFunction;
     CommonOptionsMixin.class,
     TestFrameworkCandidates.class,
     TestFrameworkConverter.class,
+    AcmeServerOption.class
 })
 public class MicronautStarter extends BaseCommand implements Callable<Integer> {
 

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/feature/acme/AcmeServerOption.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/feature/acme/AcmeServerOption.java
@@ -39,6 +39,9 @@ public final class AcmeServerOption {
     @CommandLine.Option(names = {"--lets-encrypt-staging"}, required = true, description = "Use the Let's Encrypt staging URL")
     private boolean letsEncryptStaging;
 
+    public AcmeServerOption() {
+    }
+
     /**
      * Obtains the configured server url.
      *

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/feature/acme/AcmeServerOption.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/feature/acme/AcmeServerOption.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.starter.cli.feature.acme;
 
+import io.micronaut.core.annotation.ReflectiveAccess;
 import picocli.CommandLine;
 
 /**
@@ -26,12 +27,15 @@ public final class AcmeServerOption {
 
     public static final String LE_STAGING_URL = "https://acme-staging-v02.api.letsencrypt.org/directory";
 
+    @ReflectiveAccess
     @CommandLine.Option(names = {"-u", "--url"}, required = true, description = "URL of ACME server to use")
     private String serverUrl;
 
+    @ReflectiveAccess
     @CommandLine.Option(names = {"--lets-encrypt-prod"}, required = true, description = "Use the Let's Encrypt prod URL.")
     private boolean letsEncryptProd;
 
+    @ReflectiveAccess
     @CommandLine.Option(names = {"--lets-encrypt-staging"}, required = true, description = "Use the Let's Encrypt staging URL")
     private boolean letsEncryptStaging;
 

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/feature/acme/CreateAccount.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/feature/acme/CreateAccount.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.cli.feature.acme;
 
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.core.util.functional.ThrowingSupplier;
 import io.micronaut.starter.cli.CodeGenConfig;
 import io.micronaut.starter.io.ConsoleOutput;
@@ -39,9 +40,11 @@ import java.security.KeyPair;
 )
 @Prototype
 public final class CreateAccount extends CreateKeyPair {
+    @ReflectiveAccess
     @CommandLine.Option(names = {"-e", "--email"}, required = true, description = "Email address to create account with.")
     String email;
 
+    @ReflectiveAccess
     @CommandLine.ArgGroup(multiplicity = "1", heading = "ACME server URL%n")
     AcmeServerOption acmeServerOption;
 

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/feature/acme/CreateKeyPair.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/feature/acme/CreateKeyPair.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.cli.feature.acme;
 
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.core.util.functional.ThrowingSupplier;
 import io.micronaut.starter.cli.CodeGenConfig;
 import io.micronaut.starter.cli.command.CodeGenCommand;
@@ -44,12 +45,16 @@ import static picocli.CommandLine.Help.Visibility;
 )
 @Prototype
 public class CreateKeyPair extends CodeGenCommand {
+
+    @ReflectiveAccess
     @CommandLine.Option(names = {"-k", "--key-dir"}, showDefaultValue = Visibility.ALWAYS, defaultValue = "src/main/resources", description = "Custom location on disk to put the key to be used with this account.")
     String keyDir;
 
+    @ReflectiveAccess
     @CommandLine.Option(names = {"-n", "--key-name"}, required = true, description = "Name of the key to be created")
     String keyName;
 
+    @ReflectiveAccess
     @CommandLine.Option(names = {"-s", "--key-size"}, showDefaultValue = Visibility.ALWAYS, defaultValue = "4096", description = "Size of the key to be generated")
     int keySize;
 

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/feature/acme/DeactivateAccount.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/feature/acme/DeactivateAccount.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.cli.feature.acme;
 
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.core.util.functional.ThrowingSupplier;
 import io.micronaut.starter.cli.CodeGenConfig;
 import io.micronaut.starter.cli.command.CodeGenCommand;
@@ -44,12 +45,15 @@ import java.security.KeyPair;
 )
 @Prototype
 public final class DeactivateAccount extends CodeGenCommand {
+    @ReflectiveAccess
     @CommandLine.Option(names = {"-n", "--key-name"}, showDefaultValue = CommandLine.Help.Visibility.ALWAYS, description = "Name of the key to be used")
     String keyName;
 
+    @ReflectiveAccess
     @CommandLine.Option(names = {"-k", "--key-dir"}, showDefaultValue = CommandLine.Help.Visibility.ALWAYS, defaultValue = "src/main/resources", description = "Directory to find the key to be used for this account.")
     String keyDir;
 
+    @ReflectiveAccess
     @CommandLine.ArgGroup(multiplicity = "1", heading = "ACME server URL%n")
     AcmeServerOption acmeServerOption;
 

--- a/starter-cli/src/test/groovy/io/micronaut/starter/cli/ReflectiveValidatorSpec.groovy
+++ b/starter-cli/src/test/groovy/io/micronaut/starter/cli/ReflectiveValidatorSpec.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.starter.cli
+
+import io.micronaut.core.annotation.ReflectiveAccess
+import org.reflections.Reflections
+import org.reflections.scanners.FieldAnnotationsScanner
+import org.reflections.scanners.SubTypesScanner
+import org.reflections.scanners.TypeAnnotationsScanner
+import org.spockframework.util.Assert
+import picocli.CommandLine
+import spock.lang.Specification
+
+import java.lang.reflect.Field
+
+class ReflectiveValidatorSpec extends Specification{
+
+    void "validate all CommandLine Option are setup to be used with graalvm"(){
+        expect:
+        Reflections ref = new Reflections("io.micronaut.starter.cli",
+                new FieldAnnotationsScanner())
+
+        def fields = ref.getFieldsAnnotatedWith(CommandLine.Option)
+
+        for(Field field : fields){
+            def annotation = field.getAnnotation(ReflectiveAccess)
+            if(!annotation) {
+                Assert.fail("For options to work in graalvm you must add @ReflectiveAccess to all @CommandLine.Option fields. Class : %s, Field : %s", field.declaringClass.getSimpleName(), field.name)
+            }
+        }
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/acme/AcmeSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/acme/AcmeSpec.groovy
@@ -1,0 +1,63 @@
+package io.micronaut.starter.feature.acme
+
+import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.application.generator.GeneratorContext
+import io.micronaut.starter.feature.build.gradle.templates.buildGradle
+import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.Language
+import spock.lang.Unroll
+
+class AcmeSpec extends BeanContextSpec implements CommandOutputFixture {
+
+    void 'test readme.md with feature acme contains links to micronaut docs'() {
+        when:
+        def output = generate(['acme'])
+        def readme = output["README.md"]
+
+        then:
+        readme
+        readme.contains("https://micronaut-projects.github.io/micronaut-acme/latest/guide/index.html")
+    }
+
+    @Unroll
+    void 'test gradle acme feature for language=#language'() {
+        when:
+        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['acme'], language)).render().toString()
+
+        then:
+        template.contains('implementation "io.micronaut.acme:micronaut-acme')
+
+        where:
+        language << Language.values().toList()
+    }
+
+    @Unroll
+    void 'test maven acme feature for language=#language'() {
+        when:
+        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['acme'], language), []).render().toString()
+
+        then:
+        template.contains("""
+    <dependency>
+      <groupId>io.micronaut.acme</groupId>
+      <artifactId>micronaut-acme</artifactId>
+      <scope>compile</scope>
+    </dependency>
+""")
+
+        where:
+        language << Language.values().toList()
+    }
+
+    void 'test acme configuration'() {
+        when:
+        GeneratorContext commandContext = buildGeneratorContext(['acme'])
+
+        then:
+        commandContext.configuration.get('acme.enabled'.toString()) == 'true'
+        commandContext.configuration.get('acme.tos-agree'.toString()) == 'true'
+        commandContext.configuration.get('micronaut.server.ssl.enabled'.toString()) == 'true'
+    }
+}


### PR DESCRIPTION
I was missing 2 things 

1. @ReflectiveAccess on all the @CommandLine.Option so they just did not show up at all
2. The AcmeServerOption was not being picked up correctly so needed to add a constructor and add it to @TypeHint for graal to be happy with it. 

I also added a test to help catch future @ReflectiveAccess issues if they are not added in new commands.