### PR TITLE
Add tests of Maven configuration for unit tests with Spock or KotlinTest

### DIFF
--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/KotlinTestSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/KotlinTestSpec.groovy
@@ -1,0 +1,41 @@
+package io.micronaut.starter.feature.test
+
+import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.Features
+import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.TestFramework
+
+class KotlinTestSpec extends BeanContextSpec {
+
+    void 'test maven configure unit tests'() {
+        given:
+        Features features = getFeatures([], null, TestFramework.KOTLINTEST, BuildTool.MAVEN)
+
+        when:
+        String template = pom.template(ApplicationType.DEFAULT, buildProject(), features, []).render().toString()
+
+        then:
+        template.contains('''
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*Spec.*</include>
+            <include>**/*Test.*</include>
+          </includes>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit5.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+''')
+
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/SpockSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/SpockSpec.groovy
@@ -1,0 +1,34 @@
+package io.micronaut.starter.feature.test
+
+import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.Features
+import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.TestFramework
+
+class SpockSpec extends BeanContextSpec {
+
+    void 'test maven configure unit tests'() {
+        given:
+        Features features = getFeatures([], null, TestFramework.SPOCK, BuildTool.MAVEN)
+
+        when:
+        String template = pom.template(ApplicationType.DEFAULT, buildProject(), features, []).render().toString()
+
+        then:
+        template.contains("""
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*Spec.*</include>
+            <include>**/*Test.*</include>
+          </includes>
+        </configuration>
+      </plugin>
+""")
+
+    }
+}


### PR DESCRIPTION
Add tests to check the generated pom.xml when you are using Spock or KotlinTest.

@alvarosanchez I think this is what your was looking for. Tell me If you want that I change something.