### PR TITLE
Change wrong gradle dependency scope

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dependencies.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dependencies.rocker.raw
@@ -485,22 +485,22 @@ dependencies {
 }
 @if (features.contains("testcontainers")) {
 @if (features.contains("r2dbc")) {
-    @dependency.template("org.testcontainers", "r2dbc", "testRuntimeOnly", null)
+    @dependency.template("org.testcontainers", "r2dbc", "testImplementation", null)
 }
 @if (features.contains("mysql")) {
-    @dependency.template("org.testcontainers", "mysql", "testRuntimeOnly", null)
+    @dependency.template("org.testcontainers", "mysql", "testImplementation", null)
 }
 @if (features.contains("postgres")) {
-    @dependency.template("org.testcontainers", "postgresql", "testRuntimeOnly", null)
+    @dependency.template("org.testcontainers", "postgresql", "testImplementation", null)
 }
 @if (features.contains("mariadb")) {
-    @dependency.template("org.testcontainers", "mariadb", "testRuntimeOnly", null)
+    @dependency.template("org.testcontainers", "mariadb", "testImplementation", null)
 }
 @if (features.contains("oracle")) {
-    @dependency.template("org.testcontainers", "oracle-xe", "testRuntimeOnly", null)
+    @dependency.template("org.testcontainers", "oracle-xe", "testImplementation", null)
 }
 @if (features.contains("sqlserver")) {
-    @dependency.template("org.testcontainers", "mssqlserver", "testRuntimeOnly", null)
+    @dependency.template("org.testcontainers", "mssqlserver", "testImplementation", null)
 }
 }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/TestContainersSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/TestContainersSpec.groovy
@@ -15,7 +15,7 @@ class TestContainersSpec extends BeanContextSpec {
         String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'oracle']), false).render().toString()
 
         then:
-        template.contains('testRuntimeOnly("org.testcontainers:oracle-xe")')
+        template.contains('testImplementation("org.testcontainers:oracle-xe")')
     }
 
     void "test mysql dependency is present for gradle"() {
@@ -23,7 +23,7 @@ class TestContainersSpec extends BeanContextSpec {
         String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'mysql']), false).render().toString()
 
         then:
-        template.contains('testRuntimeOnly("org.testcontainers:mysql")')
+        template.contains('testImplementation("org.testcontainers:mysql")')
     }
 
     void "test postgres dependency is present for gradle"() {
@@ -31,7 +31,7 @@ class TestContainersSpec extends BeanContextSpec {
         String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'postgres']), false).render().toString()
 
         then:
-        template.contains('testRuntimeOnly("org.testcontainers:postgresql")')
+        template.contains('testImplementation("org.testcontainers:postgresql")')
     }
 
     void "test mariadb dependency is present for gradle"() {
@@ -39,7 +39,7 @@ class TestContainersSpec extends BeanContextSpec {
         String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'mariadb']), false).render().toString()
 
         then:
-        template.contains('testRuntimeOnly("org.testcontainers:mariadb")')
+        template.contains('testImplementation("org.testcontainers:mariadb")')
     }
 
     void "test sqlserver dependency is present for gradle"() {
@@ -47,7 +47,7 @@ class TestContainersSpec extends BeanContextSpec {
         String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'sqlserver']), false).render().toString()
 
         then:
-        template.contains('testRuntimeOnly("org.testcontainers:mssqlserver")')
+        template.contains('testImplementation("org.testcontainers:mssqlserver")')
     }
 
     void "test oracle dependency is present for maven"() {


### PR DESCRIPTION
Change testcontainers gradle dependency scope from `testRuntimeOnly` to `testImplementation` for:

* r2dbc
* mysql
* postgresql
* mariadb
* oracle-xe
* mssqlserver

See: https://github.com/micronaut-projects/micronaut-starter/issues/588