### PR TITLE
Add Dekorate support

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/annotationProcessors.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/annotationProcessors.rocker.raw
@@ -44,3 +44,24 @@ Features features
 @if (features.contains("security-annotations")) {
 @annotationProcessor.template(features, "\"io.micronaut.security:micronaut-security-annotations\"")
 }
+@if (features.contains("dekorate-kubernetes")) {
+@annotationProcessor.template(features, "\"io.dekorate:kubernetes-annotations:${dekorateVersion}\"")
+}
+@if (features.contains("dekorate-openshift")) {
+@annotationProcessor.template(features, "\"io.dekorate:openshift-annotations:${dekorateVersion}\"")
+}
+@if (features.contains("dekorate-knative")) {
+@annotationProcessor.template(features, "\"io.dekorate:knative-annotations:${dekorateVersion}\"")
+}
+@if (features.contains("dekorate-prometheus")) {
+@annotationProcessor.template(features, "\"io.dekorate:prometheus-annotations:${dekorateVersion}\"")
+}
+@if (features.contains("dekorate-jaeger")) {
+@annotationProcessor.template(features, "\"io.dekorate:jaeger-annotations:${dekorateVersion}\"")
+}
+@if (features.contains("dekorate-servicecatalog")) {
+@annotationProcessor.template(features, "\"io.dekorate:servicecatalog-annotations:${dekorateVersion}\"")
+}
+@if (features.contains("dekorate-halkyon")) {
+@annotationProcessor.template(features, "\"io.dekorate:halkyon-annotations:${dekorateVersion}\"")
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -440,6 +440,27 @@ dependencies {
 @if (features.contains("jmx")) {
     @dependency.template("io.micronaut.jmx", "micronaut-jmx", "implementation", null)
 }
+@if (features.contains("dekorate-kubernetes")) {
+    @dependency.template("io.dekorate", "kubernetes-annotations", "implementation", "${dekorateVersion}")
+}
+@if (features.contains("dekorate-openshift")) {
+    @dependency.template("io.dekorate", "openshift-annotations", "implementation", "${dekorateVersion}")
+}
+@if (features.contains("dekorate-knative")) {
+    @dependency.template("io.dekorate", "knative-annotations", "implementation", "${dekorateVersion}")
+}
+@if (features.contains("dekorate-prometheus")) {
+    @dependency.template("io.dekorate", "prometheus-annotations", "implementation", "${dekorateVersion}")
+}
+@if (features.contains("dekorate-jaeger")) {
+    @dependency.template("io.dekorate", "jaeger-annotations", "implementation", "${dekorateVersion}")
+}
+@if (features.contains("dekorate-servicecatalog")) {
+    @dependency.template("io.dekorate", "servicecatalog-annotations", "implementation", "${dekorateVersion}")
+}
+@if (features.contains("dekorate-halkyon")) {
+    @dependency.template("io.dekorate", "halkyon-annotations", "implementation", "${dekorateVersion}")
+}
 @if (features.contains("spring")) {
     @dependency.template("org.springframework.boot", "spring-boot-starter", "implementation", null)
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -444,6 +444,27 @@ List<Property> properties
 @if (features.contains("jmx")) {
 @dependency.template("io.micronaut.jmx", "micronaut-jmx", "compile", null)
 }
+@if (features.contains("dekorate-kubernetes")) {
+@dependency.template("io.dekorate", "kubernetes-annotations", "compile", "${dekorate.version}")
+}
+@if (features.contains("dekorate-openshift")) {
+@dependency.template("io.dekorate", "openshift-annotations", "compile", "${dekorate.version}")
+}
+@if (features.contains("dekorate-knative")) {
+@dependency.template("io.dekorate", "knative-annotations", "compile", "${dekorate.version}")
+}
+@if (features.contains("dekorate-servicecatalog")) {
+@dependency.template("io.dekorate", "servicecatalog-annotations", "compile", "${dekorate.version}")
+}
+@if (features.contains("dekorate-halkyon")) {
+@dependency.template("io.dekorate", "halkyon-annotations", "compile", "${dekorate.version}")
+}
+@if (features.contains("dekorate-prometheus")) {
+@dependency.template("io.dekorate", "prometheus-annotations", "compile", "${dekorate.version}")
+}
+@if (features.contains("dekorate-jaeger")) {
+@dependency.template("io.dekorate", "jaeger-annotations", "compile", "${dekorate.version}")
+}
 @if (features.contains("spring")) {
 @dependency.template("org.springframework.boot", "spring-boot-starter", "compile", null)
 @if (features.language().isGroovy()) {
@@ -801,6 +822,56 @@ List<Property> properties
               <version>${micronaut.security.version}</version>
             </path>
 }
+@if (features.contains("dekorate-kubernetes")) {
+            <path>
+              <groupId>io.dekorate</groupId>
+              <artifactId>kubernetes-annotations</artifactId>
+              <version>${dekorate.version}</version>
+            </path>
+}
+@if (features.contains("dekorate-openshift")) {
+            <path>
+              <groupId>io.dekorate</groupId>
+              <artifactId>openshift-annotations</artifactId>
+              <version>${dekorate.version}</version>
+            </path>
+}
+@if (features.contains("dekorate-knative")) {
+            <path>
+              <groupId>io.dekorate</groupId>
+              <artifactId>knative-annotations</artifactId>
+              <version>${dekorate.version}</version>
+            </path>
+}
+@if (features.contains("dekorate-servicecatalog")) {
+            <path>
+              <groupId>io.dekorate</groupId>
+              <artifactId>servicecatalog-annotations</artifactId>
+              <version>${dekorate.version}</version>
+            </path>
+}
+@if (features.contains("dekorate-jaeger")) {
+            <path>
+              <groupId>io.dekorate</groupId>
+              <artifactId>jaeger-annotations</artifactId>
+              <version>${dekorate.version}</version>
+            </path>
+}
+@if (features.contains("dekorate-prometheus")) {
+            <path>
+              <groupId>io.dekorate</groupId>
+              <artifactId>prometheus-annotations</artifactId>
+              <version>${dekorate.version}</version>
+            </path>
+}
+@if (features.contains("dekorate-halkyon")) {
+            <path>
+              <groupId>io.dekorate</groupId>
+              <artifactId>halkyon-annotations</artifactId>
+              <version>${dekorate.version}</version>
+            </path>
+}
+
           </annotationProcessorPaths>
           <compilerArgs>
             <arg>-Amicronaut.processing.group=@project.getPackageName()</arg>
@@ -975,6 +1046,55 @@ List<Property> properties
                   <groupId>io.micronaut.security</groupId>
                   <artifactId>micronaut-security-annotations</artifactId>
                   <version>${micronaut.security.version}</version>
+                </annotationProcessorPath>
+}
+@if (features.contains("dekorate-kubernetes")) {
+                <annotationProcessorPath>
+                  <groupId>io.dekorate</groupId>
+                  <artifactId>kubernetes-annotations</artifactId>
+                  <version>${dekorate.version}</version>
+                </annotationProcessorPath>
+}
+@if (features.contains("dekorate-openshift")) {
+                <annotationProcessorPath>
+                  <groupId>io.dekorate</groupId>
+                  <artifactId>openshift-annotations</artifactId>
+                  <version>${dekorate.version}</version>
+                </annotationProcessorPath>
+}
+@if (features.contains("dekorate-knative")) {
+                <annotationProcessorPath>
+                  <groupId>io.dekorate</groupId>
+                  <artifactId>knative-annotations</artifactId>
+                  <version>${dekorate.version}</version>
+                </annotationProcessorPath>
+}
+@if (features.contains("dekorate-servicecatalog")) {
+                <annotationProcessorPath>
+                  <groupId>io.dekorate</groupId>
+                  <artifactId>servicecatalog-annotations</artifactId>
+                  <version>${dekorate.version}</version>
+                </annotationProcessorPath>
+}
+@if (features.contains("dekorate-prometheus")) {
+                <annotationProcessorPath>
+                  <groupId>io.dekorate</groupId>
+                  <artifactId>prometheus-annotations</artifactId>
+                  <version>${dekorate.version}</version>
+                </annotationProcessorPath>
+}
+@if (features.contains("dekorate-jaeger")) {
+                <annotationProcessorPath>
+                  <groupId>io.dekorate</groupId>
+                  <artifactId>jaeger-annotations</artifactId>
+                  <version>${dekorate.version}</version>
+                </annotationProcessorPath>
+}
+@if (features.contains("dekorate-halkyon")) {
+                <annotationProcessorPath>
+                  <groupId>io.dekorate</groupId>
+                  <artifactId>halkyon-annotations</artifactId>
+                  <version>${dekorate.version}</version>
                 </annotationProcessorPath>
 }
               </annotationProcessorPaths>

--- a/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/AbstractDekorateFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/AbstractDekorateFeature.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.dekorate;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.feature.Category;
+import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.util.VersionInfo;
+
+/**
+ * Abstract implementation of Dekorate feature.
+ *
+ * @author Pavol Gressa
+ * @since 2.0
+ */
+public abstract class AbstractDekorateFeature implements Feature {
+
+    @Override
+    public String getCategory() {
+        return Category.CLOUD;
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return applicationType == ApplicationType.DEFAULT || applicationType == ApplicationType.GRPC;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        if (generatorContext.getBuildTool().equals(BuildTool.MAVEN)) {
+            generatorContext.getBuildProperties().put("dekorate.version", VersionInfo.getBomVersion("dekorate"));
+        } else {
+            generatorContext.getBuildProperties().put("dekorateVersion", VersionInfo.getBomVersion("dekorate"));
+        }
+    }
+
+    @Override
+    public boolean isPreview() {
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public String getMicronautDocumentation() {
+        return "https://micronaut-projects.github.io/micronaut-kubernetes/latest/guide/index.html";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/AbstractDekoratePlatformFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/AbstractDekoratePlatformFeature.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.dekorate;
+
+import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.other.Management;
+
+/**
+ * Abstract class for Dekorate platform features.
+ *
+ * @author Pavol Gressa
+ * @since 2.1
+ */
+public abstract class AbstractDekoratePlatformFeature extends AbstractDekorateFeature {
+
+    private final Management management;
+
+    public AbstractDekoratePlatformFeature(Management management) {
+        this.management = management;
+    }
+
+    @Override
+    public void processSelectedFeatures(FeatureContext featureContext) {
+        if (!featureContext.isPresent(Management.class)) {
+            featureContext.addFeature(management);
+        }
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/AbstractDekorateServiceFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/AbstractDekorateServiceFeature.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.dekorate;
+
+import io.micronaut.starter.feature.FeatureContext;
+
+/**
+ * Abstract class for all Dekorate features that requries to for proper functionality
+ * one of {@link AbstractDekoratePlatformFeature}
+ *
+ * @author Pavol Gressa
+ * @since 2.1
+ */
+public abstract class AbstractDekorateServiceFeature extends AbstractDekorateFeature {
+
+    private final DekorateKubernetes dekorateKubernetes;
+
+    public AbstractDekorateServiceFeature(DekorateKubernetes dekorateKubernetes) {
+        this.dekorateKubernetes = dekorateKubernetes;
+    }
+
+    @Override
+    public void processSelectedFeatures(FeatureContext featureContext) {
+        if (!featureContext.isPresent(AbstractDekoratePlatformFeature.class)) {
+            featureContext.addFeature(dekorateKubernetes);
+        }
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateFeatureValidator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.dekorate;
+
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.validation.FeatureValidator;
+import io.micronaut.starter.options.Language;
+import io.micronaut.starter.options.Options;
+
+import javax.inject.Singleton;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Dekorate feature validator.
+ *
+ * @author Pavol Gressa
+ * @since 2.1
+ */
+@Singleton
+public class DekorateFeatureValidator implements FeatureValidator {
+
+    private final List<AbstractDekoratePlatformFeature> dekoratePlatformFeatures;
+
+    public DekorateFeatureValidator(List<AbstractDekoratePlatformFeature> dekoratePlatformFeatures) {
+        this.dekoratePlatformFeatures = dekoratePlatformFeatures;
+    }
+
+    @Override
+    public void validatePreProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+    }
+
+    @Override
+    public void validatePostProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+        if (features.stream().anyMatch(f -> f instanceof AbstractDekorateFeature)) {
+            if (options.getLanguage() == Language.GROOVY) {
+                throw new IllegalArgumentException("Dekorate is not supported in Groovy applications");
+            }
+
+            if (features.stream().noneMatch(f -> f instanceof AbstractDekoratePlatformFeature)) {
+                throw new IllegalArgumentException(String.format("At least one of %s features must be selected in order to use Dekorate properly",
+                        dekoratePlatformFeatures.stream().map(Feature::getName).collect(Collectors.toList())));
+            }
+        }
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateHalkyon.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateHalkyon.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.dekorate;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import javax.inject.Singleton;
+
+/**
+ * Adds Dekorate Service Halkyon support.
+ *
+ * @author Pavol Gressa
+ * @since 2.1
+ */
+@Singleton
+public class DekorateHalkyon extends AbstractDekorateServiceFeature {
+
+    public DekorateHalkyon(DekorateKubernetes dekorateKubernetes) {
+        super(dekorateKubernetes);
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "dekorate-halkyon";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Dekorate Halkyon Support";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Extends Decorate's generated kubernetes deployment manifests with Halkyon resources " +
+                "using Dekorate Halkyon Support.";
+    }
+
+    @Nullable
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://github.com/dekorateio/dekorate#halkyon-crd";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateJaeger.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateJaeger.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.dekorate;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import javax.inject.Singleton;
+
+/**
+ * Adds Dekorate Jaeger support.
+ *
+ * @author Pavol Gressa
+ * @since 2.1
+ */
+@Singleton
+public class DekorateJaeger extends AbstractDekorateServiceFeature {
+
+    public DekorateJaeger(DekorateKubernetes dekorateKubernetes) {
+        super(dekorateKubernetes);
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "dekorate-jaeger";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Dekorate Jaeger Support";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Adds to Decorate deployment manifests Jaeger sidecar container.";
+    }
+
+    @Nullable
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://github.com/dekorateio/dekorate#jaeger-annotations";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateKnative.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateKnative.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.dekorate;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.starter.feature.other.Management;
+
+import javax.inject.Singleton;
+
+/**
+ * Adds Dekorate Knative support.
+ *
+ * @author Pavol Gressa
+ * @since 2.1
+ */
+@Singleton
+public class DekorateKnative extends AbstractDekoratePlatformFeature {
+
+    public DekorateKnative(Management management) {
+        super(management);
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "dekorate-knative";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Dekorate Knative Support";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Generates Knative kubernetes deployment manifest using Dekorate Knative Support.";
+    }
+
+    @Nullable
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://github.com/dekorateio/dekorate#knative";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateKubernetes.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateKubernetes.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.dekorate;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.starter.feature.other.Management;
+
+import javax.inject.Singleton;
+
+/**
+ * Adds Dekorate Kubernetes support.
+ *
+ * @author Pavol Gressa
+ * @since 2.1
+ */
+@Singleton
+public class DekorateKubernetes extends AbstractDekoratePlatformFeature {
+
+    public DekorateKubernetes(Management management) {
+        super(management);
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "dekorate-kubernetes";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Dekorate Kubernetes Support";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Generates Kubernetes deployment manifest using Dekorate Kubernetes Support.";
+    }
+
+    @Nullable
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://github.com/dekorateio/dekorate#kubernetes";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateOpenshift.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateOpenshift.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.dekorate;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.starter.feature.other.Management;
+
+import javax.inject.Singleton;
+
+/**
+ * Adds Dekorate Openshift support.
+ *
+ * @author Pavol Gressa
+ * @since 2.1
+ */
+@Singleton
+public class DekorateOpenshift extends AbstractDekoratePlatformFeature {
+
+    public DekorateOpenshift(Management management) {
+        super(management);
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "dekorate-openshift";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Dekorate Openshift Support";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Generates OpenShift deployment manifest using Dekorate OpenShift Support.";
+    }
+
+    @Nullable
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://github.com/dekorateio/dekorate#kubernetes";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekoratePrometheus.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekoratePrometheus.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.dekorate;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.micrometer.Prometheus;
+
+import javax.inject.Singleton;
+
+/**
+ * Adds Dekorate Prometheus support that generates ServiceMonitor resource.
+ *
+ * @author Pavol Gressa
+ * @since 2.1
+ */
+@Singleton
+public class DekoratePrometheus extends AbstractDekorateServiceFeature {
+
+    private final Prometheus prometheus;
+
+    public DekoratePrometheus(DekorateKubernetes dekorateKubernetes, Prometheus prometheus) {
+        super(dekorateKubernetes);
+        this.prometheus = prometheus;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "dekorate-prometheus";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Dekorate Prometheus Support";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Extends Decorate's generated kubernetes deployment manifests with Prometheus ServiceMonitor resource " +
+                "using Dekorate Prometheus Support.";
+    }
+
+    public void processSelectedFeatures(FeatureContext featureContext) {
+        super.processSelectedFeatures(featureContext);
+        if (!featureContext.isPresent(Prometheus.class)) {
+            featureContext.addFeature(prometheus);
+        }
+    }
+
+    @Nullable
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://github.com/dekorateio/dekorate#prometheus-annotations";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateServiceCatalog.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateServiceCatalog.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.dekorate;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import javax.inject.Singleton;
+
+/**
+ * Adds Dekorate Service Catalog support.
+ *
+ * @author Pavol Gressa
+ * @since 2.1
+ */
+@Singleton
+public class DekorateServiceCatalog extends AbstractDekorateServiceFeature {
+
+    public DekorateServiceCatalog(DekorateKubernetes dekorateKubernetes) {
+        super(dekorateKubernetes);
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "dekorate-servicecatalog";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Dekorate Service Catalog Support";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Extends Decorate's generated kubernetes deployment manifests with Service Catalog resources " +
+                "using Dekorate Service Catalog Support.";
+    }
+
+    @Nullable
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://github.com/dekorateio/dekorate#service-catalog";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/application.rocker.raw
@@ -1,5 +1,8 @@
 @import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Feature
 @import io.micronaut.starter.feature.Features
+@import io.micronaut.starter.feature.dekorate.AbstractDekoratePlatformFeature
+@import java.util.stream.Collectors
 
 @args (Project project, Features features)
 
@@ -11,6 +14,30 @@ import io.swagger.v3.oas.annotations.*;
 import io.swagger.v3.oas.annotations.info.*;
 }
 
+@if(features.getFeatures().stream().anyMatch(f -> f instanceof AbstractDekoratePlatformFeature)) {
+@if (features.contains("dekorate-kubernetes")) {
+import io.dekorate.kubernetes.annotation.KubernetesApplication;
+}
+@if (features.contains("dekorate-openshift")) {
+import io.dekorate.openshift.annotation.OpenshiftApplication;
+}
+@if (features.contains("dekorate-knative")) {
+import io.dekorate.knative.annotation.KnativeApplication;
+}
+import io.dekorate.kubernetes.annotation.Label;
+import io.dekorate.kubernetes.annotation.Port;
+import io.dekorate.kubernetes.annotation.Probe;
+}
+@if (features.contains("dekorate-prometheus")) {
+import io.dekorate.prometheus.annotation.EnableServiceMonitor;
+}
+@if (features.contains("dekorate-jeager")) {
+import io.dekorate.jaeger.annotation.EnableJaegerAgent;
+}
+@if (features.contains("dekorate-halkyon")) {
+import io.dekorate.halkyon.annotation.HalkyonComponent;
+}
+
 
 @if (features.contains("openapi")) {
 @@OpenAPIDefinition(
@@ -19,6 +46,33 @@ import io.swagger.v3.oas.annotations.info.*;
             version = "0.0"
     )
 )
+}
+
+@for(Feature feature : features.getFeatures().stream().filter(f -> f instanceof AbstractDekoratePlatformFeature).iterator()) {
+
+@if (feature.getName().equals("dekorate-kubernetes")) {
+@@KubernetesApplication(
+} else if (feature.getName().equals("dekorate-openshift")) {
+@@OpenshiftApplication(
+} else if (feature.getName().equals("dekorate-knative")) {
+@@KnativeApplication(
+}
+    name = "@project.getName()",
+    labels = @@Label(key = "app", value = "@project.getName()"),
+    ports = @@Port(name = "http", containerPort = 8080),
+    livenessProbe = @@Probe(httpActionPath = "/health/liveness", initialDelaySeconds = 5, timeoutSeconds = 3, failureThreshold = 10),
+    readinessProbe = @@Probe(httpActionPath = "/health/readiness", initialDelaySeconds = 5, timeoutSeconds = 3, failureThreshold = 10)
+)
+}
+
+@if (features.contains("dekorate-prometheus")) {
+@@EnableServiceMonitor(port = "http", path="/prometheus")
+}
+@if (features.contains("dekorate-jeager")) {
+@@EnableJaegerAgent
+}
+@if (features.contains("dekorate-halkyon")) {
+@@HalkyonComponent(name = "@project.getName()")
 }
 public class Application {
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/application.rocker.raw
@@ -1,11 +1,38 @@
 @import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Feature
 @import io.micronaut.starter.feature.Features
+@import io.micronaut.starter.feature.dekorate.AbstractDekoratePlatformFeature
+@import java.util.stream.Collectors
 
 @args (Project project, Features features)
 
 package @project.getPackageName()
 
 import io.micronaut.runtime.Micronaut.*
+@if(features.getFeatures().stream().anyMatch(f -> f instanceof AbstractDekoratePlatformFeature)) {
+@if (features.contains("dekorate-kubernetes")) {
+import io.dekorate.kubernetes.annotation.KubernetesApplication
+}
+@if (features.contains("dekorate-openshift")) {
+import io.dekorate.openshift.annotation.OpenshiftApplication
+}
+@if (features.contains("dekorate-knative")) {
+import io.dekorate.knative.annotation.KnativeApplication
+}
+import io.dekorate.kubernetes.annotation.Label
+import io.dekorate.kubernetes.annotation.Port
+import io.dekorate.kubernetes.annotation.Probe
+}
+@if (features.contains("dekorate-prometheus")) {
+import io.dekorate.prometheus.annotation.EnableServiceMonitor
+}
+@if (features.contains("dekorate-jeager")) {
+import io.dekorate.jaeger.annotation.EnableJaegerAgent
+}
+@if (features.contains("dekorate-halkyon")) {
+import io.dekorate.halkyon.annotation.HalkyonComponent
+}
+
 @if (features.contains("openapi")) {
 import io.swagger.v3.oas.annotations.*
 import io.swagger.v3.oas.annotations.info.*
@@ -20,6 +47,37 @@ object Api {
 }
 }
 
+@if (features.stream().anyMatch((s) -> s.startsWith("dekorate"))){
+@for(Feature feature : features.getFeatures().stream().filter(f -> f instanceof AbstractDekoratePlatformFeature).iterator()) {
+@if (feature.getName().equals("dekorate-kubernetes")) {
+@@KubernetesApplication(
+} else if (feature.getName().equals("dekorate-openshift")) {
+@@OpenshiftApplication(
+} else if (feature.getName().equals("dekorate-knative")) {
+@@KnativeApplication(
+}
+    name = "@project.getName()",
+    labels = [Label(key = "app", value = "@project.getName()")],
+    ports = [Port(name = "http", containerPort = 8080)],
+    livenessProbe = Probe(httpActionPath = "/health/liveness", initialDelaySeconds = 5, timeoutSeconds = 3, failureThreshold = 10),
+    readinessProbe = Probe(httpActionPath = "/health/readiness", initialDelaySeconds = 5, timeoutSeconds = 3, failureThreshold = 10)
+)
+}
+@if (features.contains("dekorate-prometheus")) {
+@@EnableServiceMonitor(port = "http", path="/prometheus")
+}
+@if (features.contains("dekorate-jeager")) {
+@@EnableJaegerAgent
+}
+@if (features.contains("dekorate-tekton")) {
+@@TektonApplication(name = "@project.getName()")
+}
+@if (features.contains("dekorate-halkyon")){
+@@HalkyonComponent(name = "@project.getName()")
+}
+object Dekorate {
+}
+}
 
 fun main(args: Array<String>) {
 	build()

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/dekorate/DekorateFeatureValidatorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/dekorate/DekorateFeatureValidatorSpec.groovy
@@ -1,0 +1,54 @@
+package io.micronaut.starter.feature.dekorate
+
+import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.Feature
+import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
+import spock.lang.Unroll
+
+class DekorateFeatureValidatorSpec extends BeanContextSpec implements CommandOutputFixture {
+
+    void 'test feature #feature.name is not supported for Groovy and #buildTool'(Feature feature, BuildTool buildTool){
+        when:
+        getFeatures([feature.getName()], Language.GROOVY, TestFramework.JUNIT, buildTool)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("Dekorate is not supported in Groovy applications")
+
+        where:
+        [feature, buildTool] << [
+                beanContext.getBeansOfType(AbstractDekorateFeature),
+                [BuildTool.MAVEN, BuildTool.GRADLE]].combinations()
+    }
+
+    void 'test feature #feature.name is supported for Kotlin and Maven'(Feature feature){
+        when:
+        getFeatures([feature.getName()], Language.KOTLIN, TestFramework.JUNIT, BuildTool.MAVEN)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        feature << beanContext.getBeansOfType(AbstractDekorateFeature)
+    }
+
+    @Unroll
+    void 'test dekorate service feature #feature.name uses default platform feature for #language'(
+            Feature feature, Language language) {
+        when:
+        pom.template(ApplicationType.DEFAULT, buildProject(),
+                getFeatures([feature.getName()], language, TestFramework.JUNIT, BuildTool.MAVEN), []).render().toString()
+
+        then:
+        beanContext.containsBean(DekorateKubernetes)
+
+        where:
+        [feature, language] << [beanContext.getBeansOfType(AbstractDekorateServiceFeature),
+                                [Language.JAVA, Language.KOTLIN]].combinations()
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/dekorate/DekorateSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/dekorate/DekorateSpec.groovy
@@ -1,0 +1,83 @@
+package io.micronaut.starter.feature.dekorate
+
+import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.Feature
+import io.micronaut.starter.feature.build.gradle.templates.buildGradle
+import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
+import spock.lang.Unroll
+
+class DekorateSpec extends BeanContextSpec implements CommandOutputFixture {
+
+    void 'test readme.md with feature dekorate-kubernetes contains links to micronaut docs'() {
+        when:
+        def output = generate(['dekorate-kubernetes'])
+        def readme = output["README.md"]
+
+        then:
+        readme
+        readme.contains("https://micronaut-projects.github.io/micronaut-kubernetes/latest/guide/index.html")
+    }
+
+    @Unroll
+    void 'test gradle dekorate #feature.name feature with for #language' (Feature feature, Language language) {
+        when:
+        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures([feature.getName()], language)).render().toString()
+        String service = feature.getName().replaceFirst("dekorate-", "")
+
+        then:
+        if(language == Language.JAVA) {
+            assert template.contains(String.format('annotationProcessor("io.dekorate:%s-annotations:${dekorateVersion}")', service))
+        }
+        template.contains(String.format('implementation("io.dekorate:%s-annotations:${dekorateVersion}")', service))
+        template.contains('implementation("io.micronaut:micronaut-management")')
+
+        where:
+        [feature, language] << [
+                beanContext.getBeansOfType(AbstractDekorateFeature),
+                Language.JAVA, Language.KOTLIN].combinations()
+    }
+
+    @Unroll
+    void 'test maven dekorate #feature.name for #language' (Feature feature, Language language) {
+        when:
+        String template = pom.template(ApplicationType.DEFAULT, buildProject(),
+                getFeatures([feature.getName()], language, TestFramework.JUNIT, BuildTool.MAVEN), []).render().toString()
+        String service = feature.getName().replaceFirst("dekorate-", "")
+
+        then:
+        template.contains(String.format("""
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>%s-annotations</artifactId>
+      <version>\${dekorate.version}</version>
+      <scope>compile</scope>
+    </dependency>""", service))
+
+        if (language == Language.KOTLIN) {
+            assert template.contains(String.format("""
+                <annotationProcessorPath>
+                  <groupId>io.dekorate</groupId>
+                  <artifactId>%s-annotations</artifactId>
+                  <version>\${dekorate.version}</version>
+                </annotationProcessorPath>""", service))
+        } else {
+            assert template.contains(String.format("""
+            <path>
+              <groupId>io.dekorate</groupId>
+              <artifactId>%s-annotations</artifactId>
+              <version>\${dekorate.version}</version>
+            </path>""", service))
+        }
+
+
+        where:
+        [feature, language] << [
+                beanContext.getBeansOfType(AbstractDekorateFeature),
+                [Language.JAVA, Language.KOTLIN]].combinations()
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/lang/JavaApplicationSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/lang/JavaApplicationSpec.groovy
@@ -2,6 +2,9 @@ package io.micronaut.starter.feature.lang
 
 import io.micronaut.context.BeanContext
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.Feature
+import io.micronaut.starter.feature.dekorate.AbstractDekorateFeature
+import io.micronaut.starter.feature.dekorate.AbstractDekoratePlatformFeature
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.fixture.ContextFixture
 import io.micronaut.starter.feature.lang.java.application
@@ -14,6 +17,7 @@ import io.micronaut.starter.util.VersionInfo
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class JavaApplicationSpec extends Specification implements ProjectFixture, ContextFixture, CommandOutputFixture {
 
@@ -84,6 +88,37 @@ import io.swagger.v3.oas.annotations.info.*;
             title = "foo",
             version = "0.0"
     )
+)
+public class Application {
+
+    public static void main(String[] args) {
+        Micronaut.run(Application.class, args);
+    }
+}
+""".trim())
+    }
+
+    void "test java application with dekorate-kubernetes"() {
+        String applicationJava = application.template(buildProject(), getFeatures(["dekorate-kubernetes"]))
+                .render()
+                .toString()
+
+        expect:
+        applicationJava.contains("""
+package example.micronaut;
+
+import io.micronaut.runtime.Micronaut;
+import io.dekorate.kubernetes.annotation.KubernetesApplication;
+import io.dekorate.kubernetes.annotation.Label;
+import io.dekorate.kubernetes.annotation.Port;
+import io.dekorate.kubernetes.annotation.Probe;
+
+@KubernetesApplication(
+    name = "foo",
+    labels = @Label(key = "app", value = "foo"),
+    ports = @Port(name = "http", containerPort = 8080),
+    livenessProbe = @Probe(httpActionPath = "/health/liveness", initialDelaySeconds = 5, timeoutSeconds = 3, failureThreshold = 10),
+    readinessProbe = @Probe(httpActionPath = "/health/readiness", initialDelaySeconds = 5, timeoutSeconds = 3, failureThreshold = 10)
 )
 public class Application {
 

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/feature/dekorate/DekorateSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/feature/dekorate/DekorateSpec.groovy
@@ -1,0 +1,104 @@
+package io.micronaut.starter.core.test.feature.dekorate
+
+import io.micronaut.starter.feature.Feature
+import io.micronaut.starter.feature.dekorate.AbstractDekorateFeature
+import io.micronaut.starter.feature.dekorate.AbstractDekorateServiceFeature
+import io.micronaut.starter.feature.dekorate.AbstractDekoratePlatformFeature
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.test.BuildToolCombinations
+import io.micronaut.starter.test.CommandSpec
+import spock.lang.Unroll
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class DekorateSpec extends CommandSpec {
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "dekorate"
+    }
+
+    @Unroll
+    void "test maven dekorate platform #feature.name with #language"(Feature feature, Language language) {
+        when:
+        generateProject(language, BuildTool.MAVEN, [feature.getName()])
+        String output =  executeMaven("compile")
+        String manifestName = feature.getName().replaceFirst("dekorate-", "")
+
+        then:
+        output?.contains("BUILD SUCCESS")
+        Files.exists(Paths.get(dir.getPath(),"target/classes", String.format("META-INF/dekorate/%s.json", manifestName)))
+        Files.exists(Paths.get(dir.getPath(),"target/classes", String.format("META-INF/dekorate/%s.json", manifestName)))
+
+        where:
+        [feature, language] << [
+                beanContext.getBeansOfType(AbstractDekoratePlatformFeature),
+                [Language.JAVA, Language.KOTLIN]].combinations()
+    }
+
+
+    @Unroll
+    void "test maven dekorate service #feature.name with #language on default platform"(Feature feature, Language language) {
+        when:
+        generateProject(language, BuildTool.MAVEN, [feature.getName()])
+        String output =  executeMaven("compile")
+        String manifestName = feature.getName().replaceFirst("dekorate-", "")
+
+        then:
+        output?.contains("BUILD SUCCESS")
+        Files.exists(Paths.get(dir.getPath(),"target/classes", "META-INF/dekorate/kubernetes.json"))
+        Files.exists(Paths.get(dir.getPath(),"target/classes", "META-INF/dekorate/kubernetes.json"))
+
+        where:
+        [feature, language] << [
+                beanContext.getBeansOfType(AbstractDekorateServiceFeature),
+                [Language.JAVA, Language.KOTLIN]].combinations()
+    }
+
+    @Unroll
+    void "test gradle dekorate platform #feature.name with #language"(Feature feature, Language language) {
+        when:
+        generateProject(language, BuildTool.GRADLE, [feature.getName()])
+        String output =  executeGradle("compileJava")?.output
+        String manifestName = feature.getName().replaceFirst("dekorate-", "")
+
+        then:
+        output?.contains("BUILD SUCCESS")
+        if(language == Language.KOTLIN){
+            assert Files.exists(Paths.get(dir.getPath(),"build/tmp/kapt3/classes/main", String.format("META-INF/dekorate/%s.json", manifestName)))
+            assert Files.exists(Paths.get(dir.getPath(),"build/tmp/kapt3/classes/main", String.format("META-INF/dekorate/%s.json", manifestName)))
+        }else{
+            assert Files.exists(Paths.get(dir.getPath(),"build/classes/java/main", String.format("META-INF/dekorate/%s.json", manifestName)))
+            assert Files.exists(Paths.get(dir.getPath(),"build/classes/java/main", String.format("META-INF/dekorate/%s.json", manifestName)))
+        }
+
+        where:
+        [feature, language] << [
+                beanContext.getBeansOfType(AbstractDekoratePlatformFeature),
+                [Language.JAVA, Language.KOTLIN]].combinations()
+    }
+
+    @Unroll
+    void "test gradle dekorate service #feature.name with #language on default platform"(Feature feature, Language language) {
+        when:
+        generateProject(language, BuildTool.GRADLE, [feature.getName()])
+        String output =  executeGradle("compileJava")?.output
+
+        then:
+        output?.contains("BUILD SUCCESS")
+        if (language == Language.KOTLIN) {
+            assert Files.exists(Paths.get(dir.getPath(), "build/tmp/kapt3/classes/main", "META-INF/dekorate/kubernetes.json"))
+            assert Files.exists(Paths.get(dir.getPath(), "build/tmp/kapt3/classes/main", "META-INF/dekorate/kubernetes.json"))
+        } else {
+            assert Files.exists(Paths.get(dir.getPath(), "build/classes/java/main", "META-INF/dekorate/kubernetes.json"))
+            assert Files.exists(Paths.get(dir.getPath(), "build/classes/java/main", "META-INF/dekorate/kubernetes.json"))
+        }
+
+        where:
+        [feature, language] << [
+                beanContext.getBeansOfType(AbstractDekorateServiceFeature),
+                [Language.JAVA, Language.KOTLIN]].combinations()
+    }
+}


### PR DESCRIPTION
[Dekorate](https://github.com/dekorateio/dekorate) in latests stable version [1.0.1](https://github.com/dekorateio/dekorate/tree/1.0.1) covers in this MR:

- Kubernetes
- OpenShift
- Knative
- Prometheus
- Jaeger
- Service Catalog
- Halkyon CRD

Left to do:
- [ ] review documentation hints
- [x] move dekorate version to bom https://github.com/micronaut-projects/micronaut-core/blob/2.1.x/build.gradle#L92
- [x] dekorate now supports only Kotlin and Java, Groovy is not supported
- [x] dekorate does not support Kotlin + Gradle https://github.com/dekorateio/dekorate/issues/632