### PR TITLE
Allow use any JDK version to create app from the CLI

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/options/JdkVersion.java
+++ b/starter-core/src/main/java/io/micronaut/starter/options/JdkVersion.java
@@ -16,6 +16,7 @@
 package io.micronaut.starter.options;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -25,41 +26,33 @@ import java.util.stream.Collectors;
  * @since 1.0.0
  */
 public enum JdkVersion {
-    JDK_8(8, true),
-    JDK_9(9, false),
-    JDK_10(10, false),
-    JDK_11(11, true),
-    JDK_12(12, false),
-    JDK_13(13, false),
-    JDK_14(14, false),
-    JDK_15(15, true);
+    JDK_8(8),
+    JDK_9(9),
+    JDK_10(10),
+    JDK_11(11),
+    JDK_12(12),
+    JDK_13(13),
+    JDK_14(14),
+    JDK_15(15);
+
+    private static final List<Integer> SUPPORTED_JDKS = Arrays.stream(JdkVersion.values()).map(JdkVersion::majorVersion).collect(Collectors.toList());
 
     private final int majorVersion;
-    private final boolean hasSupport;
 
-    JdkVersion(int majorVersion, boolean hasSupport) {
+    JdkVersion(int majorVersion) {
         this.majorVersion = majorVersion;
-        this.hasSupport = hasSupport;
     }
 
     public static JdkVersion valueOf(int majorVersion) {
-        switch (majorVersion) {
-            case 8:
-                return JDK_8;
-            case 11:
-                return JDK_11;
-            case 15:
-                return JDK_15;
-            default:
-                throw new IllegalArgumentException("Unsupported JDK version: " + majorVersion + ". Supported values are " + Arrays.stream(JdkVersion.values()).map(JdkVersion::majorVersion).collect(Collectors.toList()));
-        }
+        return Arrays
+                .stream(JdkVersion.values())
+                .filter(jdkVersion -> jdkVersion.majorVersion == majorVersion)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported JDK version: " + majorVersion + ". Supported values are " + SUPPORTED_JDKS));
     }
 
     public int majorVersion() {
         return majorVersion;
     }
 
-    public boolean hasSupport() {
-        return hasSupport;
-    }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/options/JdkVersionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/options/JdkVersionSpec.groovy
@@ -4,10 +4,12 @@ import spock.lang.Specification
 
 class JdkVersionSpec extends Specification {
 
-    void "test valueOf error"() {
+    void 'test valueOf with a supported JDK version'() {
         expect:
-        JdkVersion.JDK_11 == JdkVersion.valueOf(11)
+        JdkVersion.JDK_14 == JdkVersion.valueOf(14)
+    }
 
+    void 'test valueOf when the JDK version does not exist'() {
         when:
         JdkVersion.valueOf(16)
 


### PR DESCRIPTION
Fixes #498 Fixes #506

---

I've removed the `hasSupport` boolean because we are not using it in any place and it's misleading because it is possible to create applications with "unsupported" JDKs. Besides that, if we allow to use any JDK version, there are no "unsupported" versions (as long as they exist) in the enum.

The CLI didn't allow to create apps with "unsupported versions" because the `getJdkVersion` method here
https://github.com/micronaut-projects/micronaut-starter/blob/43a3acc5be0ea532a3574efd919b9a746217def6/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateCommand.java#L122

eventually calls the following, that only allow the so called supported JDKs:

https://github.com/micronaut-projects/micronaut-starter/blob/acc2d80c4bff32a123c92ddce91c6e9987bdb6f6/starter-core/src/main/java/io/micronaut/starter/options/JdkVersion.java#L45-L55

On the other hand, the API directly receives a `JdkVersion` as parameter

https://github.com/micronaut-projects/micronaut-starter/blob/847bb5781616a3853aa4f9df5107c1ddf99e38d7/starter-api/src/main/java/io/micronaut/starter/api/create/AbstractCreateController.java#L86

and it only checks if it is `null` or not to set a default JDK_8:

https://github.com/micronaut-projects/micronaut-starter/blob/847bb5781616a3853aa4f9df5107c1ddf99e38d7/starter-api/src/main/java/io/micronaut/starter/api/create/AbstractCreateController.java#L100


With this change both the CLI and the API will behave the same.