### PR TITLE
Generated Maven pom.xml use defaults from Micronaut parent pom

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -33,15 +33,9 @@ List<Property> properties
 @if (features.javaVersion() == JdkVersion.JDK_8) {
     <!-- If you are building with JDK 9 or higher, you can uncomment the lines below to set the release version -->
     <!-- <release.version>@features.javaVersion().majorVersion()</release.version> -->
-    <!-- <maven.compiler.release>${release.version}</maven.compiler.release> -->
 } else {
     <release.version>@features.javaVersion().majorVersion()</release.version>
-    <maven.compiler.release>${release.version}</maven.compiler.release>
 }
-    <maven.compiler.target>${jdk.version}</maven.compiler.target>
-    <maven.compiler.source>${jdk.version}</maven.compiler.source>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 @for (Property prop : properties) {
 @if (prop.isComment()) {
     <!--@prop.getComment()-->
@@ -592,7 +586,6 @@ List<Property> properties
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-surefire-plugin.version}</version>
 @if (features.testFramework().isJunit() || features.testFramework().isSpock()) {
         <configuration>
           <detail>true</detail>
@@ -619,15 +612,6 @@ List<Property> properties
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${maven-failsafe-plugin.version}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 @if (features.contains("views-rocker")) {
       <plugin>

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/TestFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/TestFeature.java
@@ -17,11 +17,9 @@ package io.micronaut.starter.feature.test;
 
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
-import io.micronaut.starter.build.BuildProperties;
 import io.micronaut.starter.feature.DefaultFeature;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeaturePhase;
-import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.Language;
 import io.micronaut.starter.options.Options;
 import io.micronaut.starter.options.TestFramework;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/TestFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/TestFeature.java
@@ -43,11 +43,6 @@ public interface TestFeature extends DefaultFeature {
 
     @Override
     default void apply(GeneratorContext generatorContext) {
-        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
-            BuildProperties props = generatorContext.getBuildProperties();
-            props.put("maven-surefire-plugin.version", "2.22.2");
-            props.put("maven-failsafe-plugin.version", "2.22.2");
-        }
         doApply(generatorContext);
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
@@ -6,8 +6,39 @@ import io.micronaut.starter.feature.Features
 import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.util.VersionInfo
 
 class MavenSpec extends BeanContextSpec {
+
+    void "test use defaults from parent pom"() {
+        when:
+        Features features = getFeatures([], null, null, BuildTool.MAVEN)
+        String template = pom.template(ApplicationType.DEFAULT, buildProject(), features, []).render().toString()
+
+        then:
+        template.contains("""
+  <parent>
+    <groupId>io.micronaut</groupId>
+    <artifactId>micronaut-parent</artifactId>
+    <version>${VersionInfo.micronautVersion}</version>
+  </parent>
+""")
+
+        // There are no Maven specific properties defined, all of them are inherited from parent pom.
+        !template.contains('<maven.compiler.target>')
+        !template.contains('<maven.compiler.source>')
+        !template.contains('<project.build.sourceEncoding>')
+        !template.contains('<project.reporting.outputEncoding>')
+
+        // Simple failsafe plugin declaration without any special configuration.
+        // The default configuration is inherited from parent pom.
+        template.contains("""
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+""")
+    }
 
     void "test annotation processor dependencies"() {
         when:


### PR DESCRIPTION
Whit this PR I try to use the defaults defined in the Micronaut parent pom (my previous PRs in micronaut-core project) so the generated poms by the starter are simpler and more "Maven compliant"