### PR TITLE
Generated Maven pom.xml use defaults from Micronaut parent pom

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -29,10 +29,6 @@ List<Property> properties
 
   <properties>
     <jdk.version>@features.getTargetJdk()</jdk.version>
-    <maven.compiler.target>${jdk.version}</maven.compiler.target>
-    <maven.compiler.source>${jdk.version}</maven.compiler.source>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 @for (Property prop : properties) {
 @if (prop.isComment()) {
     <!--@prop.getComment()-->
@@ -583,7 +579,6 @@ List<Property> properties
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-surefire-plugin.version}</version>
 @if (features.testFramework().isJunit() || features.testFramework().isSpock()) {
         <configuration>
           <detail>true</detail>
@@ -610,15 +605,6 @@ List<Property> properties
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${maven-failsafe-plugin.version}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 @if (features.contains("views-rocker")) {
       <plugin>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
@@ -6,9 +6,40 @@ import io.micronaut.starter.feature.Features
 import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.util.VersionInfo
 
 class MavenSpec extends BeanContextSpec {
 
+    void "test use defaults from parent pom"() {
+        when:
+        Features features = getFeatures([], null, null, BuildTool.MAVEN)
+        String template = pom.template(ApplicationType.DEFAULT, buildProject(), features, []).render().toString()
+
+        then:
+        template.contains("""
+  <parent>
+    <groupId>io.micronaut</groupId>
+    <artifactId>micronaut-parent</artifactId>
+    <version>${VersionInfo.micronautVersion}</version>
+  </parent>
+""")
+
+        // There are no Maven specific properties defined, all of them are inherited from parent pom.
+        !template.contains('<maven.compiler.target>')
+        !template.contains('<maven.compiler.source>')
+        !template.contains('<project.build.sourceEncoding>')
+        !template.contains('<project.reporting.outputEncoding>')
+
+        // Simple failsafe plugin declaration without any special configuration.
+        // The default configuration is inherited from parent pom.
+        template.contains("""
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+""")
+    }
+    
     void "test annotation processor dependencies"() {
         when:
         Features features = getFeatures([], null, null, BuildTool.MAVEN)


### PR DESCRIPTION
Whit this PR I try to use the defaults defined in the Micronaut parent pom (my previous PRs in micronaut-core project) so the generated poms by the starter are simpler and more "Maven compliant",