### PR TITLE
refactor: %s/isKotlinTest/isKotlinTestFramework

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/annotationProcessor.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/annotationProcessor.rocker.raw
@@ -6,7 +6,7 @@ String artifact
 )
 
 @if (features.language().isJava()) {
-@if (features.testFramework().isKotlinTest()) {
+@if (features.testFramework().isKotlinTestFramework()) {
     kapt(@artifact)
 } else {
     annotationProcessor(@artifact)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -18,7 +18,7 @@ plugins {
 @if (features.language().isJava()) {
     id "com.diffplug.eclipse.apt" version "3.22.0"
 }
-@if (features.language().isKotlin() || features.testFramework().isKotlinTest()) {
+@if (features.language().isKotlin() || features.testFramework().isKotlinTestFramework()) {
     id "org.jetbrains.kotlin.jvm" version "1.3.72"
     id "org.jetbrains.kotlin.kapt" version "1.3.72"
     id "org.jetbrains.kotlin.plugin.allopen" version "1.3.72"
@@ -564,7 +564,7 @@ tasks.withType(JavaCompile) {
     ])
 }
 }
-@if (features.language().isKotlin() || features.testFramework().isKotlinTest()) {
+@if (features.language().isKotlin() || features.testFramework().isKotlinTestFramework()) {
 allOpen {
     annotation("io.micronaut.aop.Around")
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/testFrameworks.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/testFrameworks.rocker.raw
@@ -35,7 +35,7 @@ TestFeature testFeature
     @dependency.template("org.junit.jupiter", "junit-jupiter-api", "testImplementation", null)
     @dependency.template("io.micronaut.test", "micronaut-test-junit5", "testImplementation", null)
     @dependency.template("org.junit.jupiter", "junit-jupiter-engine", "testRuntimeOnly", null)
-} else if (testFeature.isKotlinTest()) {
+} else if (testFeature.isKotlinTestFramework()) {
     @if (VersionInfo.getMicronautVersion().endsWith("-SNAPSHOT")) {
     kaptTest(enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion"))
     } else {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -510,7 +510,7 @@ List<Property> properties
 @dependency.template("org.junit.jupiter", "junit-jupiter-api", "test", null)
 @dependency.template("org.junit.jupiter", "junit-jupiter-engine", "test", null)
 @dependency.template("io.micronaut.test", "micronaut-test-junit5", "test", null)
-} else if (features.testFramework().isKotlinTest()) {
+} else if (features.testFramework().isKotlinTestFramework()) {
 @dependency.template("io.micronaut.test", "micronaut-test-kotlintest", "test", null)
 @dependency.template("io.mockk", "mockk", "test", "1.9.3")
 @dependency.template("io.kotlintest", "kotlintest-runner-junit5", "test", "3.3.2")
@@ -583,7 +583,7 @@ List<Property> properties
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
 }
-@if (features.testFramework().isKotlinTest() || features.testFramework().isSpock()) {
+@if (features.testFramework().isKotlinTestFramework() || features.testFramework().isSpock()) {
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -593,7 +593,7 @@ List<Property> properties
             <include>**/*Test.*</include>
           </includes>
         </configuration>
-@if (features.testFramework().isKotlinTest()) {
+@if (features.testFramework().isKotlinTestFramework()) {
         <dependencies>
           <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -988,7 +988,7 @@ List<Property> properties
               </sourceDirs>
             </configuration>
           </execution>
-@if (features.testFramework().isKotlinTest() || features.testFramework().isJunit()) {
+@if (features.testFramework().isKotlinTestFramework() || features.testFramework().isJunit()) {
           <execution>
             <id>test-kapt</id>
             <goals>

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/TestFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/TestFeature.java
@@ -58,7 +58,7 @@ public interface TestFeature extends DefaultFeature {
         return getTestFramework() == TestFramework.SPOCK;
     }
 
-    default boolean isKotlinTest() {
+    default boolean isKotlinTestFramework() {
         return getTestFramework() == TestFramework.KOTLINTEST;
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/TestFeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/TestFeatureSpec.groovy
@@ -1,0 +1,46 @@
+package io.micronaut.starter.feature.test
+
+import io.micronaut.starter.application.generator.GeneratorContext
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class TestFeatureSpec extends Specification {
+
+    @Unroll("for test framework: #testFramework isKotlinTestFramework return #expected")
+    void "isKotlinTestFramework returns true for test framework which require Kotlin dependencies"(TestFramework testFramework) {
+        given:
+        TestFeature feature = new TestFeature() {
+
+            @Override
+            void doApply(GeneratorContext generatorContext) {
+
+            }
+
+            @Override
+            TestFramework getTestFramework() {
+                return testFramework
+            }
+
+            @Override
+            List<Language> getDefaultLanguages() {
+                return null
+            }
+
+            @Override
+            String getName() {
+                return null
+            }
+        }
+        expect:
+        expected == feature.isKotlinTestFramework()
+
+        where:
+        expected | testFramework
+        false    | TestFramework.JUNIT
+        true     | TestFramework.KOTLINTEST
+        false    | TestFramework.SPOCK
+
+    }
+}


### PR DESCRIPTION
It allows for future Kotlin related test framework to be used in the method implementation of isKotlinTestFramework.

For example:

```java
default boolean isKotlinTestFramework() {
        return getTestFramework() == TestFramework.KOTLINTEST ||   getTestFramework() == TestFramework.KOTEST;
}
```