### PR TITLE
Add .factorypath to .gitignore

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gitignore.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gitignore.rocker.raw
@@ -11,3 +11,4 @@ out/
 .project
 .settings
 .classpath
+.factorypath


### PR DESCRIPTION
This file was present in a new project I setup. From doing a Google search it appears to be related to Eclipse. All the other Eclipse files are ignored (`.project`, `.settings`, `.classpath`), so it'd make sense to ignore this one too.

This possibly came from the Gradle Buildship plugin that is suggested to be installed in "Configuring Eclipse IDE": https://docs.micronaut.io/latest/guide/index.html#ideSetup
