### PR TITLE
Issue 631 - add retry to spock tests that fail intermittently due to port binding race conditions on CI

### DIFF
--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsAlexaSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsAlexaSpec.groovy
@@ -9,6 +9,7 @@ import io.micronaut.starter.options.TestFramework
 import spock.lang.Retry
 import spock.lang.Unroll
 
+@Retry // can fail on CI due to port binding race condition, so retry
 class CreateAwsAlexaSpec extends CommandSpec {
 
     @Override
@@ -16,7 +17,6 @@ class CreateAwsAlexaSpec extends CommandSpec {
         return "test-awsalexa"
     }
 
-    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features aws-alexa #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsAlexaSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsAlexaSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.starter.test.CommandSpec
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
+import spock.lang.Retry
 import spock.lang.Unroll
 
 class CreateAwsAlexaSpec extends CommandSpec {
@@ -15,6 +16,7 @@ class CreateAwsAlexaSpec extends CommandSpec {
         return "test-awsalexa"
     }
 
+    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features aws-alexa #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaCustomRuntimeSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaCustomRuntimeSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.starter.test.CommandSpec
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
+import spock.lang.Retry
 import spock.lang.Unroll
 
 class CreateAwsLambdaCustomRuntimeSpec extends CommandSpec {
@@ -14,6 +15,7 @@ class CreateAwsLambdaCustomRuntimeSpec extends CommandSpec {
         "test-awslambdacustomruntime"
     }
 
+    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features aws-lambda, aws-lambda-custom-runtime #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                                            Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaCustomRuntimeSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaCustomRuntimeSpec.groovy
@@ -9,13 +9,13 @@ import io.micronaut.starter.options.TestFramework
 import spock.lang.Retry
 import spock.lang.Unroll
 
+@Retry // can fail on CI due to port binding race condition, so retry
 class CreateAwsLambdaCustomRuntimeSpec extends CommandSpec {
     @Override
     String getTempDirectoryPrefix() {
         "test-awslambdacustomruntime"
     }
 
-    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features aws-lambda, aws-lambda-custom-runtime #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                                            Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaGraalvmSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaGraalvmSpec.groovy
@@ -9,11 +9,12 @@ import io.micronaut.starter.test.CommandSpec
 import spock.lang.Requires
 import spock.lang.Retry
 import spock.lang.Unroll
+import spock.util.environment.Jvm
 
+@Retry // can fail on CI due to port binding race condition, so retry
 class CreateAwsLambdaGraalvmSpec extends CommandSpec {
 
-    @Requires({ jvm.isJava8() || jvm.isJava11() })
-    @Retry // can fail on CI due to port binding race condition, so retry
+    @Requires({ Jvm.current.java8 || Jvm.current.java11 })
     @Unroll
     void 'create-#applicationType with features aws-lambda, graalvm and lang #lang and build #build and test framework: #testFramework'(ApplicationType applicationType, Language lang, BuildTool build, TestFramework testFramework
 

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaGraalvmSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaGraalvmSpec.groovy
@@ -1,17 +1,19 @@
 package io.micronaut.starter.core.test.aws
 
 import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.test.BuildToolCombinations
-import io.micronaut.starter.test.CommandSpec
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
+import io.micronaut.starter.test.BuildToolCombinations
+import io.micronaut.starter.test.CommandSpec
 import spock.lang.Requires
+import spock.lang.Retry
 import spock.lang.Unroll
 
 class CreateAwsLambdaGraalvmSpec extends CommandSpec {
 
     @Requires({ jvm.isJava8() || jvm.isJava11() })
+    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features aws-lambda, graalvm and lang #lang and build #build and test framework: #testFramework'(ApplicationType applicationType, Language lang, BuildTool build, TestFramework testFramework
 

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.starter.test.CommandSpec
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
+import spock.lang.Retry
 import spock.lang.Unroll
 
 class CreateAwsLambdaSpec extends CommandSpec {
@@ -15,6 +16,7 @@ class CreateAwsLambdaSpec extends CommandSpec {
         "test-awslambda"
     }
 
+    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features aws-lambda #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                 Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaSpec.groovy
@@ -9,6 +9,7 @@ import io.micronaut.starter.options.TestFramework
 import spock.lang.Retry
 import spock.lang.Unroll
 
+@Retry // can fail on CI due to port binding race condition, so retry
 class CreateAwsLambdaSpec extends CommandSpec {
 
     @Override
@@ -16,7 +17,6 @@ class CreateAwsLambdaSpec extends CommandSpec {
         "test-awslambda"
     }
 
-    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features aws-lambda #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                 Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/buildTool/MavenPackageSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/buildTool/MavenPackageSpec.groovy
@@ -4,9 +4,11 @@ import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.test.CommandSpec
 import spock.lang.Requires
+import spock.lang.Retry
 import spock.lang.Unroll
 import spock.util.environment.Jvm
 
+@Retry // sometimes CI gets connection failure/reset resolving dependencies from Maven central
 class MavenPackageSpec extends CommandSpec {
 
     @Override

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
@@ -9,6 +9,7 @@ import io.micronaut.starter.test.CommandSpec
 import spock.lang.Retry
 import spock.lang.Unroll
 
+@Retry // can fail on CI due to port binding race condition, so retry
 class CreateAzureFunctionSpec extends CommandSpec {
 
     @Override
@@ -16,7 +17,6 @@ class CreateAzureFunctionSpec extends CommandSpec {
         "test-azure-function"
     }
 
-    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features azure-function #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                 Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.ApplicationTypeCombinations
 import io.micronaut.starter.test.CommandSpec
+import spock.lang.Retry
 import spock.lang.Unroll
 
 class CreateAzureFunctionSpec extends CommandSpec {
@@ -15,6 +16,7 @@ class CreateAzureFunctionSpec extends CommandSpec {
         "test-azure-function"
     }
 
+    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features azure-function #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                 Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/gcp/CreateGoogleCloudFunctionSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/gcp/CreateGoogleCloudFunctionSpec.groovy
@@ -12,13 +12,13 @@ import spock.lang.Unroll
 import spock.util.environment.Jvm
 
 @Requires({Jvm.current.isJava11Compatible()})
+@Retry // can fail on CI due to port binding race condition, so retry
 class CreateGoogleCloudFunctionSpec extends CommandSpec{
     @Override
     String getTempDirectoryPrefix() {
         "test-gcpfunction"
     }
 
-    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features google-cloud-function #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                            Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/gcp/CreateGoogleCloudFunctionSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/gcp/CreateGoogleCloudFunctionSpec.groovy
@@ -6,8 +6,8 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.ApplicationTypeCombinations
 import io.micronaut.starter.test.CommandSpec
-import spock.lang.IgnoreIf
 import spock.lang.Requires
+import spock.lang.Retry
 import spock.lang.Unroll
 import spock.util.environment.Jvm
 
@@ -18,6 +18,7 @@ class CreateGoogleCloudFunctionSpec extends CommandSpec{
         "test-gcpfunction"
     }
 
+    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features google-cloud-function #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                            Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/gcp/CreateGoogleCloudRawFunctionSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/gcp/CreateGoogleCloudRawFunctionSpec.groovy
@@ -12,13 +12,13 @@ import spock.lang.Unroll
 import spock.util.environment.Jvm
 
 @Requires({ Jvm.current.isJava11Compatible()})
+@Retry // can fail on CI due to port binding race condition, so retry
 class CreateGoogleCloudRawFunctionSpec extends CommandSpec {
     @Override
     String getTempDirectoryPrefix() {
         "test-gcpfunctionraw"
     }
 
-    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features google-cloud-function #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                 Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/gcp/CreateGoogleCloudRawFunctionSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/gcp/CreateGoogleCloudRawFunctionSpec.groovy
@@ -7,6 +7,7 @@ import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.ApplicationTypeCombinations
 import io.micronaut.starter.test.CommandSpec
 import spock.lang.Requires
+import spock.lang.Retry
 import spock.lang.Unroll
 import spock.util.environment.Jvm
 
@@ -17,6 +18,7 @@ class CreateGoogleCloudRawFunctionSpec extends CommandSpec {
         "test-gcpfunctionraw"
     }
 
+    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features google-cloud-function #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                 Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleFunctionSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleFunctionSpec.groovy
@@ -9,13 +9,13 @@ import io.micronaut.starter.test.CommandSpec
 import spock.lang.Retry
 import spock.lang.Unroll
 
+@Retry // can fail on CI due to port binding race condition, so retry
 class CreateOracleFunctionSpec extends CommandSpec{
     @Override
     String getTempDirectoryPrefix() {
         "test-oraclefunction"
     }
 
-    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features oracle-function #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                            Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleFunctionSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleFunctionSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.ApplicationTypeCombinations
 import io.micronaut.starter.test.CommandSpec
+import spock.lang.Retry
 import spock.lang.Unroll
 
 class CreateOracleFunctionSpec extends CommandSpec{
@@ -14,6 +15,7 @@ class CreateOracleFunctionSpec extends CommandSpec{
         "test-oraclefunction"
     }
 
+    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features oracle-function #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                            Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleRawFunctionSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleRawFunctionSpec.groovy
@@ -9,13 +9,13 @@ import io.micronaut.starter.test.CommandSpec
 import spock.lang.Retry
 import spock.lang.Unroll
 
+@Retry // can fail on CI due to port binding race condition, so retry
 class CreateOracleRawFunctionSpec extends CommandSpec{
     @Override
     String getTempDirectoryPrefix() {
         "test-raw-oraclefunction"
     }
 
-    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features oracle-function #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                      Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleRawFunctionSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleRawFunctionSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.ApplicationTypeCombinations
 import io.micronaut.starter.test.CommandSpec
+import spock.lang.Retry
 import spock.lang.Unroll
 
 class CreateOracleRawFunctionSpec extends CommandSpec{
@@ -14,6 +15,7 @@ class CreateOracleRawFunctionSpec extends CommandSpec{
         "test-raw-oraclefunction"
     }
 
+    @Retry // can fail on CI due to port binding race condition, so retry
     @Unroll
     void 'create-#applicationType with features oracle-function #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                      Language lang,

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateAppSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateAppSpec.groovy
@@ -4,8 +4,10 @@ import io.micronaut.starter.test.CommandSpec
 import io.micronaut.starter.test.LanguageBuildCombinations
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
+import spock.lang.Retry
 import spock.lang.Unroll
 
+@Retry // sometimes CI gets connection failure/reset resolving dependencies from Maven central
 class CreateAppSpec extends CommandSpec {
 
     @Unroll

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateAsciidoctorSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateAsciidoctorSpec.groovy
@@ -4,8 +4,10 @@ import io.micronaut.starter.test.CommandSpec
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.test.LanguageBuildCombinations
+import spock.lang.Retry
 import spock.lang.Unroll
 
+@Retry // sometimes CI gets connection failure/reset resolving dependencies from Maven central
 class CreateAsciidoctorSpec extends CommandSpec {
 
     @Unroll

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateCliSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateCliSpec.groovy
@@ -5,8 +5,10 @@ import io.micronaut.starter.test.CommandSpec
 import io.micronaut.starter.test.LanguageBuildCombinations
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
+import spock.lang.Retry
 import spock.lang.Unroll
 
+@Retry // sometimes CI gets connection failure/reset resolving dependencies from Maven central
 class CreateCliSpec extends CommandSpec {
 
     @Override

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateGrpcSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateGrpcSpec.groovy
@@ -9,8 +9,10 @@ import io.micronaut.starter.test.CommandSpec
 import io.micronaut.starter.test.LanguageBuildCombinations
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
+import spock.lang.Retry
 import spock.lang.Unroll
 
+@Retry // sometimes CI gets connection failure/reset resolving dependencies from Maven central
 class CreateGrpcSpec extends CommandSpec {
     @Override
     String getTempDirectoryPrefix() {

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateMessagingSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateMessagingSpec.groovy
@@ -7,12 +7,14 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.test.CommandSpec
 import io.micronaut.starter.test.LanguageBuildCombinations
 import org.gradle.testkit.runner.UnexpectedBuildFailure
+import spock.lang.Retry
 import spock.lang.Unroll
 
 import java.util.stream.Collectors
 
 import static io.micronaut.starter.options.BuildTool.MAVEN
 
+@Retry // sometimes CI gets connection failure/reset resolving dependencies from Maven central
 class CreateMessagingSpec extends CommandSpec {
 
     @Override

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/KtorSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/KtorSpec.groovy
@@ -5,10 +5,10 @@ import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.test.BuildToolCombinations
 import io.micronaut.starter.test.CommandSpec
-import spock.lang.PendingFeature
+import spock.lang.Retry
 import spock.lang.Unroll
-import spock.util.concurrent.PollingConditions
 
+@Retry // sometimes CI gets connection failure/reset resolving dependencies from Maven central
 class KtorSpec extends CommandSpec {
 
     @Unroll

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/feature/testcontainers/TestcontainersSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/feature/testcontainers/TestcontainersSpec.groovy
@@ -1,5 +1,8 @@
 package io.micronaut.starter.core.test.feature.testcontainers
 
+import io.micronaut.starter.core.test.feature.testcontainers.book
+import io.micronaut.starter.core.test.feature.testcontainers.bookRepository
+import io.micronaut.starter.core.test.feature.testcontainers.bookRepositoryTest
 import io.micronaut.starter.feature.database.DatabaseDriverFeature
 import io.micronaut.starter.io.ConsoleOutput
 import io.micronaut.starter.io.FileSystemOutputHandler
@@ -7,13 +10,12 @@ import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.template.RockerWritable
 import io.micronaut.starter.test.CommandSpec
-import io.micronaut.starter.core.test.feature.testcontainers.bookRepository
-import io.micronaut.starter.core.test.feature.testcontainers.bookRepositoryTest
-import io.micronaut.starter.core.test.feature.testcontainers.book
+import spock.lang.Retry
 import spock.lang.Unroll
 
 import java.util.stream.Collectors
 
+@Retry // sometimes CI gets connection failure/reset resolving dependencies from Maven central
 class TestcontainersSpec extends CommandSpec {
 
     @Override


### PR DESCRIPTION
Fixes #631 