### PR TITLE
Remove modifier 'public' from Java class definition because it is usu…

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/template/javaJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/template/javaJunit.rocker.raw
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Assertions;
 import javax.inject.Inject;
 
 @@MicronautTest
-public class @project.getClassName()Test {
+class @project.getClassName()Test {
 
     @@Inject
     EmbeddedApplication<?> application;


### PR DESCRIPTION
…ally omitted for JUnit 5 tests