### PR TITLE
Update installHomebrew.adoc

### DIFF
--- a/src/main/docs/guide/installation/installHomebrew.adoc
+++ b/src/main/docs/guide/installation/installHomebrew.adoc
@@ -2,7 +2,7 @@ In order to install Micronaut, run following command:
 
 [source,bash]
 ----
-$ brew cask install micronaut-projects/tap/micronaut
+$ brew install --cask micronaut-projects/tap/micronaut
 ----
 
 You can find more information about Homebrew usage on their https://brew.sh/[homepage].


### PR DESCRIPTION
`brew cask install` is deprecated and doesn't even work in latest homebrew. A way to do this now is `brew install --cask`.