### PR TITLE
Removed confusing JVM version information

### DIFF
--- a/starter-cli/src/main/java/io/micronaut/starter/cli/util/MicronautVersionProvider.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/util/MicronautVersionProvider.java
@@ -45,8 +45,7 @@ public class MicronautVersionProvider implements IVersionProvider {
 
     public String[] getVersion() {
         return new String[] {
-                "Micronaut Version: " + VersionInfo.getMicronautVersion(),
-                "JVM Version: " + System.getProperty("java.version")
+                "Micronaut Version: " + VersionInfo.getMicronautVersion()
         };
     }
 }


### PR DESCRIPTION
Starting from Micronaut 2.0, the `mn --version` started displaying the JVM version associated with the GraalVM versions used to compile the native image of the Micronaut CLI. Previously (1.3.x branch), the JVM version information was associated with the JVM version of the host that runs the `mn` command.

Fixes #293