### PR TITLE
Issue 621 - adding support to generate application environment configuration rooted other than in src/main/resources (e.g. application-test.yml to /src/test/resources)

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
@@ -24,7 +24,9 @@ import io.micronaut.starter.application.Project;
 import io.micronaut.starter.build.BuildProperties;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.Features;
-import io.micronaut.starter.feature.config.EnvConfiguration;
+import io.micronaut.starter.feature.config.ApplicationConfiguration;
+import io.micronaut.starter.feature.config.BootstrapConfiguration;
+import io.micronaut.starter.feature.config.Configuration;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.JdkVersion;
 import io.micronaut.starter.options.Language;
@@ -35,15 +37,18 @@ import io.micronaut.starter.template.RockerTemplate;
 import io.micronaut.starter.template.Template;
 import io.micronaut.starter.template.Writable;
 import io.micronaut.starter.util.VersionInfo;
+import sun.security.krb5.Config;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A context object used when generating projects.
@@ -56,9 +61,12 @@ public class GeneratorContext {
     private final Project project;
     private final OperatingSystem operatingSystem;
     private final BuildProperties buildProperties = new BuildProperties();
-    private final Map<String, Object> configuration = new LinkedHashMap<>();
-    private final Map<String, EnvConfiguration> environmentConfiguration = new LinkedHashMap<>();
-    private final Map<String, Object> bootstrapConfig = new LinkedHashMap<>();
+    private final ApplicationConfiguration configuration = new ApplicationConfiguration();
+    private final Map<String, ApplicationConfiguration> applicationEnvironmentConfiguration = new LinkedHashMap<>();
+    private final Map<String, BootstrapConfiguration> bootstrapEnvironmentConfiguration = new LinkedHashMap<>();
+    private final BootstrapConfiguration bootstrapConfiguration = new BootstrapConfiguration();
+    private final Set<Configuration> otherConfiguration = new HashSet<>();
+
     private final Map<String, Template> templates = new LinkedHashMap<>();
     private final List<Writable> helpTemplates = new ArrayList<>(8);
     private final ApplicationType command;
@@ -119,30 +127,51 @@ public class GeneratorContext {
     /**
      * @return The configuration
      */
-    @NonNull public Map<String, Object> getConfiguration() {
+    @NonNull public ApplicationConfiguration getConfiguration() {
         return configuration;
     }
 
     /**
      * @return The configuration
      */
-    @NonNull public EnvConfiguration getEnvConfiguration(String env, String path) {
-        return environmentConfiguration.computeIfAbsent(env, (k) ->
-            new EnvConfiguration(path, new LinkedHashMap<>()));
+    @Nullable public ApplicationConfiguration getConfiguration(String env) {
+        return applicationEnvironmentConfiguration.get(env);
+    }
+
+    @NonNull public ApplicationConfiguration getConfiguration(String env, ApplicationConfiguration defaultConfig) {
+        return applicationEnvironmentConfiguration.computeIfAbsent(env, (key) -> defaultConfig);
     }
 
     /**
      * @return The configuration
      */
-    @NonNull public Map<String, EnvConfiguration> getEnvConfigurations() {
-        return environmentConfiguration;
+    @Nullable public BootstrapConfiguration getBootstrapConfiguration(String env) {
+        return bootstrapEnvironmentConfiguration.get(env);
+    }
+
+    @NonNull public BootstrapConfiguration getBootstrapConfiguration(String env, BootstrapConfiguration defaultConfig) {
+        return bootstrapEnvironmentConfiguration.computeIfAbsent(env, (key) -> defaultConfig);
     }
 
     /**
      * @return The bootstrap config
      */
-    @NonNull public Map<String, Object> getBootstrapConfig() {
-        return bootstrapConfig;
+    @NonNull public BootstrapConfiguration getBootstrapConfiguration() {
+        return bootstrapConfiguration;
+    }
+
+    public void addConfiguration(@NonNull Configuration configuration) {
+        otherConfiguration.add(configuration);
+    }
+
+    @NonNull public Set<Configuration> getAllConfigurations() {
+        Set<Configuration> allConfigurations = new HashSet<>();
+        allConfigurations.add(configuration);
+        allConfigurations.add(bootstrapConfiguration);
+        allConfigurations.addAll(applicationEnvironmentConfiguration.values());
+        allConfigurations.addAll(bootstrapEnvironmentConfiguration.values());
+        allConfigurations.addAll(otherConfiguration);
+        return allConfigurations;
     }
 
     /**

--- a/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
@@ -18,19 +18,32 @@ package io.micronaut.starter.application.generator;
 import com.fizzed.rocker.RockerModel;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import io.micronaut.starter.application.OperatingSystem;
-import io.micronaut.starter.options.*;
-import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.OperatingSystem;
+import io.micronaut.starter.application.Project;
+import io.micronaut.starter.build.BuildProperties;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.Features;
+import io.micronaut.starter.feature.config.EnvConfiguration;
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.options.JdkVersion;
+import io.micronaut.starter.options.Language;
+import io.micronaut.starter.options.Options;
+import io.micronaut.starter.options.TestFramework;
+import io.micronaut.starter.options.TestRockerModelProvider;
 import io.micronaut.starter.template.RockerTemplate;
 import io.micronaut.starter.template.Template;
 import io.micronaut.starter.template.Writable;
 import io.micronaut.starter.util.VersionInfo;
-import io.micronaut.starter.build.BuildProperties;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * A context object used when generating projects.
@@ -44,7 +57,7 @@ public class GeneratorContext {
     private final OperatingSystem operatingSystem;
     private final BuildProperties buildProperties = new BuildProperties();
     private final Map<String, Object> configuration = new LinkedHashMap<>();
-    private final Map<String, Map<String, Object>> environmentConfiguration = new LinkedHashMap<>();
+    private final Map<String, EnvConfiguration> environmentConfiguration = new LinkedHashMap<>();
     private final Map<String, Object> bootstrapConfig = new LinkedHashMap<>();
     private final Map<String, Template> templates = new LinkedHashMap<>();
     private final List<Writable> helpTemplates = new ArrayList<>(8);
@@ -113,14 +126,15 @@ public class GeneratorContext {
     /**
      * @return The configuration
      */
-    @NonNull public Map<String, Object> getEnvConfiguration(String env) {
-        return environmentConfiguration.computeIfAbsent(env, (k) -> new LinkedHashMap<>());
+    @NonNull public EnvConfiguration getEnvConfiguration(String env, String path) {
+        return environmentConfiguration.computeIfAbsent(env, (k) ->
+            new EnvConfiguration(path, new LinkedHashMap<>()));
     }
 
     /**
      * @return The configuration
      */
-    @NonNull public Map<String, Map<String, Object>> getEnvConfigurations() {
+    @NonNull public Map<String, EnvConfiguration> getEnvConfigurations() {
         return environmentConfiguration;
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
@@ -37,7 +37,6 @@ import io.micronaut.starter.template.RockerTemplate;
 import io.micronaut.starter.template.Template;
 import io.micronaut.starter.template.Writable;
 import io.micronaut.starter.util.VersionInfo;
-import sun.security.krb5.Config;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
 
 /**
  * A context object used when generating projects.

--- a/starter-core/src/main/java/io/micronaut/starter/feature/Feature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/Feature.java
@@ -99,7 +99,7 @@ public interface Feature extends Named, Ordered, Described {
      *
      * This method can be implemented to modify the generated project. The feature can add templates
      * by executing {@link GeneratorContext#addTemplate(String, io.micronaut.starter.template.Template)}, modify configuration
-     * by modifying {@link GeneratorContext#getConfiguration()} or {@link GeneratorContext#getBootstrapConfig()}, or modify build properties through {@link GeneratorContext#getBuildProperties()}.
+     * by modifying {@link GeneratorContext#getConfiguration()} or {@link GeneratorContext#getBootstrapConfiguration()}, or modify build properties through {@link GeneratorContext#getBuildProperties()}.
      *
      * @param generatorContext THe generator context
      */

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/ApplicationConfiguration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/ApplicationConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.starter.feature.config;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/ApplicationConfiguration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/ApplicationConfiguration.java
@@ -1,0 +1,22 @@
+package io.micronaut.starter.feature.config;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class ApplicationConfiguration extends Configuration {
+
+    public ApplicationConfiguration(@NonNull String sourceSet, @NonNull String environment) {
+        super(sourceSet, "application-" + environment, "application-config-" + environment);
+    }
+
+    public ApplicationConfiguration(@NonNull String environment) {
+        this("main", environment);
+    }
+
+    public ApplicationConfiguration() {
+        super("main", "application", "application-config");
+    }
+
+    public static ApplicationConfiguration testConfig() {
+        return new ApplicationConfiguration("test", "test");
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/BootstrapConfiguration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/BootstrapConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.starter.feature.config;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/BootstrapConfiguration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/BootstrapConfiguration.java
@@ -1,0 +1,22 @@
+package io.micronaut.starter.feature.config;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class BootstrapConfiguration extends Configuration {
+
+    public BootstrapConfiguration(@NonNull String sourceSet, @NonNull String environment) {
+        super(sourceSet, "bootstrap-" + environment, "bootstrap-config-" + environment);
+    }
+
+    public BootstrapConfiguration(@NonNull String environment) {
+        this("main", environment);
+    }
+
+    public BootstrapConfiguration() {
+        super("main", "bootstrap", "bootstrap-config");
+    }
+
+    public static BootstrapConfiguration testConfig() {
+        return new BootstrapConfiguration("test", "test");
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/Config4k.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/Config4k.java
@@ -26,13 +26,17 @@ import io.micronaut.starter.feature.FeaturePredicate;
 import io.micronaut.starter.feature.LanguageSpecificFeature;
 import io.micronaut.starter.options.Language;
 import io.micronaut.starter.template.Config4kTemplate;
+import io.micronaut.starter.template.Template;
 
 import javax.inject.Singleton;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 @Singleton
 public class Config4k implements ConfigurationFeature, LanguageSpecificFeature {
+
+    private static final String EXTENSION = "conf";
 
     @NonNull
     @Override
@@ -85,20 +89,8 @@ public class Config4k implements ConfigurationFeature, LanguageSpecificFeature {
     }
 
     @Override
-    public void apply(GeneratorContext generatorContext) {
-        generatorContext.addTemplate("confConfig", new Config4kTemplate("src/main/resources/application.conf", generatorContext.getConfiguration()));
-        if (!generatorContext.getBootstrapConfig().isEmpty()) {
-            generatorContext.addTemplate("confBootstrapConfig", new Config4kTemplate("src/main/resources/bootstrap.conf", generatorContext.getBootstrapConfig()));
-        }
-        Map<String, EnvConfiguration> envConfigs = generatorContext.getEnvConfigurations();
-        if (!envConfigs.isEmpty()) {
-            for (Map.Entry<String, EnvConfiguration> envConfig: envConfigs.entrySet()) {
-                String env = envConfig.getKey();
-                Map<String, Object> configs = envConfig.getValue().getEnvConfiguration();
-                String path = envConfig.getValue().getPath();
-                generatorContext.addTemplate("confConfig" + StringUtils.capitalize(env),
-                    new Config4kTemplate(path + "application-" + env + ".conf", configs));
-            }
-        }
+    public Function<Configuration, Template> createTemplate() {
+        return (config) -> new Config4kTemplate(config.getFullPath(EXTENSION), config);
     }
+
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/Config4k.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/Config4k.java
@@ -90,10 +90,14 @@ public class Config4k implements ConfigurationFeature, LanguageSpecificFeature {
         if (!generatorContext.getBootstrapConfig().isEmpty()) {
             generatorContext.addTemplate("confBootstrapConfig", new Config4kTemplate("src/main/resources/bootstrap.conf", generatorContext.getBootstrapConfig()));
         }
-        Map<String, Map<String, Object>> envConfigs = generatorContext.getEnvConfigurations();
+        Map<String, EnvConfiguration> envConfigs = generatorContext.getEnvConfigurations();
         if (!envConfigs.isEmpty()) {
-            for (Map.Entry<String, Map<String, Object>> envConfig: envConfigs.entrySet()) {
-                generatorContext.addTemplate("confConfig" + StringUtils.capitalize(envConfig.getKey()), new Config4kTemplate("src/main/resources/application-" + envConfig.getKey() + ".conf", envConfig.getValue()));
+            for (Map.Entry<String, EnvConfiguration> envConfig: envConfigs.entrySet()) {
+                String env = envConfig.getKey();
+                Map<String, Object> configs = envConfig.getValue().getEnvConfiguration();
+                String path = envConfig.getValue().getPath();
+                generatorContext.addTemplate("confConfig" + StringUtils.capitalize(env),
+                    new Config4kTemplate(path + "application-" + env + ".conf", configs));
             }
         }
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/Config4k.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/Config4k.java
@@ -16,9 +16,7 @@
 package io.micronaut.starter.feature.config;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.starter.application.ApplicationType;
-import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.FeaturePhase;
@@ -29,7 +27,6 @@ import io.micronaut.starter.template.Config4kTemplate;
 import io.micronaut.starter.template.Template;
 
 import javax.inject.Singleton;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/Configuration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/Configuration.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.feature.config;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -26,31 +27,42 @@ import java.util.Objects;
  *
  * @since 2.3.0
  */
-public class EnvConfiguration {
-
-    public static final String DEFAULT_MAIN_PATH = "src/main/resources/";
-    public static final String DEFAULT_TEST_PATH = "src/test/resources/";
+public class Configuration extends LinkedHashMap<String, Object> {
 
     private final String path;
-    private final Map<String, Object> envConfiguration;
+    private final String fileName;
+    private final String templateKey;
 
     /**
      * A configuration rooted at path, with the given map of configurations
      *
-     * @param path where the configuration is rooted, e.g. src/main/resources
-     * @param envConfiguration the configuration value
+     * @param sourceSet where the configuration is rooted, e.g. main, test
      */
-    public EnvConfiguration(@NonNull String path, @NonNull Map<String, Object> envConfiguration) {
-        this.path = path.endsWith("/") ? path : path + "/";
-        this.envConfiguration = envConfiguration;
+    public Configuration(@NonNull String sourceSet, @NonNull String fileName, @NonNull String templateKey) {
+        super();
+        this.path = "src/" + sourceSet + "/resources/";
+        this.fileName = fileName;
+        this.templateKey = templateKey;
     }
 
-    @NonNull public String getPath() {
+    @NonNull
+    public String getPath() {
         return path;
     }
 
-    @NonNull public Map<String, Object> getEnvConfiguration() {
-        return envConfiguration;
+    @NonNull
+    public String getFileName() {
+        return fileName;
+    }
+
+    @NonNull
+    public String getFullPath(String extension) {
+        return path + fileName + "." + extension;
+    }
+
+    @NonNull
+    public String getTemplateKey() {
+        return templateKey;
     }
 
     @Override
@@ -61,12 +73,13 @@ public class EnvConfiguration {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        EnvConfiguration that = (EnvConfiguration) o;
-        return path.equals(that.path) && envConfiguration.equals(that.envConfiguration);
+        Configuration that = (Configuration) o;
+        return templateKey.equals(that.templateKey);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(path, envConfiguration);
+        return Objects.hash(templateKey);
     }
+
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/Configuration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/Configuration.java
@@ -18,7 +18,6 @@ package io.micronaut.starter.feature.config;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/ConfigurationFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/ConfigurationFeature.java
@@ -15,8 +15,16 @@
  */
 package io.micronaut.starter.feature.config;
 
+import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.OneOfFeature;
+import io.micronaut.starter.template.Template;
+import io.micronaut.starter.template.YamlTemplate;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 public interface ConfigurationFeature extends OneOfFeature {
 
@@ -28,5 +36,18 @@ public interface ConfigurationFeature extends OneOfFeature {
     @Override
     default String getCategory() {
         return Category.CONFIGURATION;
+    }
+
+    Function<Configuration, Template> createTemplate();
+
+    @Override
+    default void apply(GeneratorContext generatorContext) {
+        Function<Configuration, Template> createTemplateFunc = createTemplate();
+        generatorContext.getAllConfigurations()
+                .stream()
+                .filter(config -> !config.isEmpty())
+                .forEach(config -> {
+                    generatorContext.addTemplate(config.getTemplateKey(), createTemplateFunc.apply(config));
+                });
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/ConfigurationFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/ConfigurationFeature.java
@@ -19,11 +19,7 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.OneOfFeature;
 import io.micronaut.starter.template.Template;
-import io.micronaut.starter.template.YamlTemplate;
 
-import java.util.Map;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public interface ConfigurationFeature extends OneOfFeature {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/EnvConfiguration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/EnvConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.config;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Models application environment configuration to specify where the configuration is rooted
+ * for the given configuration values (key/value pairs).
+ *
+ * @since 2.3.0
+ */
+public class EnvConfiguration {
+
+    public static final String DEFAULT_MAIN_PATH = "src/main/resources/";
+    public static final String DEFAULT_TEST_PATH = "src/test/resources/";
+
+    private final String path;
+    private final Map<String, Object> envConfiguration;
+
+    /**
+     * A configuration rooted at path, with the given map of configurations
+     *
+     * @param path where the configuration is rooted, e.g. src/main/resources
+     * @param envConfiguration the configuration value
+     */
+    public EnvConfiguration(@NonNull String path, @NonNull Map<String, Object> envConfiguration) {
+        this.path = path.endsWith("/") ? path : path + "/";
+        this.envConfiguration = envConfiguration;
+    }
+
+    @NonNull public String getPath() {
+        return path;
+    }
+
+    @NonNull public Map<String, Object> getEnvConfiguration() {
+        return envConfiguration;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EnvConfiguration that = (EnvConfiguration) o;
+        return path.equals(that.path) && envConfiguration.equals(that.envConfiguration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path, envConfiguration);
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/Properties.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/Properties.java
@@ -15,16 +15,12 @@
  */
 package io.micronaut.starter.feature.config;
 
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.starter.application.ApplicationType;
-import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.FeaturePhase;
-import io.micronaut.starter.template.Config4kTemplate;
 import io.micronaut.starter.template.PropertiesTemplate;
 import io.micronaut.starter.template.Template;
 
 import javax.inject.Singleton;
-import java.util.Map;
 import java.util.function.Function;
 
 @Singleton

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/Properties.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/Properties.java
@@ -53,10 +53,14 @@ public class Properties implements ConfigurationFeature {
         if (!generatorContext.getBootstrapConfig().isEmpty()) {
             generatorContext.addTemplate("propertiesBootstrapConfig", new PropertiesTemplate("src/main/resources/bootstrap.properties", generatorContext.getBootstrapConfig()));
         }
-        Map<String, Map<String, Object>> envConfigs = generatorContext.getEnvConfigurations();
+        Map<String, EnvConfiguration> envConfigs = generatorContext.getEnvConfigurations();
         if (!envConfigs.isEmpty()) {
-            for (Map.Entry<String, Map<String, Object>> envConfig: envConfigs.entrySet()) {
-                generatorContext.addTemplate("propertiesConfig" + StringUtils.capitalize(envConfig.getKey()), new PropertiesTemplate("src/main/resources/application-" + envConfig.getKey() + ".properties", envConfig.getValue()));
+            for (Map.Entry<String, EnvConfiguration> envConfig: envConfigs.entrySet()) {
+                String env = envConfig.getKey();
+                Map<String, Object> configs = envConfig.getValue().getEnvConfiguration();
+                String path = envConfig.getValue().getPath();
+                generatorContext.addTemplate("propertiesConfig" + StringUtils.capitalize(env),
+                    new PropertiesTemplate(path + "application-" + env + ".properties", configs));
             }
         }
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/Properties.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/Properties.java
@@ -19,13 +19,18 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.FeaturePhase;
+import io.micronaut.starter.template.Config4kTemplate;
 import io.micronaut.starter.template.PropertiesTemplate;
+import io.micronaut.starter.template.Template;
 
 import javax.inject.Singleton;
 import java.util.Map;
+import java.util.function.Function;
 
 @Singleton
 public class Properties implements ConfigurationFeature {
+
+    private static final String EXTENSION = "properties";
 
     @Override
     public String getName() {
@@ -48,21 +53,8 @@ public class Properties implements ConfigurationFeature {
     }
 
     @Override
-    public void apply(GeneratorContext generatorContext) {
-        generatorContext.addTemplate("propertiesConfig", new PropertiesTemplate("src/main/resources/application.properties", generatorContext.getConfiguration()));
-        if (!generatorContext.getBootstrapConfig().isEmpty()) {
-            generatorContext.addTemplate("propertiesBootstrapConfig", new PropertiesTemplate("src/main/resources/bootstrap.properties", generatorContext.getBootstrapConfig()));
-        }
-        Map<String, EnvConfiguration> envConfigs = generatorContext.getEnvConfigurations();
-        if (!envConfigs.isEmpty()) {
-            for (Map.Entry<String, EnvConfiguration> envConfig: envConfigs.entrySet()) {
-                String env = envConfig.getKey();
-                Map<String, Object> configs = envConfig.getValue().getEnvConfiguration();
-                String path = envConfig.getValue().getPath();
-                generatorContext.addTemplate("propertiesConfig" + StringUtils.capitalize(env),
-                    new PropertiesTemplate(path + "application-" + env + ".properties", configs));
-            }
-        }
+    public Function<Configuration, Template> createTemplate() {
+        return (config) -> new PropertiesTemplate(config.getFullPath(EXTENSION), config);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/Yaml.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/Yaml.java
@@ -57,10 +57,14 @@ public class Yaml implements ConfigurationFeature, DefaultFeature {
         if (!generatorContext.getBootstrapConfig().isEmpty()) {
             generatorContext.addTemplate("yamlBootstrapConfig", new YamlTemplate("src/main/resources/bootstrap.yml", generatorContext.getBootstrapConfig()));
         }
-        Map<String, Map<String, Object>> envConfigs = generatorContext.getEnvConfigurations();
+        Map<String, EnvConfiguration> envConfigs = generatorContext.getEnvConfigurations();
         if (!envConfigs.isEmpty()) {
-            for (Map.Entry<String, Map<String, Object>> envConfig: envConfigs.entrySet()) {
-                generatorContext.addTemplate("yamlConfig" + StringUtils.capitalize(envConfig.getKey()), new YamlTemplate("src/main/resources/application-" + envConfig.getKey() + ".yml", envConfig.getValue()));
+            for (Map.Entry<String, EnvConfiguration> envConfig: envConfigs.entrySet()) {
+                String env = envConfig.getKey();
+                Map<String, Object> configs = envConfig.getValue().getEnvConfiguration();
+                String path = envConfig.getValue().getPath();
+                generatorContext.addTemplate("yamlConfig" + StringUtils.capitalize(env),
+                    new YamlTemplate(path + "application-" + env + ".yml", configs));
             }
         }
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/Yaml.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/Yaml.java
@@ -22,14 +22,19 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.feature.DefaultFeature;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeaturePhase;
+import io.micronaut.starter.template.PropertiesTemplate;
+import io.micronaut.starter.template.Template;
 import io.micronaut.starter.template.YamlTemplate;
 
 import javax.inject.Singleton;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 @Singleton
 public class Yaml implements ConfigurationFeature, DefaultFeature {
+
+    private static final String EXTENSION = "yml";
 
     @Override
     public String getName() {
@@ -52,21 +57,8 @@ public class Yaml implements ConfigurationFeature, DefaultFeature {
     }
 
     @Override
-    public void apply(GeneratorContext generatorContext) {
-        generatorContext.addTemplate("yamlConfig", new YamlTemplate("src/main/resources/application.yml", generatorContext.getConfiguration()));
-        if (!generatorContext.getBootstrapConfig().isEmpty()) {
-            generatorContext.addTemplate("yamlBootstrapConfig", new YamlTemplate("src/main/resources/bootstrap.yml", generatorContext.getBootstrapConfig()));
-        }
-        Map<String, EnvConfiguration> envConfigs = generatorContext.getEnvConfigurations();
-        if (!envConfigs.isEmpty()) {
-            for (Map.Entry<String, EnvConfiguration> envConfig: envConfigs.entrySet()) {
-                String env = envConfig.getKey();
-                Map<String, Object> configs = envConfig.getValue().getEnvConfiguration();
-                String path = envConfig.getValue().getPath();
-                generatorContext.addTemplate("yamlConfig" + StringUtils.capitalize(env),
-                    new YamlTemplate(path + "application-" + env + ".yml", configs));
-            }
-        }
+    public Function<Configuration, Template> createTemplate() {
+        return (config) -> new YamlTemplate(config.getFullPath(EXTENSION), config);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/Yaml.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/Yaml.java
@@ -15,19 +15,15 @@
  */
 package io.micronaut.starter.feature.config;
 
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.starter.options.Options;
-import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.feature.DefaultFeature;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeaturePhase;
-import io.micronaut.starter.template.PropertiesTemplate;
 import io.micronaut.starter.template.Template;
 import io.micronaut.starter.template.YamlTemplate;
 
 import javax.inject.Singleton;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/consul/Consul.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/consul/Consul.java
@@ -47,7 +47,7 @@ public class Consul implements Feature {
     public void apply(GeneratorContext generatorContext) {
         Map<String, Object> config;
         if (generatorContext.isFeaturePresent(DistributedConfigFeature.class)) {
-            config = generatorContext.getBootstrapConfig();
+            config = generatorContext.getBootstrapConfiguration();
         } else {
             config = generatorContext.getConfiguration();
         }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
@@ -21,7 +21,8 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
-import io.micronaut.starter.feature.config.EnvConfiguration;
+import io.micronaut.starter.feature.config.ApplicationConfiguration;
+import io.micronaut.starter.feature.config.Configuration;
 import io.micronaut.starter.feature.database.r2dbc.R2dbcFeature;
 import io.micronaut.starter.template.PropertiesTemplate;
 import io.micronaut.starter.template.StringTemplate;
@@ -65,9 +66,8 @@ public class TestContainers implements Feature {
                 }
 
                 if (url != null) {
-                    EnvConfiguration testConfig = generatorContext.getEnvConfiguration(
-                        "test", EnvConfiguration.DEFAULT_TEST_PATH);
-                    testConfig.getEnvConfiguration().put(driverConfiguration.getUrlKey(), url);
+                    Configuration testConfig = generatorContext.getConfiguration("test", ApplicationConfiguration.testConfig());
+                    testConfig.put(driverConfiguration.getUrlKey(), url);
                 }
             });
             generatorContext.getFeature(DatabaseDriverConfigurationFeature.class).ifPresent(driverConfiguration -> {
@@ -88,10 +88,9 @@ public class TestContainers implements Feature {
                 }
 
                 if (url != null) {
-                    EnvConfiguration testConfig = generatorContext.getEnvConfiguration(
-                        "test", EnvConfiguration.DEFAULT_TEST_PATH);
-                    testConfig.getEnvConfiguration().put(driverConfiguration.getUrlKey(), url);
-                    testConfig.getEnvConfiguration().put(driverConfiguration.getDriverKey(), driver);
+                    Configuration testConfig = generatorContext.getConfiguration("test", ApplicationConfiguration.testConfig());
+                    testConfig.put(driverConfiguration.getUrlKey(), url);
+                    testConfig.put(driverConfiguration.getDriverKey(), driver);
                 }
             });
         });

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
@@ -21,13 +21,13 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.config.EnvConfiguration;
 import io.micronaut.starter.feature.database.r2dbc.R2dbcFeature;
 import io.micronaut.starter.template.PropertiesTemplate;
 import io.micronaut.starter.template.StringTemplate;
 
 import javax.inject.Singleton;
 import java.util.Collections;
-import java.util.Map;
 
 @Singleton
 public class TestContainers implements Feature {
@@ -65,8 +65,9 @@ public class TestContainers implements Feature {
                 }
 
                 if (url != null) {
-                    Map<String, Object> testConfig = generatorContext.getEnvConfiguration("test");
-                    testConfig.put(driverConfiguration.getUrlKey(), url);
+                    EnvConfiguration testConfig = generatorContext.getEnvConfiguration(
+                        "test", EnvConfiguration.DEFAULT_TEST_PATH);
+                    testConfig.getEnvConfiguration().put(driverConfiguration.getUrlKey(), url);
                 }
             });
             generatorContext.getFeature(DatabaseDriverConfigurationFeature.class).ifPresent(driverConfiguration -> {
@@ -87,9 +88,10 @@ public class TestContainers implements Feature {
                 }
 
                 if (url != null) {
-                    Map<String, Object> testConfig = generatorContext.getEnvConfiguration("test");
-                    testConfig.put(driverConfiguration.getUrlKey(), url);
-                    testConfig.put(driverConfiguration.getDriverKey(), driver);
+                    EnvConfiguration testConfig = generatorContext.getEnvConfiguration(
+                        "test", EnvConfiguration.DEFAULT_TEST_PATH);
+                    testConfig.getEnvConfiguration().put(driverConfiguration.getUrlKey(), url);
+                    testConfig.getEnvConfiguration().put(driverConfiguration.getDriverKey(), driver);
                 }
             });
         });

--- a/starter-core/src/main/java/io/micronaut/starter/feature/distributedconfig/DistributedConfigConsul.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/distributedconfig/DistributedConfigConsul.java
@@ -56,7 +56,7 @@ public class DistributedConfigConsul implements DistributedConfigFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.getBootstrapConfig().put("micronaut.config-client.enabled", true);
+        generatorContext.getBootstrapConfiguration().put("micronaut.config-client.enabled", true);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/distributedconfig/KubernetesConfig.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/distributedconfig/KubernetesConfig.java
@@ -66,7 +66,7 @@ public class KubernetesConfig implements DistributedConfigFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.getBootstrapConfig().put("micronaut.config-client.enabled", true);
+        generatorContext.getBootstrapConfiguration().put("micronaut.config-client.enabled", true);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/other/AppName.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/other/AppName.java
@@ -54,7 +54,7 @@ public class AppName implements DefaultFeature {
     public void apply(GeneratorContext generatorContext) {
         Map<String, Object> appNameConfig;
         if (generatorContext.isFeaturePresent(DistributedConfigFeature.class)) {
-            appNameConfig = generatorContext.getBootstrapConfig();
+            appNameConfig = generatorContext.getBootstrapConfiguration();
         } else {
             appNameConfig = generatorContext.getConfiguration();
         }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/config/Config4kSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/config/Config4kSpec.groovy
@@ -46,11 +46,9 @@ class Config4kSpec extends BeanContextSpec implements CommandOutputFixture {
     void "test configuration files generated for config4k feature"() {
         when:
         GeneratorContext generatorContext = buildGeneratorContext(['config4k'], {context ->
-            context.getBootstrapConfig().put("abc", 123)
-            context.getEnvConfiguration("test", EnvConfiguration.DEFAULT_TEST_PATH)
-                    .getEnvConfiguration().put("abc", 456)
-            context.getEnvConfiguration("prod", EnvConfiguration.DEFAULT_MAIN_PATH)
-                    .getEnvConfiguration().put("abc", 789)
+            context.getBootstrapConfiguration().put("abc", 123)
+            context.getConfiguration("test", ApplicationConfiguration.testConfig()).put("abc", 456)
+            context.getConfiguration("prod", new ApplicationConfiguration("prod")).put("abc", 789)
         }, new Options(Language.KOTLIN, null, BuildTool.GRADLE))
         def output = generate(ApplicationType.DEFAULT, generatorContext)
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/config/Config4kSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/config/Config4kSpec.groovy
@@ -5,7 +5,6 @@ import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.FeaturePhase
 import io.micronaut.starter.fixture.CommandOutputFixture
-import io.micronaut.starter.io.MapOutputHandler
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
@@ -48,8 +47,10 @@ class Config4kSpec extends BeanContextSpec implements CommandOutputFixture {
         when:
         GeneratorContext generatorContext = buildGeneratorContext(['config4k'], {context ->
             context.getBootstrapConfig().put("abc", 123)
-            context.getEnvConfiguration("test").put("abc", 456)
-            context.getEnvConfiguration("prod").put("abc", 789)
+            context.getEnvConfiguration("test", EnvConfiguration.DEFAULT_TEST_PATH)
+                    .getEnvConfiguration().put("abc", 456)
+            context.getEnvConfiguration("prod", EnvConfiguration.DEFAULT_MAIN_PATH)
+                    .getEnvConfiguration().put("abc", 789)
         }, new Options(Language.KOTLIN, null, BuildTool.GRADLE))
         def output = generate(ApplicationType.DEFAULT, generatorContext)
 
@@ -64,7 +65,7 @@ micronaut {
         output["src/main/resources/bootstrap.conf"] == '''\
 abc=123
 '''
-        output["src/main/resources/application-test.conf"] == '''\
+        output["src/test/resources/application-test.conf"] == '''\
 abc=456
 '''
         output["src/main/resources/application-prod.conf"] == '''\

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/config/PropertiesSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/config/PropertiesSpec.groovy
@@ -35,15 +35,17 @@ class PropertiesSpec extends BeanContextSpec implements CommandOutputFixture {
         when:
         GeneratorContext generatorContext = buildGeneratorContext(['properties'], { context ->
             context.getBootstrapConfig().put("abc", 123)
-            context.getEnvConfiguration("test").put("abc", 456)
-            context.getEnvConfiguration("prod").put("abc", 789)
+            context.getEnvConfiguration("test", EnvConfiguration.DEFAULT_TEST_PATH)
+                    .getEnvConfiguration().put("abc", 456)
+            context.getEnvConfiguration("prod", EnvConfiguration.DEFAULT_MAIN_PATH)
+                    .getEnvConfiguration().put("abc", 789)
         }, new Options())
         def output = generate(ApplicationType.DEFAULT, generatorContext)
 
         then:
         output["src/main/resources/application.properties"].readLines()[1] == 'micronaut.application.name=foo'
         output["src/main/resources/bootstrap.properties"].readLines()[1] == 'abc=123'
-        output["src/main/resources/application-test.properties"].readLines()[1] == 'abc=456'
+        output["src/test/resources/application-test.properties"].readLines()[1] == 'abc=456'
         output["src/main/resources/application-prod.properties"].readLines()[1] == 'abc=789'
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/config/PropertiesSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/config/PropertiesSpec.groovy
@@ -34,11 +34,9 @@ class PropertiesSpec extends BeanContextSpec implements CommandOutputFixture {
     void "test configuration files generated for properties feature"() {
         when:
         GeneratorContext generatorContext = buildGeneratorContext(['properties'], { context ->
-            context.getBootstrapConfig().put("abc", 123)
-            context.getEnvConfiguration("test", EnvConfiguration.DEFAULT_TEST_PATH)
-                    .getEnvConfiguration().put("abc", 456)
-            context.getEnvConfiguration("prod", EnvConfiguration.DEFAULT_MAIN_PATH)
-                    .getEnvConfiguration().put("abc", 789)
+            context.getBootstrapConfiguration().put("abc", 123)
+            context.getConfiguration("test", ApplicationConfiguration.testConfig()).put("abc", 456)
+            context.getConfiguration("prod", new ApplicationConfiguration("prod")).put("abc", 789)
         }, new Options())
         def output = generate(ApplicationType.DEFAULT, generatorContext)
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/config/YamlSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/config/YamlSpec.groovy
@@ -35,8 +35,10 @@ class YamlSpec extends BeanContextSpec implements CommandOutputFixture {
         when:
         GeneratorContext generatorContext = buildGeneratorContext([], { context ->
             context.getBootstrapConfig().put("abc", 123)
-            context.getEnvConfiguration("test").put("abc", 456)
-            context.getEnvConfiguration("prod").put("abc", 789)
+            context.getEnvConfiguration("test", EnvConfiguration.DEFAULT_TEST_PATH)
+                    .getEnvConfiguration().put("abc", 456)
+            context.getEnvConfiguration("prod", EnvConfiguration.DEFAULT_MAIN_PATH)
+                    .getEnvConfiguration().put("abc", 789)
         }, new Options())
         def output = generate(ApplicationType.DEFAULT, generatorContext)
 
@@ -49,7 +51,7 @@ micronaut:
         output["src/main/resources/bootstrap.yml"] == '''\
 abc: 123
 '''
-        output["src/main/resources/application-test.yml"] == '''\
+        output["src/test/resources/application-test.yml"] == '''\
 abc: 456
 '''
         output["src/main/resources/application-prod.yml"] == '''\

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/config/YamlSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/config/YamlSpec.groovy
@@ -34,11 +34,9 @@ class YamlSpec extends BeanContextSpec implements CommandOutputFixture {
     void "test configuration files generated for yaml feature"() {
         when:
         GeneratorContext generatorContext = buildGeneratorContext([], { context ->
-            context.getBootstrapConfig().put("abc", 123)
-            context.getEnvConfiguration("test", EnvConfiguration.DEFAULT_TEST_PATH)
-                    .getEnvConfiguration().put("abc", 456)
-            context.getEnvConfiguration("prod", EnvConfiguration.DEFAULT_MAIN_PATH)
-                    .getEnvConfiguration().put("abc", 789)
+            context.getBootstrapConfiguration().put("abc", 123)
+            context.getConfiguration("test", new ApplicationConfiguration("test", "test")).put("abc", 456)
+            context.getConfiguration("prod", new ApplicationConfiguration("prod")).put("abc", 789)
         }, new Options())
         def output = generate(ApplicationType.DEFAULT, generatorContext)
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryConsulSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryConsulSpec.groovy
@@ -69,9 +69,9 @@ class DiscoveryConsulSpec extends BeanContextSpec  implements CommandOutputFixtu
 
         then:
         commandContext.configuration.get('consul.client.registration.enabled'.toString()) == true
-        commandContext.bootstrapConfig.get('consul.client.defaultZone') == '${CONSUL_HOST:localhost}:${CONSUL_PORT:8500}'
+        commandContext.bootstrapConfiguration.get('consul.client.defaultZone') == '${CONSUL_HOST:localhost}:${CONSUL_PORT:8500}'
 
-        !commandContext.bootstrapConfig.containsKey('consul.client.registration.enabled')
+        !commandContext.bootstrapConfiguration.containsKey('consul.client.registration.enabled')
         !commandContext.configuration.containsKey('consul.client.defaultZone')
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/distributedconfig/DistributedConfigConsulSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/distributedconfig/DistributedConfigConsulSpec.groovy
@@ -79,9 +79,9 @@ class DistributedConfigConsulSpec extends BeanContextSpec  implements CommandOut
         GeneratorContext commandContext = buildGeneratorContext(['config-consul'])
 
         then:
-        commandContext.bootstrapConfig.get('micronaut.application.name'.toString()) == 'foo'
-        commandContext.bootstrapConfig.get('micronaut.config-client.enabled'.toString()) == true
-        commandContext.bootstrapConfig.get('consul.client.defaultZone') == '${CONSUL_HOST:localhost}:${CONSUL_PORT:8500}'
+        commandContext.bootstrapConfiguration.get('micronaut.application.name'.toString()) == 'foo'
+        commandContext.bootstrapConfiguration.get('micronaut.config-client.enabled'.toString()) == true
+        commandContext.bootstrapConfiguration.get('consul.client.defaultZone') == '${CONSUL_HOST:localhost}:${CONSUL_PORT:8500}'
     }
 
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/distributedconfig/KubernetesConfigSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/distributedconfig/KubernetesConfigSpec.groovy
@@ -58,8 +58,8 @@ class KubernetesConfigSpec extends BeanContextSpec  implements CommandOutputFixt
         GeneratorContext commandContext = buildGeneratorContext(['config-kubernetes'])
 
         then:
-        commandContext.bootstrapConfig.get('micronaut.application.name'.toString()) == 'foo'
-        commandContext.bootstrapConfig.get('micronaut.config-client.enabled'.toString()) == true
+        commandContext.bootstrapConfiguration.get('micronaut.application.name'.toString()) == 'foo'
+        commandContext.bootstrapConfiguration.get('micronaut.config-client.enabled'.toString()) == true
         commandContext.templates.get('k8sYaml')
     }
 
@@ -69,7 +69,7 @@ class KubernetesConfigSpec extends BeanContextSpec  implements CommandOutputFixt
         GeneratorContext commandContext = buildGeneratorContext(['kubernetes'])
 
         then:
-        commandContext.bootstrapConfig.get('micronaut.config-client.enabled'.toString()) == null
+        commandContext.bootstrapConfiguration.get('micronaut.config-client.enabled'.toString()) == null
         commandContext.templates.get('k8sYaml')
     }
 }


### PR DESCRIPTION
closes #621 