### PR TITLE
Updates pom to add maven.compiler.release when Java version is not 1.8

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/Features.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/Features.java
@@ -80,6 +80,10 @@ public class Features extends ArrayList<String> {
         return featureList;
     }
 
+    public JdkVersion javaVersion() {
+        return javaVersion;
+    }
+
     public String getTargetJdk() {
         if (language().isJava() && testFramework().isJunit()) {
             return VersionInfo.toJdkVersion(javaVersion.majorVersion());

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -5,6 +5,7 @@
 @import io.micronaut.starter.feature.build.maven.templates.dependency
 @import io.micronaut.starter.build.Property
 @import io.micronaut.starter.application.ApplicationType
+@import io.micronaut.starter.options.JdkVersion
 
 @args (
 ApplicationType applicationType,
@@ -29,6 +30,14 @@ List<Property> properties
 
   <properties>
     <jdk.version>@features.getTargetJdk()</jdk.version>
+@if (features.javaVersion() == JdkVersion.JDK_8) {
+    <!-- If you are building with JDK 9 or higher, you can uncomment the lines below to set the release version -->
+    <!-- <release.version>@features.javaVersion().majorVersion()</release.version> -->
+    <!-- <maven.compiler.release>${release.version}</maven.compiler.release> -->
+} else {
+    <release.version>@features.javaVersion().majorVersion()</release.version>
+    <maven.compiler.release>${release.version}</maven.compiler.release>
+}
     <maven.compiler.target>${jdk.version}</maven.compiler.target>
     <maven.compiler.source>${jdk.version}</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This assumes that https://github.com/micronaut-projects/micronaut-core/pull/3704 (or something like it) has been merged to fix the parent pom.

I believe the combination of the changes in this branch and the ones in the PR above will bring the CI in starter back to green.

Closes #320 

