### PR TITLE
fix: resource-config.json pattern kotest not kotlintest

### DIFF
--- a/starter-core/src/main/resources/META-INF/native-image/io.micronaut.starter/micronaut-starter-core/resource-config.json
+++ b/starter-core/src/main/resources/META-INF/native-image/io.micronaut.starter/micronaut-starter-core/resource-config.json
@@ -3,7 +3,7 @@
     {"pattern":"gradle/.*$"},
     {"pattern":"functions/.*$"},
     {"pattern":"maven/.*$"},
-    {"pattern":"kotlintest/.*$"},
+    {"pattern":"kotest/.*$"},
     {"pattern":".gitkeep"},
     {"pattern":"springloaded/.*$"},
     {"pattern":"\\Qmicronaut-versions.properties\\E"}


### PR DESCRIPTION
See: https://github.com/micronaut-projects/micronaut-starter/issues/467

I think the problem is that I missed the update in `resource-config.json`

to include this file: https://github.com/micronaut-projects/micronaut-starter/blob/2.0.x/starter-core/src/main/resources/kotest/ProjectConfig.kt