### PR TITLE
Use Maven with JUnit default tests names

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -583,32 +583,27 @@ List<Property> properties
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
 }
+@if (features.testFramework().isKotlinTest() || features.testFramework().isSpock()) {
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-@if (features.testFramework().isJunit() || features.testFramework().isSpock()) {
-        <configuration>
-          <detail>true</detail>
-          <includes>
-            <include>%regex[.*]</include>
-          </includes>
-        </configuration>
-} else if (features.testFramework().isKotlinTest()) {
         <configuration>
           <includes>
             <include>**/*Spec.*</include>
             <include>**/*Test.*</include>
           </includes>
         </configuration>
+@if (features.testFramework().isKotlinTest()) {
         <dependencies>
           <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.3.1</version>
+            <version>${junit5.version}</version>
           </dependency>
         </dependencies>
 }
       </plugin>
+}
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
@@ -2,20 +2,29 @@ package io.micronaut.starter.feature.build.maven
 
 import io.micronaut.starter.BeanContextSpec
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
 import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
 import io.micronaut.starter.util.VersionInfo
 
 class MavenSpec extends BeanContextSpec {
 
-    void "test use defaults from parent pom"() {
-        when:
-        Features features = getFeatures([], null, null, BuildTool.MAVEN)
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), features, []).render().toString()
+    void 'test use defaults from parent pom'() {
+        given:
+        GeneratorContext generatorContext = buildGeneratorContext([], new Options(null, null, BuildTool.MAVEN))
 
-        then:
+        when:
+        String template = pom.template(
+                generatorContext.getApplicationType(),
+                generatorContext.getProject(),
+                generatorContext.getFeatures(),
+                generatorContext.getBuildProperties().getProperties()
+        ).render().toString()
+
+        then: 'parent pom is used'
         template.contains("""
   <parent>
     <groupId>io.micronaut</groupId>
@@ -24,42 +33,46 @@ class MavenSpec extends BeanContextSpec {
   </parent>
 """)
 
-        // There are no Maven specific properties defined, all of them are inherited from parent pom.
+        then: 'there are no Maven specific properties defined, all of them are inherited from parent pom'
         !template.contains('<maven.compiler.target>')
         !template.contains('<maven.compiler.source>')
         !template.contains('<project.build.sourceEncoding>')
         !template.contains('<project.reporting.outputEncoding>')
+        !template.contains('<maven-surefire-plugin.version>')
+        !template.contains('<maven-failsafe-plugin.version>')
 
-        // Simple failsafe plugin declaration without any special configuration.
-        // The default configuration is inherited from parent pom.
-        template.contains("""
+        then: 'Surefire is inherited from parent pom so it should not appear in generated pom'
+        !template.contains('<artifactId>maven-surefire-plugin</artifactId>')
+
+        then: 'Failsafe is declared but without any specific configuration (configuration is inherited from parent pom)'
+        template.contains('''
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
-""")
+''')
     }
 
-    void "test annotation processor dependencies"() {
+    void 'test annotation processor dependencies'() {
         when:
         Features features = getFeatures([], null, null, BuildTool.MAVEN)
         String template = pom.template(ApplicationType.DEFAULT, buildProject(), features, []).render().toString()
 
         then:
-        template.contains("""
+        template.contains('''
           <annotationProcessorPaths>
             <path>
               <groupId>io.micronaut</groupId>
               <artifactId>micronaut-inject-java</artifactId>
-              <version>\${micronaut.version}</version>
+              <version>${micronaut.version}</version>
             </path>
             <path>
               <groupId>io.micronaut</groupId>
               <artifactId>micronaut-validation</artifactId>
-              <version>\${micronaut.version}</version>
+              <version>${micronaut.version}</version>
             </path>
           </annotationProcessorPaths>
-""")
+''')
 
         when:
         features = getFeatures([], Language.KOTLIN, null, BuildTool.MAVEN)
@@ -86,7 +99,7 @@ class MavenSpec extends BeanContextSpec {
         template = pom.template(ApplicationType.DEFAULT, buildProject(), features, []).render().toString()
 
         then:
-        template.contains("""
+        template.contains('''
     <dependency>
       <groupId>io.micronaut</groupId>
       <artifactId>micronaut-inject</artifactId>
@@ -97,7 +110,7 @@ class MavenSpec extends BeanContextSpec {
       <artifactId>micronaut-validation</artifactId>
       <scope>compile</scope>
     </dependency>
-""")
+''')
     }
 
 }


### PR DESCRIPTION
Right now there is a problem with the Maven pom.xml generated by the starter when you use JUnit. The problem is that Surefire (the Maven plugin that runs unit tests) is configured to include tests in any file `<include>%regex[.*]</include>`. **This cause that, in unit testing phase, Surefire tries to run also integration tests, and build fails.**

In Maven the expected default is that Surefire runs tests in files like:
  - **/Test*.java
  - **/*Test.java
  - **/*Tests.java
  - **/*TestCase.java
and Failsafe plugin runs integration tests in files like:
  - **/IT*.java
  - **/*IT.java
  - **/*ITCase.java

With this commit the Maven pom.xml is generated with the espected defaults and is only reconfigured if Spock or Kotest are used. And in wich case the espected Spock or Kotest default filenames are used.