### PR TITLE
Upgrade to Kotlin 1.4.10 and Kotest 4.2.5

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -20,9 +20,9 @@ plugins {
 }
 
 @if (features.language().isKotlin() || features.testFramework().isKotlinTestFramework()) {
-    id "org.jetbrains.kotlin.jvm" version "1.3.72"
-    id "org.jetbrains.kotlin.kapt" version "1.3.72"
-    id "org.jetbrains.kotlin.plugin.allopen" version "1.3.72"
+    id "org.jetbrains.kotlin.jvm" version "1.4.10"
+    id "org.jetbrains.kotlin.kapt" version "1.4.10"
+    id "org.jetbrains.kotlin.plugin.allopen" version "1.4.10"
 }
 @if (features.language().isGroovy() || features.testFramework().isSpock()) {
     id "groovy"

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/testFrameworks.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/testFrameworks.rocker.raw
@@ -53,8 +53,8 @@ TestFeature testFeature
     @dependency.template("io.mockk", "mockk", "testImplementation", "1.9.3")
 @if (testFeature.isKoTest()) {
     @dependency.template("io.micronaut.test", "micronaut-test-kotest", "testImplementation", null)
-    @dependency.template("io.kotest", "kotest-runner-junit5-jvm", "testImplementation", "4.1.3")
-    @dependency.template("io.kotest", "kotest-assertions-core-jvm", "testImplementation", "4.1.3")
+    @dependency.template("io.kotest", "kotest-runner-junit5-jvm", "testImplementation", "4.2.5")
+    @dependency.template("io.kotest", "kotest-assertions-core-jvm", "testImplementation", "4.2.5")
 }
 
 } else if (testFeature.isSpock()) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -514,8 +514,8 @@ List<Property> properties
 @dependency.template("io.mockk", "mockk", "test", "1.9.3")
 @if (features.testFramework().isKoTest()) {
 @dependency.template("io.micronaut.test", "micronaut-test-kotest", "test", null)
-@dependency.template("io.kotest", "kotest-runner-junit5-jvm", "test", "4.1.3")
-@dependency.template("io.kotest", "kotest-assertions-core-jvm", "test", "4.1.3")
+@dependency.template("io.kotest", "kotest-runner-junit5-jvm", "test", "4.2.5")
+@dependency.template("io.kotest", "kotest-assertions-core-jvm", "test", "4.2.5")
 }
 } else if (features.testFramework().isSpock()) {
 @if (!features.language().isGroovy()) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/Kotlin.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/Kotlin.java
@@ -54,7 +54,7 @@ public class Kotlin implements LanguageFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.getBuildProperties().put("kotlinVersion", "1.3.72");
+        generatorContext.getBuildProperties().put("kotlinVersion", "1.4.10");
     }
 
     @Override


### PR DESCRIPTION
### This prevents the build finish ok in `master` branch

---

Upgrade Kotlin and Kotest. Without these upgrades this test https://github.com/micronaut-projects/micronaut-starter/blob/41c07061aed0d3b7b69e8d0ae596e8558e40e429/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateTestSpec.groovy fails for Gradle, Kotlin and Kotest and it doesn't even find and run the test:

```
Caused by: java.lang.NoSuchMethodError: kotlin.time.TimeMark.elapsedNow()D
	at io.kotest.core.engine.discovery.Discovery.loadSelectedSpecs(Discovery.kt:172)
	at io.kotest.core.engine.discovery.Discovery.discover(Discovery.kt:55)
	at io.kotest.runner.junit.platform.KotestJunitPlatformTestEngine.discover(KotestJunitPlatformTestEngine.kt:72)
	at io.kotest.runner.junit.platform.KotestJunitPlatformTestEngine.discover(KotestJunitPlatformTestEngine.kt:23)
	at org.junit.platform.launcher.core.DefaultLauncher.discoverEngineRoot(DefaultLauncher.java:181)
	... 31 more
```

After the update the test run and it fails with:

```
java.lang.AbstractMethodError
	at io.kotest.core.spec.LifecycleKt.invokeAllBeforeTestCallbacks(lifecycle.kt:72)
	at io.kotest.core.internal.TestCaseExecutor.executeActiveTest(TestCaseExecutor.kt:129)
	at io.kotest.core.internal.TestCaseExecutor$intercept$2.invokeSuspend(TestCaseExecutor.kt:80)
	at io.kotest.core.internal.TestCaseExecutor$intercept$2.invoke(TestCaseExecutor.kt)
	at io.kotest.core.internal.TestCaseExecutor.executeIfActive(TestCaseExecutor.kt:94)
	at io.kotest.core.internal.TestCaseExecutor.intercept(TestCaseExecutor.kt:80)
	at io.kotest.core.internal.TestCaseExecutor$intercept$3.invokeSuspend(TestCaseExecutor.kt:81)
	at io.kotest.core.internal.TestCaseExecutor$intercept$3.invoke(TestCaseExecutor.kt)
	at io.micronaut.test.extensions.kotest.MicronautKotestExtension.intercept(MicronautKotestExtension.kt:41)
	at io.kotest.core.internal.TestCaseExecutor.intercept(TestCaseExecutor.kt:81)
	at io.kotest.core.internal.TestCaseExecutor.execute(TestCaseExecutor.kt:61)
	at io.kotest.engine.runners.SingleInstanceSpecRunner.runTest(SingleInstanceSpecRunner.kt:73)
	at io.kotest.engine.runners.SingleInstanceSpecRunner$execute$2$invokeSuspend$$inlined$invoke$lambda$1.invokeSuspend(SingleInstanceSpecRunner.kt:83)
	at io.kotest.engine.runners.SingleInstanceSpecRunner$execute$2$invokeSuspend$$inlined$invoke$lambda$1.invoke(SingleInstanceSpecRunner.kt)
	at io.kotest.engine.spec.SpecRunner$runParallel$$inlined$map$lambda$2$1.invokeSuspend(SpecRunner.kt:80)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:84)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at io.kotest.engine.spec.SpecRunner$runParallel$$inlined$map$lambda$2.run(SpecRunner.kt:79)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

