### PR TITLE
test: BuildBuilder to decouple test from rocker

### DIFF
--- a/starter-core/src/test/groovy/io/micronaut/starter/ApplicationContextSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/ApplicationContextSpec.groovy
@@ -1,0 +1,59 @@
+package io.micronaut.starter
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.version.SemanticVersion
+import io.micronaut.starter.fixture.ContextFixture
+import io.micronaut.starter.fixture.ProjectFixture
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+abstract class ApplicationContextSpec extends Specification implements ProjectFixture, ContextFixture {
+
+    Map<String, Object> getConfiguration() {
+        [:]
+    }
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext beanContext = ApplicationContext.run(configuration)
+
+    protected static Optional<SemanticVersion> parsePropertySemanticVersion(String template, String propertyName) {
+        List<String> lines = template.split("\n")
+        for (String line : lines) {
+            if (line.contains("<" + propertyName + ">") && line.contains("</" + propertyName + ">")) {
+                String version = line.substring(line.indexOf("<" + propertyName + ">") + ("<" + propertyName + ">").length(), line.indexOf("</" + propertyName + ">"))
+                return Optional.of(new SemanticVersion(version))
+            }
+        }
+        return Optional.empty()
+    }
+
+    protected static Optional<SemanticVersion> parseDependencySemanticVersion(String template, String groupArtifactId) {
+        List<String> lines = template.split("\n")
+        for (String line : lines) {
+            if (line.contains(groupArtifactId)) {
+                String str = line.substring(line.indexOf(groupArtifactId) + groupArtifactId.length() + ":".length())
+                String version = str.substring(0, str.indexOf("\")"))
+                return Optional.of(new SemanticVersion(version))
+            }
+        }
+        return Optional.empty()
+    }
+
+    protected static Optional<String> parseCommunityGradlePluginVersion(String gradlePluginId, String template) {
+        String applyPlugin = 'id("' + gradlePluginId + '") version "'
+        List<String> lines = template.split('\n')
+        String pluginLine = lines.find { line ->
+            line.contains(applyPlugin)
+        }
+        if (!pluginLine) {
+            return Optional.empty()
+        }
+        String version = pluginLine.substring(pluginLine.indexOf(applyPlugin) + applyPlugin.length())
+        if (version.endsWith('"')) {
+            version = version.substring(0, version.length() - 1)
+        }
+        Optional.of(version)
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/BuildBuilder.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/BuildBuilder.groovy
@@ -1,0 +1,97 @@
+package io.micronaut.starter
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanContext
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.application.Project
+import io.micronaut.starter.application.generator.GeneratorContext
+import io.micronaut.starter.build.Property
+import io.micronaut.starter.feature.Features
+import io.micronaut.starter.fixture.ContextFixture
+import io.micronaut.starter.fixture.ProjectFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
+import io.micronaut.starter.feature.build.gradle.templates.buildGradle
+import io.micronaut.starter.feature.build.maven.templates.pom
+
+class BuildBuilder implements ProjectFixture, ContextFixture {
+
+    BuildTool buildTool
+    List<String> features
+    Language language
+    TestFramework testFramework
+    ApplicationType applicationType
+    JdkVersion jdkVersion
+    Project project
+    ApplicationContext ctx
+
+    BuildBuilder(ApplicationContext ctx, BuildTool buildTool) {
+        this.ctx = ctx
+        this.buildTool = buildTool
+    }
+
+    BuildBuilder features(List<String> features) {
+        this.features = features
+        this
+    }
+
+    BuildBuilder language(Language language) {
+        this.language = language
+        this
+    }
+
+    BuildBuilder testFramework(TestFramework testFramework) {
+        this.testFramework = testFramework
+        this
+    }
+
+    BuildBuilder applicationType(ApplicationType applicationType) {
+        this.applicationType = applicationType
+        this
+    }
+
+    BuildBuilder jdkVersion(JdkVersion jdkVersion) {
+        this.jdkVersion = jdkVersion
+        this
+    }
+
+    BuildBuilder project(Project project) {
+        this.project = project
+        this
+    }
+
+    String render() {
+        List<String> featureNames = this.features ?: []
+        Language language = this.language ?: Language.DEFAULT_OPTION
+        TestFramework testFramework = this.testFramework ?: language.defaults.test
+        ApplicationType type = this.applicationType ?: ApplicationType.DEFAULT
+        Project project = this.project ?: buildProject()
+        JdkVersion jdkVersion = this.jdkVersion ?: JdkVersion.JDK_8
+
+        Options options = new Options(language, testFramework, buildTool, jdkVersion)
+        Features features = getFeatures(featureNames, options, type)
+        if (buildTool.isGradle()) {
+            return buildGradle.template(type, project, features, buildTool == BuildTool.GRADLE_KOTLIN).render().toString()
+        } else if (buildTool == BuildTool.MAVEN) {
+            GeneratorContext ctx = createGeneratorContextAndApplyFeatures(options, features, project, type)
+            List<Property> properties = ctx.getBuildProperties().getProperties()
+            return pom.template(type, project, features, properties).render().toString()
+        }
+        null
+
+    }
+
+    GeneratorContext createGeneratorContextAndApplyFeatures(Options options, Features features, Project project, ApplicationType type) {
+        GeneratorContext ctx = new GeneratorContext(project, type, options, null, features.features)
+        features.features.each {feat -> feat.apply(ctx)}
+        ctx
+    }
+
+    @Override
+    BeanContext getBeanContext() {
+        ctx
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/GroovySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/GroovySpec.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.starter.feature
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+
+class GroovySpec extends ApplicationContextSpec {
+
+    void "for Groovy Gradle applications groovy gradle plugin is applied"() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(Language.GROOVY)
+                .render()
+
+        then:
+        template.contains('id("groovy")')
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/SpockSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/SpockSpec.groovy
@@ -1,0 +1,28 @@
+package io.micronaut.starter.feature
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.application.Project
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
+import spock.lang.Unroll
+
+class SpockSpec extends ApplicationContextSpec {
+
+    @Unroll
+    void "for #language Gradle applications groovy gradle plugin is applied if Spock is used"(Language language) {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .testFramework(TestFramework.SPOCK)
+                .render()
+
+        then:
+        template.contains('id("groovy")')
+
+        where:
+        language << [Language.JAVA, Language.KOTLIN]
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/acme/AcmeSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/acme/AcmeSpec.groovy
@@ -1,15 +1,15 @@
 package io.micronaut.starter.feature.acme
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
 import spock.lang.Unroll
 
-class AcmeSpec extends BeanContextSpec implements CommandOutputFixture {
+class AcmeSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature acme contains links to micronaut docs'() {
         when:
@@ -24,7 +24,10 @@ class AcmeSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle acme feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['acme'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['acme'])
+                .render()
 
         then:
         template.contains('implementation "io.micronaut.acme:micronaut-acme')
@@ -36,7 +39,10 @@ class AcmeSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven acme feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['acme'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['acme'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AWSSDKv2Spec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AWSSDKv2Spec.groovy
@@ -1,20 +1,21 @@
 package io.micronaut.starter.feature.aws
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 
-
-class AWSSDKv2Spec extends BeanContextSpec  implements CommandOutputFixture {
+class AWSSDKv2Spec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     @Unroll
     void 'test Oracle Cloud SDK feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['aws-v2-sdk'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['aws-v2-sdk'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.aws:micronaut-aws-sdk-v2")')
@@ -26,7 +27,10 @@ class AWSSDKv2Spec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test maven jmx feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['aws-v2-sdk'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['aws-v2-sdk'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/awsalexa/AwsAlexaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/awsalexa/AwsAlexaSpec.groovy
@@ -1,19 +1,18 @@
 package io.micronaut.starter.feature.awsalexa
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Shared
 import spock.lang.Subject
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
-import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class AwsAlexaSpec extends BeanContextSpec implements CommandOutputFixture {
+class AwsAlexaSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Shared
     @Subject
@@ -58,7 +57,11 @@ class AwsAlexaSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle aws-alexa feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.FUNCTION, buildProject(), getFeatures(['aws-alexa'], language, null, BuildTool.GRADLE, ApplicationType.FUNCTION), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['aws-alexa'])
+                .applicationType(ApplicationType.FUNCTION)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.aws:micronaut-function-aws-alexa")')
@@ -70,8 +73,11 @@ class AwsAlexaSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven aws-alexa feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.FUNCTION, buildProject(),
-                getFeatures(['aws-alexa'], language, null, BuildTool.GRADLE, ApplicationType.FUNCTION), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['aws-alexa'])
+                .applicationType(ApplicationType.FUNCTION)
+                .render()
 
         then:
         template.contains("""
@@ -87,11 +93,13 @@ class AwsAlexaSpec extends BeanContextSpec implements CommandOutputFixture {
     }
 
 
-
     @Unroll
     void 'default app with gradle aws-alexa feature for language=#language'(Language language) {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['aws-alexa'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['aws-alexa'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.aws:micronaut-aws-alexa-httpserver")')
@@ -103,7 +111,10 @@ class AwsAlexaSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'default app with maven aws-alexa feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['aws-alexa'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['aws-alexa'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/awslambdacustomruntime/AwsLambdaCustomRuntimeSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/awslambdacustomruntime/AwsLambdaCustomRuntimeSpec.groovy
@@ -1,9 +1,8 @@
 package io.micronaut.starter.feature.awslambdacustomruntime
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
@@ -14,7 +13,7 @@ import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class AwsLambdaCustomRuntimeSpec extends BeanContextSpec  implements CommandOutputFixture {
+class AwsLambdaCustomRuntimeSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     @Shared
     @Subject
@@ -138,7 +137,10 @@ class AwsLambdaCustomRuntimeSpec extends BeanContextSpec  implements CommandOutp
     @Unroll
     void 'test gradle aws-lambda-custom-runtime feature for language=#language and application: default'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['aws-lambda-custom-runtime'], language, null, BuildTool.GRADLE, ApplicationType.DEFAULT), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['aws-lambda-custom-runtime'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.aws:micronaut-function-aws-custom-runtime")')
@@ -150,7 +152,11 @@ class AwsLambdaCustomRuntimeSpec extends BeanContextSpec  implements CommandOutp
     @Unroll
     void 'test gradle aws-lambda-custom-runtime feature for language=#language and application: function'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['aws-lambda-custom-runtime'], language, null, BuildTool.GRADLE, ApplicationType.FUNCTION), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['aws-lambda-custom-runtime'])
+                .applicationType(ApplicationType.FUNCTION)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.aws:micronaut-function-aws-custom-runtime")')
@@ -162,7 +168,10 @@ class AwsLambdaCustomRuntimeSpec extends BeanContextSpec  implements CommandOutp
     @Unroll
     void 'test maven aws-lambda-custom-runtime feature for language=#language and application: #applicationType'(Language language, ApplicationType applicationType) {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['aws-lambda-custom-runtime'], language, null, BuildTool.MAVEN,applicationType), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['aws-lambda-custom-runtime'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/CaffeineSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/CaffeineSpec.groovy
@@ -1,14 +1,14 @@
 package io.micronaut.starter.feature.cache
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class CaffeineSpec extends BeanContextSpec implements CommandOutputFixture {
+class CaffeineSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature cache-caffeine contains links to micronaut docs'() {
         when:
@@ -24,7 +24,10 @@ class CaffeineSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle cache-caffeine feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['cache-caffeine'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['cache-caffeine'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.cache:micronaut-cache-caffeine")')
@@ -36,8 +39,10 @@ class CaffeineSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven cache-caffeine feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['cache-caffeine'], language), []).render().toString()
-
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['cache-caffeine'])
+                .render()
         then:
         template.contains("""
     <dependency>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/EHCacheSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/EHCacheSpec.groovy
@@ -1,15 +1,14 @@
 package io.micronaut.starter.feature.cache
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class EHCacheSpec extends BeanContextSpec implements CommandOutputFixture {
+class EHCacheSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature cache-ehcache contains links to micronaut docs'() {
         when:
@@ -25,7 +24,10 @@ class EHCacheSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle cache-ehcache feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['cache-ehcache'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['cache-ehcache'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.cache:micronaut-cache-ehcache")')
@@ -37,7 +39,10 @@ class EHCacheSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven cache-ehcache feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['cache-ehcache'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['cache-ehcache'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/HazelcastSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/HazelcastSpec.groovy
@@ -1,15 +1,14 @@
 package io.micronaut.starter.feature.cache
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class HazelcastSpec extends BeanContextSpec implements CommandOutputFixture {
+class HazelcastSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Unroll
     void 'test readme.md contains links to hazelcast and micronaut docs'() {
@@ -26,7 +25,10 @@ class HazelcastSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle cache-hazelcast feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['cache-hazelcast'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['cache-hazelcast'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.cache:micronaut-cache-hazelcast")')
@@ -38,7 +40,10 @@ class HazelcastSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven cache-hazelcast feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['cache-hazelcast'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['cache-hazelcast'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/InfinispanSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/cache/InfinispanSpec.groovy
@@ -1,15 +1,14 @@
 package io.micronaut.starter.feature.cache
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class InfinispanSpec extends BeanContextSpec  implements CommandOutputFixture {
+class InfinispanSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature cache-infinispan contains links to micronaut docs'() {
         when:
@@ -25,7 +24,10 @@ class InfinispanSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test gradle cache-infinispan feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['cache-infinispan'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['cache-infinispan'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.cache:micronaut-cache-infinispan")')
@@ -37,7 +39,10 @@ class InfinispanSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test maven cache-infinispan feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['cache-infinispan'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['cache-infinispan'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/CassandraSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/CassandraSpec.groovy
@@ -1,19 +1,21 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class CassandraSpec extends BeanContextSpec {
+class CassandraSpec extends ApplicationContextSpec {
 
     @Unroll
     void 'test gradle cassandra feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['cassandra'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['cassandra'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.cassandra:micronaut-cassandra")')
@@ -25,7 +27,10 @@ class CassandraSpec extends BeanContextSpec {
     @Unroll
     void 'test maven cassandra feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['cassandra'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['cassandra'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataJdbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataJdbcSpec.groovy
@@ -1,14 +1,15 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.core.version.SemanticVersion
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
 
-class DataJdbcSpec extends BeanContextSpec  implements CommandOutputFixture {
+class DataJdbcSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature data-jdbc contains links to micronaut docs'() {
         when:
@@ -33,50 +34,60 @@ class DataJdbcSpec extends BeanContextSpec  implements CommandOutputFixture {
 
     void "test dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["data-jdbc"]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["data-jdbc"])
+                .render()
 
         then:
-        template.contains("annotationProcessor(\"io.micronaut.data:micronaut-data-processor\")")
+        template.contains('annotationProcessor("io.micronaut.data:micronaut-data-processor")')
         template.contains('implementation("io.micronaut.data:micronaut-data-jdbc")')
         template.contains('implementation("io.micronaut.sql:micronaut-jdbc-hikari")')
-        template.contains("runtimeOnly(\"com.h2database:h2\")")
+        template.contains('runtimeOnly("com.h2database:h2")')
     }
 
     void "test dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["data-jdbc"]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['data-jdbc'])
+                .render()
 
         then:
         //src/main
-        template.contains("""
+        template.contains('''
             <path>
               <groupId>io.micronaut.data</groupId>
               <artifactId>micronaut-data-processor</artifactId>
-              <version>\${micronaut.data.version}</version>
+              <version>${micronaut.data.version}</version>
             </path>
-""")
-
-        template.contains("""
+''')
+        template.contains('''
     <dependency>
       <groupId>io.micronaut.data</groupId>
       <artifactId>micronaut-data-jdbc</artifactId>
       <scope>compile</scope>
     </dependency>
-""")
-        template.contains("""
+''')
+        template.contains('''
     <dependency>
       <groupId>io.micronaut.sql</groupId>
       <artifactId>micronaut-jdbc-hikari</artifactId>
       <scope>compile</scope>
     </dependency>
-""")
-        template.contains("""
+''')
+        template.contains('''
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>runtime</scope>
     </dependency>
-""")
+''')
+
+        when:
+        Optional<SemanticVersion> semanticVersionOptional = parsePropertySemanticVersion(template, "micronaut.data.version")
+
+        then:
+        noExceptionThrown()
+        semanticVersionOptional.isPresent()
     }
 
     void "test config"() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateGormSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateGormSpec.groovy
@@ -1,13 +1,13 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
 
-class HibernateGormSpec extends BeanContextSpec {
+class HibernateGormSpec extends ApplicationContextSpec {
 
     void "test hibernate gorm features"() {
         when:
@@ -22,7 +22,10 @@ class HibernateGormSpec extends BeanContextSpec {
 
     void "test dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["hibernate-gorm"]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["hibernate-gorm"])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.groovy:micronaut-hibernate-gorm")')
@@ -33,7 +36,10 @@ class HibernateGormSpec extends BeanContextSpec {
 
     void "test dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["hibernate-gorm"]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['hibernate-gorm'])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateJpaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateJpaSpec.groovy
@@ -1,16 +1,15 @@
 package io.micronaut.starter.feature.database
 
-
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.core.version.SemanticVersion
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 
-class HibernateJpaSpec extends BeanContextSpec  implements CommandOutputFixture {
+class HibernateJpaSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature hibernate-jpa contains links to micronaut docs'() {
         when:
@@ -34,7 +33,9 @@ class HibernateJpaSpec extends BeanContextSpec  implements CommandOutputFixture 
 
     void "test dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["hibernate-jpa"]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["hibernate-jpa"])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.sql:micronaut-hibernate-jpa")')
@@ -43,15 +44,32 @@ class HibernateJpaSpec extends BeanContextSpec  implements CommandOutputFixture 
 
     void "test kotlin jpa plugin is present for gradle kotlin project"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["hibernate-jpa"], Language.KOTLIN), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["hibernate-jpa"])
+                .language(Language.KOTLIN)
+                .render()
+
+        String pluginId = 'org.jetbrains.kotlin.plugin.jpa'
+        String applyPlugin = 'id("' + pluginId + '") version "'
 
         then:
-        template.contains('id("org.jetbrains.kotlin.plugin.jpa")')
+        template.contains(applyPlugin)
+
+        when:
+        Optional<SemanticVersion> semanticVersionOptional = parseCommunityGradlePluginVersion(pluginId, template).map(SemanticVersion::new)
+
+        then:
+        noExceptionThrown()
+        semanticVersionOptional.isPresent()
+
     }
 
     void "test kotlin jpa plugin is present for maven kotlin project"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["hibernate-jpa"], Language.KOTLIN), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['hibernate-jpa'])
+                .language(Language.KOTLIN)
+                .render()
 
         then:
         //src/main
@@ -65,7 +83,9 @@ class HibernateJpaSpec extends BeanContextSpec  implements CommandOutputFixture 
 
     void "test dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["hibernate-jpa"]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['hibernate-jpa'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/JAsyncSQLSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/JAsyncSQLSpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class JAsyncSQLSpec extends BeanContextSpec implements CommandOutputFixture {
+class JAsyncSQLSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature jasync-sql contains links to micronaut and 3rd party docs'() {
         when:
@@ -75,7 +74,10 @@ jasync:
     @Unroll
     void 'test gradle jasync-sql feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['jasync-sql','mysql'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['jasync-sql','mysql'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.sql:micronaut-jasync-sql")')
@@ -87,7 +89,10 @@ jasync:
     @Unroll
     void 'test maven jasync-sql feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['jasync-sql','mysql'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['jasync-sql','mysql'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/JooqSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/JooqSpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class JooqSpec extends BeanContextSpec  implements CommandOutputFixture {
+class JooqSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature jooq contains links to micronaut docs'() {
         when:
@@ -23,7 +22,10 @@ class JooqSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test gradle jooq feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['jooq'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['jooq'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.sql:micronaut-jooq")')
@@ -35,7 +37,10 @@ class JooqSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test maven jooq feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['jooq'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['jooq'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MariaDBSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MariaDBSpec.groovy
@@ -1,18 +1,20 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class MariaDBSpec extends BeanContextSpec {
+class MariaDBSpec extends ApplicationContextSpec {
 
     @Unroll
     void 'test gradle mariadb feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['mariadb'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['mariadb'])
+                .language(language)
+                .render()
 
         then:
         template.contains('runtimeOnly("org.mariadb.jdbc:mariadb-java-client")')
@@ -24,7 +26,10 @@ class MariaDBSpec extends BeanContextSpec {
     @Unroll
     void 'test maven mariadb feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['mariadb'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['mariadb'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MongoGormSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MongoGormSpec.groovy
@@ -1,18 +1,16 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
-import io.micronaut.starter.options.TestFramework
 
-class MongoGormSpec extends BeanContextSpec implements CommandOutputFixture {
+class MongoGormSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature mongo-sync contains links to micronaut and 3rd party docs'() {
         when:
@@ -39,7 +37,10 @@ class MongoGormSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["mongo-gorm"]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["mongo-gorm"])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.groovy:micronaut-mongo-gorm")')
@@ -48,8 +49,10 @@ class MongoGormSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test testcontainers dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(),
-                getFeatures(["mongo-gorm", "testcontainers"], Language.GROOVY, TestFramework.SPOCK), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["mongo-gorm", "testcontainers"])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.groovy:micronaut-mongo-gorm")')
@@ -61,7 +64,10 @@ class MongoGormSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["mongo-gorm"]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['mongo-gorm'])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MongoSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MongoSpec.groovy
@@ -1,14 +1,14 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
 
-class MongoSpec extends BeanContextSpec implements CommandOutputFixture {
+class MongoSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature mongo-sync contains links to micronaut and 3rd party docs'() {
         when:
@@ -31,8 +31,9 @@ class MongoSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test mongo sync dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(),
-                getFeatures(["mongo-sync"]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["mongo-sync"])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.mongodb:micronaut-mongo-sync")')
@@ -41,7 +42,9 @@ class MongoSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test mongo sync dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["mongo-sync"]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['mongo-sync'])
+                .render()
 
         then:
         template.contains("""
@@ -81,8 +84,9 @@ class MongoSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["mongo-reactive"]), false).render().toString()
-
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["mongo-reactive"])
+                .render()
         then:
         template.contains('implementation("io.micronaut.mongodb:micronaut-mongo-reactive")')
         template.contains('testImplementation("org.testcontainers:mongodb")')
@@ -90,7 +94,9 @@ class MongoSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["mongo-reactive"]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['mongo-reactive'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MySQLSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MySQLSpec.groovy
@@ -1,18 +1,20 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class MySQLSpec extends BeanContextSpec {
+class MySQLSpec extends ApplicationContextSpec {
 
     @Unroll
     void 'test gradle mysql feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['mysql'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['mysql'])
+                .language(language)
+                .render()
 
         then:
         template.contains('runtimeOnly("mysql:mysql-connector-java")')
@@ -24,7 +26,10 @@ class MySQLSpec extends BeanContextSpec {
     @Unroll
     void 'test maven mysql feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['mysql'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['mysql'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/Neo4jBoltSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/Neo4jBoltSpec.groovy
@@ -1,15 +1,14 @@
 package io.micronaut.starter.feature.database
 
-
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
 
-class Neo4jBoltSpec extends BeanContextSpec  implements CommandOutputFixture {
+class Neo4jBoltSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature neo4j-bolt contains links to micronaut docs'() {
         when:
@@ -31,7 +30,9 @@ class Neo4jBoltSpec extends BeanContextSpec  implements CommandOutputFixture {
 
     void "test dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["neo4j-bolt"]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["neo4j-bolt"])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.neo4j:micronaut-neo4j-bolt")')
@@ -40,7 +41,9 @@ class Neo4jBoltSpec extends BeanContextSpec  implements CommandOutputFixture {
 
     void "test dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["neo4j-bolt"]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['neo4j-bolt'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/Neo4jGormSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/Neo4jGormSpec.groovy
@@ -1,13 +1,13 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
 
-class Neo4jGormSpec extends BeanContextSpec {
+class Neo4jGormSpec extends ApplicationContextSpec {
 
     void "test neo4j gorm features"() {
         when:
@@ -21,7 +21,10 @@ class Neo4jGormSpec extends BeanContextSpec {
 
     void "test dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["neo4j-gorm"]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["neo4j-gorm"])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.groovy:micronaut-neo4j-gorm")')
@@ -31,7 +34,10 @@ class Neo4jGormSpec extends BeanContextSpec {
 
     void "test dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["neo4j-gorm"]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['neo4j-gorm'])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/OracleSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/OracleSpec.groovy
@@ -1,22 +1,24 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.feature.database.r2dbc.R2dbcFeature
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
 import java.util.stream.Collectors
 
-class OracleSpec extends BeanContextSpec implements CommandOutputFixture {
+class OracleSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Unroll
     void 'test gradle oracle feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['oracle'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['oracle'])
+                .language(language)
+                .render()
 
         then:
         template.contains('runtimeOnly("com.oracle.database.jdbc:ojdbc8")')
@@ -28,7 +30,10 @@ class OracleSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven oracle feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['oracle'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['oracle'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/PostgreSQLSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/PostgreSQLSpec.groovy
@@ -1,19 +1,20 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class PostgreSQLSpec extends BeanContextSpec {
+class PostgreSQLSpec extends ApplicationContextSpec {
 
     @Unroll
     void 'test gradle postgres feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['postgres'], language), false).render().toString()
-
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['postgres'])
+                .language(language)
+                .render()
         then:
         template.contains('runtimeOnly("org.postgresql:postgresql")')
 
@@ -24,7 +25,10 @@ class PostgreSQLSpec extends BeanContextSpec {
     @Unroll
     void 'test maven postgres feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['postgres'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['postgres'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/SQLServerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/SQLServerSpec.groovy
@@ -1,18 +1,20 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class SQLServerSpec extends BeanContextSpec {
+class SQLServerSpec extends ApplicationContextSpec {
 
     @Unroll
     void 'test gradle sqlserver feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['sqlserver'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['sqlserver'])
+                .language(language)
+                .render()
 
         then:
         template.contains('runtimeOnly("com.microsoft.sqlserver:mssql-jdbc")')
@@ -24,7 +26,10 @@ class SQLServerSpec extends BeanContextSpec {
     @Unroll
     void 'test maven sqlserver feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['sqlserver'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['sqlserver'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/TestContainersSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/TestContainersSpec.groovy
@@ -1,21 +1,22 @@
 package io.micronaut.starter.feature.database
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 
 import java.util.stream.Collectors
 
-class TestContainersSpec extends BeanContextSpec {
+class TestContainersSpec extends ApplicationContextSpec {
 
     void "test oracle dependency is present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'oracle']), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['testcontainers', 'oracle'])
+                .render()
 
         then:
         template.contains('testImplementation("org.testcontainers:oracle-xe")')
@@ -24,7 +25,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test mysql dependency is present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'mysql']), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['testcontainers', 'mysql'])
+                .render()
 
         then:
         template.contains('testImplementation("org.testcontainers:mysql")')
@@ -33,7 +36,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test postgres dependency is present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'postgres']), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['testcontainers', 'postgres'])
+                .render()
 
         then:
         template.contains('testImplementation("org.testcontainers:postgresql")')
@@ -42,7 +47,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test mariadb dependency is present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'mariadb']), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['testcontainers', 'mariadb'])
+                .render()
 
         then:
         template.contains('testImplementation("org.testcontainers:mariadb")')
@@ -51,7 +58,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test sqlserver dependency is present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'sqlserver']), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['testcontainers', 'sqlserver'])
+                .render()
 
         then:
         template.contains('testImplementation("org.testcontainers:mssqlserver")')
@@ -60,7 +69,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test mongo-reactive dependency is present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'mongo-reactive']), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['testcontainers', 'mongo-reactive'])
+                .render()
 
         then:
         template.contains('testImplementation("org.testcontainers:mongodb")')
@@ -69,7 +80,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test mongo-sync dependency is present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'mongo-sync']), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['testcontainers', 'mongo-sync'])
+                .render()
 
         then:
         template.contains('testImplementation("org.testcontainers:mongodb")')
@@ -78,8 +91,10 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test mongo-gorm dependency is present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(),
-                getFeatures(['testcontainers', 'mongo-gorm'], Language.GROOVY), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['testcontainers', 'mongo-gorm'])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains('testImplementation("org.testcontainers:mongodb")')
@@ -88,7 +103,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test testcontainers core is present when no testcontainer modules are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers']), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['testcontainers'])
+                .render()
 
         then:
         template.contains('testImplementation("org.testcontainers:testcontainers")')
@@ -96,8 +113,10 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "testframework dependency is present for gradle for feature #feature and spock framework"() {
         when:
-        def template = buildGradle.template(ApplicationType.DEFAULT, buildProject(),
-                getFeatures([feature], Language.DEFAULT_OPTION, TestFramework.SPOCK), false).render().toString()
+        def template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features([feature])
+                .testFramework(TestFramework.SPOCK)
+                .render()
 
         then:
         template.contains('testImplementation("org.testcontainers:spock")')
@@ -109,8 +128,10 @@ class TestContainersSpec extends BeanContextSpec {
     void "testframework dependency is present for gradle for feature #feature and junit framework"() {
 
         when:
-        def template = buildGradle.template(ApplicationType.DEFAULT, buildProject(),
-                getFeatures([feature], Language.DEFAULT_OPTION, TestFramework.JUNIT), false).render().toString()
+        def template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features([feature])
+                .testFramework(TestFramework.JUNIT)
+                .render()
 
         then:
         template.contains('testImplementation("org.testcontainers:junit-jupiter")')
@@ -121,7 +142,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test oracle dependency is present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'oracle']), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['testcontainers', 'oracle'])
+                .render()
 
         then:
         template.contains("""
@@ -142,7 +165,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test mysql dependency is present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'mysql']), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['testcontainers', 'mysql'])
+                .render()
 
         then:
         template.contains("""
@@ -163,7 +188,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test postgres dependency is present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'postgres']), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['testcontainers', 'postgres'])
+                .render()
 
         then:
         template.contains("""
@@ -184,7 +211,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test mariadb dependency is present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'mariadb']), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['testcontainers', 'mariadb'])
+                .render()
 
         then:
         template.contains("""
@@ -205,7 +234,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test sqlserver dependency is present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'sqlserver']), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['testcontainers', 'sqlserver'])
+                .render()
 
         then:
         template.contains("""
@@ -226,7 +257,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test mongo-reactive dependency is present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'mongo-reactive']), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['testcontainers', 'mongo-reactive'])
+                .render()
 
         then:
         template.contains("""
@@ -247,7 +280,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test mongo-sync dependency is present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', 'mongo-sync']), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['testcontainers', 'mongo-sync'])
+                .render()
 
         then:
         template.contains("""
@@ -268,8 +303,10 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test mongo-gorm dependency is present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(),
-                getFeatures(['testcontainers', 'mongo-gorm'], Language.GROOVY), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['testcontainers', 'mongo-gorm'])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains("""
@@ -290,7 +327,9 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test testcontainers dependency is present and no testcontainer modules are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers']), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['testcontainers'])
+                .render()
 
         then:
         template.contains("""
@@ -304,8 +343,10 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "testframework dependency is present for maven for feature #feature and spock framework"() {
         when:
-        def template = pom.template(ApplicationType.DEFAULT, buildProject(),
-                getFeatures([feature], Language.DEFAULT_OPTION, TestFramework.SPOCK, BuildTool.MAVEN,ApplicationType.DEFAULT),[]).render().toString()
+        def template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features([feature])
+                .testFramework(TestFramework.SPOCK)
+                .render()
 
         then:
         template.contains("""
@@ -323,8 +364,10 @@ class TestContainersSpec extends BeanContextSpec {
     void "testframework dependency is present for maven for feature #feature and junit framework"() {
 
         when:
-        def template = pom.template(ApplicationType.DEFAULT, buildProject(),
-                getFeatures([feature], Language.DEFAULT_OPTION, TestFramework.JUNIT, BuildTool.MAVEN,ApplicationType.DEFAULT),[]).render().toString()
+        def template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features([feature])
+                .testFramework(TestFramework.JUNIT)
+                .render()
 
         then:
         template.contains("""
@@ -341,8 +384,13 @@ class TestContainersSpec extends BeanContextSpec {
 
     void "test there is a dependency for every non embedded driver feature"() {
         when:
-        String mavenTemplate = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', driverFeature.getName()]), []).render().toString()
-        String gradleTemplate = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['testcontainers', driverFeature.getName()]), false).render().toString()
+        String mavenTemplate = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['testcontainers', driverFeature.getName()])
+                .render()
+
+        String gradleTemplate = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['testcontainers', driverFeature.getName()])
+                .render()
 
         then:
         gradleTemplate.contains("org.testcontainers")

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/jdbc/JdbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/jdbc/JdbcSpec.groovy
@@ -1,19 +1,21 @@
 package io.micronaut.starter.feature.database.jdbc
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class JdbcSpec extends BeanContextSpec implements CommandOutputFixture {
+class JdbcSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Unroll
     void "test gradle jdbc feature #jdbcFeature"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures([jdbcFeature]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features([jdbcFeature])
+                .render()
 
         then:
         template.contains("implementation(\"io.micronaut.sql:micronaut-${jdbcFeature}\")")
@@ -32,7 +34,9 @@ class JdbcSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void "test maven jdbc feature #jdbcFeature"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures([jdbcFeature]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features([jdbcFeature])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/R2dbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/R2dbcSpec.groovy
@@ -1,20 +1,21 @@
 package io.micronaut.starter.feature.database.r2dbc
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.feature.database.DatabaseDriverFeature
 import io.micronaut.starter.feature.database.jdbc.JdbcFeature
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import spock.lang.Unroll
 
-class R2dbcSpec extends BeanContextSpec implements CommandOutputFixture {
+class R2dbcSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Unroll
     void "test gradle r2dbc feature #driver"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["r2dbc", driver]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["r2dbc", driver])
+                .render()
         driver = getDriverName(driver)
 
         then:
@@ -28,7 +29,9 @@ class R2dbcSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void "test maven r2dbc feature #driver"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["r2dbc", driver]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(["r2dbc", driver])
+                .render()
         driver = getDriverName(driver)
         JdbcFeature jdbcFeature = beanContext.getBean(JdbcFeature)
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/dekorate/DekorateFeatureValidatorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/dekorate/DekorateFeatureValidatorSpec.groovy
@@ -1,16 +1,15 @@
 package io.micronaut.starter.feature.dekorate
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.feature.Feature
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Unroll
 
-class DekorateFeatureValidatorSpec extends BeanContextSpec implements CommandOutputFixture {
+class DekorateFeatureValidatorSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test feature #feature.name is not supported for Groovy and #buildTool'(Feature feature, BuildTool buildTool){
         when:
@@ -38,11 +37,13 @@ class DekorateFeatureValidatorSpec extends BeanContextSpec implements CommandOut
     }
 
     @Unroll
-    void 'test dekorate service feature #feature.name uses default platform feature for #language'(
-            Feature feature, Language language) {
+    void 'test dekorate service feature #feature.name uses default platform feature for #language'(Feature feature, Language language) {
         when:
-        pom.template(ApplicationType.DEFAULT, buildProject(),
-                getFeatures([feature.getName()], language, TestFramework.JUNIT, BuildTool.MAVEN), []).render().toString()
+        new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features([feature.getName()])
+                .testFramework(TestFramework.JUNIT)
+                .render()
 
         then:
         beanContext.containsBean(DekorateKubernetes)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryConsulSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryConsulSpec.groovy
@@ -1,16 +1,16 @@
 package io.micronaut.starter.feature.discovery
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
 import spock.lang.Issue
 import spock.lang.Unroll
 
-class DiscoveryConsulSpec extends BeanContextSpec  implements CommandOutputFixture {
+class DiscoveryConsulSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature discovery-consul contains links to micronaut docs'() {
         when:
@@ -26,7 +26,10 @@ class DiscoveryConsulSpec extends BeanContextSpec  implements CommandOutputFixtu
     @Unroll
     void 'test gradle discovery-consul feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['discovery-consul'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['discovery-consul'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.discovery:micronaut-discovery-client")')
@@ -38,7 +41,10 @@ class DiscoveryConsulSpec extends BeanContextSpec  implements CommandOutputFixtu
     @Unroll
     void 'test maven discovery-consul feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['discovery-consul'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['discovery-consul'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/EurekaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/EurekaSpec.groovy
@@ -1,15 +1,14 @@
 package io.micronaut.starter.feature.discovery
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class EurekaSpec extends BeanContextSpec implements CommandOutputFixture {
+class EurekaSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature discovery-eureka contains links to micronaut docs'() {
         when:
@@ -24,7 +23,10 @@ class EurekaSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle discovery-eureka feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['discovery-eureka'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['discovery-eureka'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.discovery:micronaut-discovery-client")')
@@ -36,7 +38,10 @@ class EurekaSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven discovery-eureka feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['discovery-eureka'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['discovery-eureka'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/distributedconfig/DistributedConfigConsulSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/distributedconfig/DistributedConfigConsulSpec.groovy
@@ -1,15 +1,14 @@
 package io.micronaut.starter.feature.distributedconfig
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class DistributedConfigConsulSpec extends BeanContextSpec  implements CommandOutputFixture {
+class DistributedConfigConsulSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature discovery-consul contains links to micronaut docs'() {
         when:
@@ -25,7 +24,10 @@ class DistributedConfigConsulSpec extends BeanContextSpec  implements CommandOut
     @Unroll
     void 'test gradle config-consul feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['config-consul'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['config-consul'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.discovery:micronaut-discovery-client")')
@@ -36,7 +38,9 @@ class DistributedConfigConsulSpec extends BeanContextSpec  implements CommandOut
 
     void 'test gradle config-consul multiple features'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['config-consul', 'discovery-consul']), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['config-consul', 'discovery-consul'])
+                .render()
 
         then:
         template.count('implementation("io.micronaut.discovery:micronaut-discovery-client")') == 1
@@ -45,7 +49,10 @@ class DistributedConfigConsulSpec extends BeanContextSpec  implements CommandOut
     @Unroll
     void 'test maven config-consul feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['config-consul'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['config-consul'])
+                .render()
 
         then:
         template.contains("""
@@ -62,7 +69,9 @@ class DistributedConfigConsulSpec extends BeanContextSpec  implements CommandOut
 
     void 'test maven config-consul multiple features'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['config-consul', 'discovery-consul']), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['config-consul', 'discovery-consul'])
+                .render()
 
         then:
         template.count("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/elasticsearch/ElasticsearchSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/elasticsearch/ElasticsearchSpec.groovy
@@ -1,16 +1,15 @@
 package io.micronaut.starter.feature.elasticsearch
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Requires
 import spock.lang.Unroll
 
-class ElasticsearchSpec extends BeanContextSpec  implements CommandOutputFixture {
+class ElasticsearchSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature elasticsearch contains links to micronaut docs'() {
         when:
@@ -25,7 +24,10 @@ class ElasticsearchSpec extends BeanContextSpec  implements CommandOutputFixture
     @Unroll
     void 'test gradle elasticsearch feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['elasticsearch'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['elasticsearch'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.elasticsearch:micronaut-elasticsearch")')
@@ -37,7 +39,10 @@ class ElasticsearchSpec extends BeanContextSpec  implements CommandOutputFixture
     @Unroll
     void 'test maven elasticsearch feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['elasticsearch'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['elasticsearch'])
+                .render()
 
         then:
         template.contains("""
@@ -64,7 +69,10 @@ class ElasticsearchSpec extends BeanContextSpec  implements CommandOutputFixture
     @Requires({ jvm.isJava8() || jvm.isJava11() })
     void 'test gradle elasticsearch and graalvm features for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['elasticsearch', 'graalvm'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['elasticsearch', 'graalvm'])
+                .language(language)
+                .render()
 
         then:
         template.contains('runtimeOnly("org.slf4j:log4j-over-slf4j:1.7.30")')
@@ -79,7 +87,10 @@ class ElasticsearchSpec extends BeanContextSpec  implements CommandOutputFixture
     @Requires({ jvm.isJava8() || jvm.isJava11() })
     void 'test maven elasticsearch and graalvm features for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['elasticsearch', 'graalvm'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['elasticsearch', 'graalvm'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/awslambda/AwsLambdaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/awslambda/AwsLambdaSpec.groovy
@@ -1,20 +1,15 @@
 package io.micronaut.starter.feature.function.awslambda
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
-import io.micronaut.starter.options.BuildTool
-import io.micronaut.starter.options.JdkVersion
-import io.micronaut.starter.options.Language
-import io.micronaut.starter.options.Options
-import io.micronaut.starter.options.TestFramework
+import io.micronaut.starter.options.*
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class AwsLambdaSpec extends BeanContextSpec implements CommandOutputFixture {
+class AwsLambdaSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Shared
     @Subject
@@ -68,7 +63,10 @@ class AwsLambdaSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'aws-lambda is the default feature for function for gradle and language=#language'(Language language) {
         when:
-        String template = buildGradle.template(ApplicationType.FUNCTION, buildProject(), getFeatures([], language, null, BuildTool.GRADLE, ApplicationType.FUNCTION), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .applicationType(ApplicationType.FUNCTION)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.aws:micronaut-function-aws")')
@@ -80,7 +78,11 @@ class AwsLambdaSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle aws-lambda feature for language=#language'(Language language) {
         when:
-        String template = buildGradle.template(ApplicationType.FUNCTION, buildProject(), getFeatures(['aws-lambda'], language, null, BuildTool.GRADLE, ApplicationType.FUNCTION), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['aws-lambda'])
+                .language(language)
+                .applicationType(ApplicationType.FUNCTION)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.aws:micronaut-function-aws")')
@@ -93,7 +95,10 @@ class AwsLambdaSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'aws-lambda feature is default feature for function and language=#language'(Language language) {
         when:
-        String template = pom.template(ApplicationType.FUNCTION, buildProject(), getFeatures([], language, null, BuildTool.GRADLE, ApplicationType.FUNCTION), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .applicationType(ApplicationType.FUNCTION)
+                .render()
 
         then:
         template.contains("""
@@ -111,7 +116,11 @@ class AwsLambdaSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'function with maven and aws-lambda feature for language=#language'(Language language) {
         when:
-        String template = pom.template(ApplicationType.FUNCTION, buildProject(), getFeatures(['aws-lambda'], language, null, BuildTool.GRADLE, ApplicationType.FUNCTION), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .applicationType(ApplicationType.FUNCTION)
+                .features(['aws-lambda'])
+                .render()
 
         then:
         template.contains("""
@@ -250,7 +259,10 @@ class AwsLambdaSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'aws-lambda features includes dependency to micronaut-function-aws-api-proxy for function for gradle and language=#language'(Language language) {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['aws-lambda'], language, null, BuildTool.GRADLE, ApplicationType.DEFAULT), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['aws-lambda'])
+                .language(language)
+                .render()
 
         then:
         template.contains('runtime("lambda")')
@@ -264,7 +276,10 @@ class AwsLambdaSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven micronaut-function-aws-api-proxy feature for language=#language'(Language language) {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['aws-lambda'], language, null, BuildTool.GRADLE, ApplicationType.DEFAULT), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['aws-lambda'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.starter.feature.function.azure
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.core.version.SemanticVersion
+import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
@@ -10,7 +11,7 @@ import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Unroll
 
-class AzureCloudFunctionSpec extends BeanContextSpec implements CommandOutputFixture {
+class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Unroll
     void "#jdkVersion supported for #feature"(ApplicationType applicationType, JdkVersion jdkVersion, String feature) {
@@ -85,7 +86,6 @@ class AzureCloudFunctionSpec extends BeanContextSpec implements CommandOutputFix
         def readme = output["README.md"]
 
         then:
-        build.contains('id("com.microsoft.azure.azurefunctions")')
         build.contains('runtime("azure_function")')
         build.contains('azurefunctions {')
         build.contains('os = "linux"')
@@ -105,6 +105,21 @@ class AzureCloudFunctionSpec extends BeanContextSpec implements CommandOutputFix
         output.containsKey("$testSrcDir/example/micronaut/FooFunctionTest.$extension".toString())
         output.get("$testSrcDir/example/micronaut/FooFunctionTest.$extension".toString())
                 .contains("HttpRequestMessageBuilder")
+
+        when:
+        String pluginId = 'com.microsoft.azure.azurefunctions'
+        String applyPlugin = 'id("' + pluginId + '") version "'
+
+        then:
+        build.contains(applyPlugin)
+
+        when:
+        Optional<SemanticVersion> semanticVersionOptional = parseCommunityGradlePluginVersion(pluginId, build).map(SemanticVersion::new)
+
+        then:
+        noExceptionThrown()
+        semanticVersionOptional.isPresent()
+
         where:
         language << Language.values().toList()
         extension << Language.extensions()

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/graalvm/GraalVMSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/graalvm/GraalVMSpec.groovy
@@ -1,9 +1,8 @@
 package io.micronaut.starter.feature.graalvm
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
@@ -16,7 +15,7 @@ import spock.lang.Subject
 import spock.lang.Unroll
 
 @Requires({ jvm.isJava8() || jvm.isJava11() })
-class GraalVMSpec extends BeanContextSpec implements CommandOutputFixture {
+class GraalVMSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Subject
     @Shared
@@ -33,7 +32,10 @@ class GraalVMSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void 'graalvm feature not supported for groovy and gradle'() {
         when:
-        buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["graalvm"], Language.GROOVY), false).render().toString()
+        new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['graalvm'])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         IllegalArgumentException e = thrown()
@@ -42,7 +44,9 @@ class GraalVMSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test maven graalvm feature doesn't add dependencies and processor defined in parent pom"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["graalvm"]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(["graalvm"])
+                .render()
 
         then:
         !template.contains("""
@@ -74,7 +78,10 @@ class GraalVMSpec extends BeanContextSpec implements CommandOutputFixture {
 """)
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["graalvm"], Language.KOTLIN), []).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(Language.KOTLIN)
+                .features(["graalvm"])
+                .render()
 
         then:
         !template.contains("""
@@ -101,7 +108,10 @@ class GraalVMSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void 'graalvm feature not supported for Groovy and maven'() {
         when:
-        pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["graalvm"], Language.GROOVY), []).render().toString()
+        new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(Language.GROOVY)
+                .features(["graalvm"])
+                .render()
 
         then:
         IllegalArgumentException e = thrown()
@@ -112,9 +122,9 @@ class GraalVMSpec extends BeanContextSpec implements CommandOutputFixture {
     void 'it is not possible to use graalvm with JDK versions different than JDK8 through JDK11'(JdkVersion jdkVersion) {
         when:
         generate(
-            ApplicationType.DEFAULT,
-            new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, jdkVersion),
-            ['graalvm']
+                ApplicationType.DEFAULT,
+                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, jdkVersion),
+                ['graalvm']
         )
 
         then:
@@ -129,9 +139,9 @@ class GraalVMSpec extends BeanContextSpec implements CommandOutputFixture {
     void 'Application file is generated for a default application type with gradle and features graalvm & aws-lambda for language: #language'(Language language, String extension) {
         when:
         def output = generate(
-            ApplicationType.DEFAULT,
-            new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
-            ['graalvm', 'aws-lambda']
+                ApplicationType.DEFAULT,
+                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+                ['graalvm', 'aws-lambda']
         )
 
         then:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/graphql/GraphQLSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/graphql/GraphQLSpec.groovy
@@ -1,17 +1,16 @@
 package io.micronaut.starter.feature.graphql
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.feature.Category
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class GraphQLSpec extends BeanContextSpec  implements CommandOutputFixture {
+class GraphQLSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature graphql contains links to micronaut docs'() {
         when:
@@ -35,7 +34,10 @@ class GraphQLSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test gradle graphql feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['graphql'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['graphql'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.graphql:micronaut-graphql")')
@@ -47,7 +49,10 @@ class GraphQLSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test maven graphql feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['graphql'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['graphql'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/jaxrs/JaxRsSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/jaxrs/JaxRsSpec.groovy
@@ -1,14 +1,14 @@
 package io.micronaut.starter.feature.jaxrs
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class JaxRsSpec extends BeanContextSpec  implements CommandOutputFixture {
+class JaxRsSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature jax-rs contains links to micronaut docs'() {
         when:
@@ -20,11 +20,13 @@ class JaxRsSpec extends BeanContextSpec  implements CommandOutputFixture {
         readme.contains("https://micronaut-projects.github.io/micronaut-jaxrs/latest/guide/index.html")
     }
 
-
     @Unroll
     void 'test jax-rs with Gradle for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['jax-rs'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['jax-rs'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.jaxrs:micronaut-jaxrs-server")')
@@ -39,7 +41,9 @@ class JaxRsSpec extends BeanContextSpec  implements CommandOutputFixture {
 
     void 'test maven jax-rs feature'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['jax-rs'], Language.JAVA), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['jax-rs'])
+                .render()
 
         then:
         template.contains("""
@@ -58,7 +62,10 @@ class JaxRsSpec extends BeanContextSpec  implements CommandOutputFixture {
 """)
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['jax-rs'], Language.KOTLIN), []).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(Language.KOTLIN)
+                .features(['jax-rs'])
+                .render()
 
         then:
         template.contains("""
@@ -77,7 +84,10 @@ class JaxRsSpec extends BeanContextSpec  implements CommandOutputFixture {
 """) == 2
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['jax-rs'], Language.GROOVY), []).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(Language.GROOVY)
+                .features(['jax-rs'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/jdbi/JdbiFeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/jdbi/JdbiFeatureSpec.groovy
@@ -1,16 +1,16 @@
 package io.micronaut.starter.feature.jdbi
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class JdbiFeatureSpec extends BeanContextSpec  implements CommandOutputFixture {
+class JdbiFeatureSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature sql-jdbi contains links to micronaut docs'() {
         when:
@@ -38,8 +38,10 @@ class JdbiFeatureSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'dependency is included with maven and feature sql-jdbi for language=#language'(Language language) {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['sql-jdbi'], language), []).render().toString()
-
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['sql-jdbi'])
+                .render()
         then:
         template.contains("""
     <dependency>
@@ -56,7 +58,10 @@ class JdbiFeatureSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'dependency is included with gradle and feature sql-jdbi for language=#language'(Language language) {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['sql-jdbi'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['sql-jdbi'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.sql:micronaut-jdbi")')

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/jmx/JmxSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/jmx/JmxSpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.jmx
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class JmxSpec extends BeanContextSpec  implements CommandOutputFixture {
+class JmxSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     @Unroll
     void 'test readme.md contains links to jmx and micronaut docs'() {
@@ -25,7 +24,10 @@ class JmxSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test gradle jmx feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['jmx'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['jmx'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.jmx:micronaut-jmx")')
@@ -37,7 +39,10 @@ class JmxSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test maven jmx feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['jmx'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['jmx'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/kotlin/KotlinExtensionFunctionsSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/kotlin/KotlinExtensionFunctionsSpec.groovy
@@ -1,17 +1,17 @@
 package io.micronaut.starter.feature.kotlin
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.feature.LanguageSpecificFeature
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class KotlinExtensionFunctionsSpec extends BeanContextSpec {
+class KotlinExtensionFunctionsSpec extends ApplicationContextSpec {
 
     @Subject
     @Shared
@@ -52,7 +52,10 @@ class KotlinExtensionFunctionsSpec extends BeanContextSpec {
     @Unroll
     void 'dependency is included with maven and feature kotlin-extension-functions for language=#language'(Language language) {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['kotlin-extension-functions'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['kotlin-extension-functions'])
+                .render()
 
         then:
         template.contains("""
@@ -69,8 +72,10 @@ class KotlinExtensionFunctionsSpec extends BeanContextSpec {
     @Unroll
     void 'exception with maven and feature kotlin-extension-functions for language=#language'(Language language) {
         when:
-        pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['kotlin-extension-functions'], language), []).render().toString()
-
+        new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['kotlin-extension-functions'])
+                .render()
         then:
         IllegalArgumentException e = thrown()
         e.message.contains("The selected features are incompatible")
@@ -82,7 +87,10 @@ class KotlinExtensionFunctionsSpec extends BeanContextSpec {
     @Unroll
     void 'dependency is included with gradle and feature kotlin-extension-functions for language=#language'(Language language) {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['kotlin-extension-functions'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['kotlin-extension-functions'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.kotlin:micronaut-kotlin-extension-functions")')
@@ -94,7 +102,10 @@ class KotlinExtensionFunctionsSpec extends BeanContextSpec {
     @Unroll
     void 'exception with gradle and feature kotlin-extension-functions for language=#language'(Language language) {
         when:
-        buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['kotlin-extension-functions'], language), false).render().toString()
+        new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['kotlin-extension-functions'])
+                .language(language)
+                .render()
 
         then:
         IllegalArgumentException e = thrown()

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/kotlin/KtorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/kotlin/KtorSpec.groovy
@@ -1,6 +1,8 @@
 package io.micronaut.starter.feature.kotlin
 
+import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.feature.LanguageSpecificFeature
@@ -12,10 +14,8 @@ import io.micronaut.starter.options.TestFramework
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 
-class KtorSpec extends BeanContextSpec  implements CommandOutputFixture {
+class KtorSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
 
     @Subject
@@ -77,7 +77,10 @@ class KtorSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'dependency is included with maven and feature ktor for language=#language'(Language language) {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['ktor'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['ktor'])
+                .render()
 
         then:
         template.contains("""
@@ -121,7 +124,10 @@ class KtorSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'exception for maven and feature ktor for language=#language'(Language language) {
         when:
-        pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['ktor'], language), []).render().toString()
+        new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['ktor'])
+                .render()
 
         then:
         IllegalArgumentException e = thrown()
@@ -134,7 +140,10 @@ class KtorSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'dependency is included with gradle and feature ktor for language=#language'(Language language) {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['ktor'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['ktor'])
+                .language(language)
+                .render()
 
         then:
         template.contains("mainClass.set(\"example.micronaut.Application\")")
@@ -151,7 +160,10 @@ class KtorSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'exception with gradle and feature ktor for language=#language'(Language language) {
         when:
-        buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['ktor'], language), false).render().toString()
+        new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['ktor'])
+                .language(language)
+                .render()
 
         then:
         IllegalArgumentException e = thrown()

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/Log4j2Spec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/Log4j2Spec.groovy
@@ -1,0 +1,53 @@
+package io.micronaut.starter.feature.logging
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.options.BuildTool
+
+class Log4j2Spec extends ApplicationContextSpec {
+
+    void "org.apache.logging.log4j dependencies are present for log4j2 feature and build gradle"() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['log4j2'])
+                .render()
+
+        then:
+        template.contains('implementation("org.apache.logging.log4j:log4j-core:2.12.1")')
+        template.contains('runtimeOnly("org.apache.logging.log4j:log4j-api:2.12.1")')
+        template.contains('runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.12.1")')
+    }
+
+    void "org.apache.logging.log4j dependencies are present for log4j2 feature and build maven"() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['log4j2'])
+                .render()
+
+        then:
+        template.contains("""
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.12.1</version>
+      <scope>compile</scope>
+    </dependency>
+""")
+        template.contains("""
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.12.1</version>
+      <scope>runtime</scope>
+    </dependency>
+""")
+        template.contains("""
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>2.12.1</version>
+      <scope>runtime</scope>
+    </dependency>
+""")
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/SimpleLoggingSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/SimpleLoggingSpec.groovy
@@ -1,15 +1,13 @@
 package io.micronaut.starter.feature.logging
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 
-
-class SimpleLoggingSpec extends BeanContextSpec  implements CommandOutputFixture {
+class SimpleLoggingSpec extends ApplicationContextSpec  implements CommandOutputFixture {
     void 'test generate simple logger properties'() {
         when:
         def output = generate(['slf4j-simple'])
@@ -23,7 +21,10 @@ class SimpleLoggingSpec extends BeanContextSpec  implements CommandOutputFixture
     @Unroll
     void 'test configure slf4j-simple for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['slf4j-simple'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['slf4j-simple'])
+                .language(language)
+                .render()
 
         then:
         template.contains('runtimeOnly("org.slf4j:slf4j-simple")')
@@ -36,7 +37,10 @@ class SimpleLoggingSpec extends BeanContextSpec  implements CommandOutputFixture
     @Unroll
     void 'test slf4j-simple feature for Maven and language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['slf4j-simple'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['slf4j-simple'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/jms/JmsSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/jms/JmsSpec.groovy
@@ -1,16 +1,20 @@
 package io.micronaut.starter.feature.messaging.jms
 
+import io.micronaut.context.ApplicationContext
+import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.build.gradle.templates.buildGradle
 import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 
 import java.util.stream.Collectors
 
 import static io.micronaut.starter.application.ApplicationType.DEFAULT
 
-class JmsSpec extends BeanContextSpec implements CommandOutputFixture {
+class JmsSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test README.md with feature jms contains links to micronaut docs'() {
         when:
@@ -30,7 +34,9 @@ class JmsSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void 'test dependencies are present for Gradle'() {
         when:
-        String template = buildGradle.template(DEFAULT, buildProject(), getFeatures(['jms-' + name]), false).render()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['jms-' + name])
+                .render()
 
         then:
         template.contains """implementation("io.micronaut.jms:micronaut-jms-$name")"""
@@ -41,7 +47,9 @@ class JmsSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void 'test dependencies are present for Maven'() {
         when:
-        String template = pom.template(DEFAULT, buildProject(), getFeatures(['jms-' + name]), []).render()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['jms-' + name])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/kafka/KafkaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/kafka/KafkaSpec.groovy
@@ -1,13 +1,12 @@
 package io.micronaut.starter.feature.messaging.kafka
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 
-class KafkaSpec extends BeanContextSpec implements CommandOutputFixture {
+class KafkaSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature kafka contains links to micronaut docs'() {
         when:
@@ -21,7 +20,9 @@ class KafkaSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["kafka"]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['kafka'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.kafka:micronaut-kafka")')
@@ -29,8 +30,9 @@ class KafkaSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["kafka"]), []).render().toString()
-
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(["kafka"])
+                .render()
         then:
         template.contains("""
     <dependency>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/kafka/KafkaStreamsSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/kafka/KafkaStreamsSpec.groovy
@@ -1,16 +1,16 @@
 package io.micronaut.starter.feature.messaging.kafka
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 
-class KafkaStreamsSpec extends BeanContextSpec implements CommandOutputFixture {
+class KafkaStreamsSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature kafka-streams contains links to micronaut docs'() {
         when:
@@ -49,7 +49,9 @@ class KafkaStreamsSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["kafka-streams"]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['kafka-streams'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.kafka:micronaut-kafka")')
@@ -58,7 +60,9 @@ class KafkaStreamsSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["kafka-streams"]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(["kafka-streams"])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/mqtt/MqttSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/mqtt/MqttSpec.groovy
@@ -1,15 +1,15 @@
 package io.micronaut.starter.feature.messaging.mqtt
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
 
 import java.util.stream.Collectors
 
-class MqttSpec extends BeanContextSpec implements CommandOutputFixture {
+class MqttSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature mqtt contains links to micronaut docs'() {
         when:
@@ -28,7 +28,9 @@ class MqttSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures([feature]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features([feature])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.mqtt:micronaut-' + dependency + '")')
@@ -41,8 +43,9 @@ class MqttSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures([feature]), []).render().toString()
-
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features([feature])
+                .render()
         then:
         template.contains("""
     <dependency>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/nats/NatsSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/nats/NatsSpec.groovy
@@ -1,16 +1,18 @@
 package io.micronaut.starter.feature.messaging.nats
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
 
-class NatsSpec extends BeanContextSpec {
+class NatsSpec extends ApplicationContextSpec {
 
     void "test dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["nats"]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["nats"])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.nats:micronaut-nats")')
@@ -18,7 +20,9 @@ class NatsSpec extends BeanContextSpec {
 
     void "test dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["nats"]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(["nats"])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/pubsub/PubSubSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/pubsub/PubSubSpec.groovy
@@ -1,15 +1,17 @@
 package io.micronaut.starter.feature.messaging.pubsub
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
 
-class PubSubSpec extends BeanContextSpec {
+class PubSubSpec extends ApplicationContextSpec {
 
     void "test dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures([PubSub.NAME]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features([PubSub.NAME])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.gcp:micronaut-gcp-pubsub")')
@@ -17,7 +19,9 @@ class PubSubSpec extends BeanContextSpec {
 
     void "test dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures([PubSub.NAME]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features([PubSub.NAME])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/rabbitmq/RabbitMQSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/rabbitmq/RabbitMQSpec.groovy
@@ -1,13 +1,14 @@
 package io.micronaut.starter.feature.messaging.rabbitmq
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.feature.messaging.pubsub.PubSub
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
 
-class RabbitMQSpec extends BeanContextSpec implements CommandOutputFixture {
+class RabbitMQSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature rabbitmq contains links to micronaut docs'() {
         when:
@@ -21,7 +22,9 @@ class RabbitMQSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test dependencies are present for gradle"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["rabbitmq"]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["rabbitmq"])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.rabbitmq:micronaut-rabbitmq")')
@@ -29,7 +32,9 @@ class RabbitMQSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test dependencies are present for maven"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(["rabbitmq"]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(["rabbitmq"])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/micrometer/MicrometerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/micrometer/MicrometerSpec.groovy
@@ -1,24 +1,23 @@
 package io.micronaut.starter.feature.micrometer
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.options.BuildTool
 import spock.lang.Unroll
 
-class MicrometerSpec extends BeanContextSpec {
+class MicrometerSpec extends ApplicationContextSpec {
 
     @Unroll
     void 'test gradle micrometer feature #micrometerFeature.name'() {
         given:
         String dependency = "micronaut-micrometer-registry-${micrometerFeature.name - 'micrometer-'}"
-        Features features = getFeatures([micrometerFeature.name])
 
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), features, false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features([micrometerFeature.name])
+                .render()
 
         then:
         template.contains("implementation(\"io.micronaut.micrometer:${dependency}\")")
@@ -29,8 +28,9 @@ class MicrometerSpec extends BeanContextSpec {
 
     void "test gradle micrometer multiple features"() {
         when:
-        Features features = getFeatures(["micrometer-atlas", "micrometer-influx"])
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), features, false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["micrometer-atlas", "micrometer-influx"])
+                .render()
 
         then:
         template.contains("""
@@ -45,10 +45,11 @@ class MicrometerSpec extends BeanContextSpec {
     void 'test maven micrometer feature #micrometerFeature.name'() {
         given:
         String dependency = "micronaut-micrometer-registry-${micrometerFeature.name - 'micrometer-'}"
-        Features features = getFeatures([micrometerFeature.name], null, null, BuildTool.MAVEN)
 
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), features, []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features([micrometerFeature.name])
+                .render()
 
         then:
         template.contains("""
@@ -65,8 +66,9 @@ class MicrometerSpec extends BeanContextSpec {
 
     void "test maven micrometer multiple features"() {
         when:
-        Features features = getFeatures(["micrometer-atlas", "micrometer-influx"], null, null, BuildTool.MAVEN)
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), features, []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(["micrometer-atlas", "micrometer-influx"])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/FlywaySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/FlywaySpec.groovy
@@ -1,13 +1,11 @@
 package io.micronaut.starter.feature.migration
 
-
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 
-class FlywaySpec extends BeanContextSpec implements CommandOutputFixture {
+class FlywaySpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature flyway contains links to micronaut docs'() {
         when:
@@ -22,7 +20,9 @@ class FlywaySpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test the dependency is added to the gradle build"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['flyway']), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['flyway'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.flyway:micronaut-flyway")')
@@ -30,7 +30,9 @@ class FlywaySpec extends BeanContextSpec implements CommandOutputFixture {
 
     void "test the dependency is added to the maven build"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['flyway']), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['flyway'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/LiquibaseSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/LiquibaseSpec.groovy
@@ -1,12 +1,11 @@
 package io.micronaut.starter.feature.migration
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 
-class LiquibaseSpec extends BeanContextSpec  implements CommandOutputFixture {
+class LiquibaseSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature liquibase contains links to micronaut docs'() {
         when:
@@ -21,7 +20,9 @@ class LiquibaseSpec extends BeanContextSpec  implements CommandOutputFixture {
 
     void "test the dependency is added to the gradle build"() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['liquibase']), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['liquibase'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.liquibase:micronaut-liquibase")')
@@ -29,7 +30,9 @@ class LiquibaseSpec extends BeanContextSpec  implements CommandOutputFixture {
 
     void "test the dependency is added to the maven build"() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['liquibase']), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['liquibase'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/multitenancy/MultitenancyGormSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/multitenancy/MultitenancyGormSpec.groovy
@@ -1,11 +1,11 @@
 package io.micronaut.starter.feature.multitenancy
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
@@ -13,7 +13,7 @@ import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class MultitenancyGormSpec extends BeanContextSpec  implements CommandOutputFixture {
+class MultitenancyGormSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     @Subject
     @Shared
@@ -54,7 +54,10 @@ class MultitenancyGormSpec extends BeanContextSpec  implements CommandOutputFixt
 
     void 'dependency is included with maven and feature multi-tenancy-gorm for groovy'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['multi-tenancy-gorm'], Language.GROOVY), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['multi-tenancy-gorm'])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains("""
@@ -76,7 +79,10 @@ class MultitenancyGormSpec extends BeanContextSpec  implements CommandOutputFixt
 
     void 'dependency is included with gradle and feature multi-tenancy-gorm for groovy'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['multi-tenancy-gorm'], Language.GROOVY), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['multi-tenancy-gorm'])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.groovy:micronaut-multitenancy-gorm")')

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/multitenancy/MultitenancySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/multitenancy/MultitenancySpec.groovy
@@ -1,17 +1,17 @@
 package io.micronaut.starter.feature.multitenancy
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 
-class MultitenancySpec extends BeanContextSpec  implements CommandOutputFixture {
+class MultitenancySpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     @Subject
     @Shared
@@ -51,7 +51,10 @@ class MultitenancySpec extends BeanContextSpec  implements CommandOutputFixture 
     @Unroll
     void 'dependency is included with maven and feature multi-tenancy for language=#language'(Language language) {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['multi-tenancy'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['multi-tenancy'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""
@@ -68,7 +71,10 @@ class MultitenancySpec extends BeanContextSpec  implements CommandOutputFixture 
     @Unroll
     void 'dependency is included with gradle and feature multi-tenancy for language=#language'(Language language) {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['multi-tenancy'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['multi-tenancy'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut:micronaut-multitenancy")')

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/ArchaiusSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/ArchaiusSpec.groovy
@@ -1,18 +1,20 @@
 package io.micronaut.starter.feature.netflix
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class ArchaiusSpec extends BeanContextSpec {
+class ArchaiusSpec extends ApplicationContextSpec {
 
     @Unroll
     void 'test gradle netflix-archaius feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['netflix-archaius'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['netflix-archaius'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.netflix:micronaut-netflix-archaius")')
@@ -24,7 +26,10 @@ class ArchaiusSpec extends BeanContextSpec {
     @Unroll
     void 'test maven netflix-archaius feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['netflix-archaius'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['netflix-archaius'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/HystrixSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/HystrixSpec.groovy
@@ -1,15 +1,14 @@
 package io.micronaut.starter.feature.netflix
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class HystrixSpec extends BeanContextSpec implements CommandOutputFixture {
+class HystrixSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature netflix-hystrix contains links to micronaut docs'() {
         when:
@@ -24,7 +23,10 @@ class HystrixSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle netflix-hystrix feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['netflix-hystrix'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['netflix-hystrix'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.netflix:micronaut-netflix-hystrix")')
@@ -36,7 +38,10 @@ class HystrixSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven netflix-hystrix feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['netflix-hystrix'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['netflix-hystrix'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/RibbonSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/netflix/RibbonSpec.groovy
@@ -1,15 +1,14 @@
 package io.micronaut.starter.feature.netflix
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class RibbonSpec extends BeanContextSpec implements CommandOutputFixture {
+class RibbonSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature netflix-ribbon contains links to micronaut docs'() {
         when:
@@ -24,7 +23,10 @@ class RibbonSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle netflix-ribbon feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['netflix-ribbon'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['netflix-ribbon'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.netflix:micronaut-netflix-ribbon")')
@@ -36,7 +38,10 @@ class RibbonSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven netflix-ribbon feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['netflix-ribbon'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['netflix-ribbon'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/oracecloud/OracleCloudSdkSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/oracecloud/OracleCloudSdkSpec.groovy
@@ -1,20 +1,21 @@
 package io.micronaut.starter.feature.oracecloud
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 
-class OracleCloudSdkSpec extends BeanContextSpec  implements CommandOutputFixture {
+class OracleCloudSdkSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     @Unroll
     void 'test Oracle Cloud SDK feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['oracle-cloud-sdk'], language), false).render().toString()
-
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['oracle-cloud-sdk'])
+                .language(language)
+                .render()
         then:
         template.contains('implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-sdk")')
 
@@ -25,7 +26,10 @@ class OracleCloudSdkSpec extends BeanContextSpec  implements CommandOutputFixtur
     @Unroll
     void 'test Oracle SDK feature for maven and language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['oracle-cloud-sdk'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['oracle-cloud-sdk'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/other/HttpSessionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/other/HttpSessionSpec.groovy
@@ -1,20 +1,17 @@
 package io.micronaut.starter.feature.other
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Category
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import io.micronaut.starter.options.Options
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class HttpSessionSpec extends BeanContextSpec implements CommandOutputFixture {
+class HttpSessionSpec extends ApplicationContextSpec implements CommandOutputFixture {
     @Shared
     @Subject
     HttpSession httpSession = beanContext.getBean(HttpSession)
@@ -55,8 +52,10 @@ class HttpSessionSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test http-session with Gradle for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['http-session'],
-                language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['http-session'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut:micronaut-session")')
@@ -69,11 +68,9 @@ class HttpSessionSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test http-session with Maven for language=#language'() {
         when:
-        def context = buildGeneratorContext(
-                ['http-session'],
-                new Options(language, BuildTool.MAVEN), ApplicationType.DEFAULT)
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(),
-                context.getFeatures(), context.getBuildProperties().getProperties()).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['http-session'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/other/OpenApiSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/other/OpenApiSpec.groovy
@@ -1,20 +1,14 @@
 package io.micronaut.starter.feature.other
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.feature.Category
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import spock.lang.Shared
-import spock.lang.Subject
 import spock.lang.Unroll
 
-class OpenApiSpec extends BeanContextSpec  implements CommandOutputFixture {
-    @Shared
-    @Subject
-    OpenApi openApi = beanContext.getBean(OpenApi)
+class OpenApiSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature openapi contains links to micronaut docs'() {
         when:
@@ -29,13 +23,16 @@ class OpenApiSpec extends BeanContextSpec  implements CommandOutputFixture {
 
     void "openApi belongs to API category"() {
         expect:
-        Category.API == openApi.category
+        Category.API == beanContext.getBean(OpenApi).category
     }
 
     @Unroll
     void 'test swagger with Gradle for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['openapi'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['openapi'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.swagger.core.v3:swagger-annotations")')
@@ -50,7 +47,9 @@ class OpenApiSpec extends BeanContextSpec  implements CommandOutputFixture {
 
     void 'test maven swagger feature'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['openapi'], Language.JAVA), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['openapi'])
+                .render()
 
         then:
         template.contains("""
@@ -60,16 +59,21 @@ class OpenApiSpec extends BeanContextSpec  implements CommandOutputFixture {
       <scope>compile</scope>
     </dependency>
 """)
-        template.contains("""
+        template.contains("<micronaut.openapi.version>")
+        template.contains("</micronaut.openapi.version>")
+        template.contains('''
             <path>
               <groupId>io.micronaut.openapi</groupId>
               <artifactId>micronaut-openapi</artifactId>
-              <version>\${micronaut.openapi.version}</version>
+              <version>${micronaut.openapi.version}</version>
             </path>
-""")
+''')
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['openapi'], Language.KOTLIN), []).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['openapi'])
+                .language(Language.KOTLIN)
+                .render()
 
         then:
         template.contains("""
@@ -79,16 +83,19 @@ class OpenApiSpec extends BeanContextSpec  implements CommandOutputFixture {
       <scope>compile</scope>
     </dependency>
 """)
-        template.contains("""
+        template.contains('''
                 <annotationProcessorPath>
                   <groupId>io.micronaut.openapi</groupId>
                   <artifactId>micronaut-openapi</artifactId>
-                  <version>\${micronaut.openapi.version}</version>
+                  <version>${micronaut.openapi.version}</version>
                 </annotationProcessorPath>
-""")
+''')
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['openapi'], Language.GROOVY), []).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['openapi'])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/other/ProjectLombokSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/other/ProjectLombokSpec.groovy
@@ -1,20 +1,16 @@
 package io.micronaut.starter.feature.other
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.feature.Category
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import io.micronaut.starter.options.Options
-import io.micronaut.starter.options.TestFramework
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class ProjectLombokSpec extends BeanContextSpec implements CommandOutputFixture {
+class ProjectLombokSpec extends ApplicationContextSpec implements CommandOutputFixture {
     @Shared
     @Subject
     ProjectLombok projectLombok = beanContext.getBean(ProjectLombok)
@@ -38,7 +34,9 @@ class ProjectLombokSpec extends BeanContextSpec implements CommandOutputFixture 
     @Unroll
     void 'test lombok with Gradle for Java'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['lombok'], Language.JAVA), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['lombok'])
+                .render()
 
         then:
         template.contains('annotationProcessor("org.projectlombok:lombok")')
@@ -48,8 +46,10 @@ class ProjectLombokSpec extends BeanContextSpec implements CommandOutputFixture 
     @Unroll
     void 'test lombok with Gradle for only Java'() {
         when:
-        buildGradle.template(ApplicationType.DEFAULT, buildProject(),
-                getFeatures(['lombok'], language), false).render().toString()
+        new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['lombok'])
+                .language(language)
+                .render()
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -61,12 +61,9 @@ class ProjectLombokSpec extends BeanContextSpec implements CommandOutputFixture 
 
     void 'test maven lombok feature'() {
         when:
-        def context = buildGeneratorContext(
-                ['lombok'],
-                new Options(Language.JAVA, TestFramework.SPOCK, BuildTool.MAVEN),
-                ApplicationType.DEFAULT)
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(),
-                context.getFeatures(), context.getBuildProperties().getProperties()).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['lombok'])
+                .render()
 
         then:
         // ensure we use version from Micronaut BOM

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/other/ShadePluginSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/other/ShadePluginSpec.groovy
@@ -1,35 +1,20 @@
-package io.micronaut.starter.feature.grpc
+package io.micronaut.starter.feature.other
 
 import io.micronaut.core.version.SemanticVersion
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.Category
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import spock.lang.Shared
-import spock.lang.Subject
 import spock.lang.Unroll
 
-class GrpcSpec extends ApplicationContextSpec {
-
-    @Shared
-    @Subject
-    Grpc grpc = beanContext.getBean(Grpc)
-
-    void "grpc belongs to API category"() {
-        expect:
-        Category.API == grpc.category
-    }
+class ShadePluginSpec extends ApplicationContextSpec {
 
     @Unroll
-    void 'test grpc plugin is applied by default for Gradle and language=#language'(Language language) {
+    void 'test shade plugin is applied by default for Gradle and language=#language'(Language language) {
         given:
-        String pluginId = 'com.google.protobuf'
-
+        String pluginId = 'com.github.johnrengelman.shadow'
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .applicationType(ApplicationType.GRPC)
                 .language(language)
                 .render()
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/reactor/ReactorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/reactor/ReactorSpec.groovy
@@ -1,17 +1,17 @@
 package io.micronaut.starter.feature.reactor
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 
-class ReactorSpec extends BeanContextSpec  implements CommandOutputFixture {
+class ReactorSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature reactor contains links to micronaut docs'() {
         when:
@@ -51,7 +51,10 @@ class ReactorSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'dependency is included with maven and feature reactor for language=#language'(Language language) {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['reactor'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['reactor'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""
@@ -68,7 +71,10 @@ class ReactorSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'dependency is included with gradle and feature reactor for language=#language'(Language language) {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['reactor'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['reactor'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.reactor:micronaut-reactor")')

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/redis/RedisLettuceSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/redis/RedisLettuceSpec.groovy
@@ -1,19 +1,21 @@
 package io.micronaut.starter.feature.redis
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class RedisLettuceSpec extends BeanContextSpec {
+class RedisLettuceSpec extends ApplicationContextSpec {
 
     @Unroll
     void 'test gradle redis-lettuce feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['redis-lettuce'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['redis-lettuce'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.redis:micronaut-redis-lettuce")')
@@ -25,7 +27,10 @@ class RedisLettuceSpec extends BeanContextSpec {
     @Unroll
     void 'test maven redis-lettuce feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['redis-lettuce'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['redis-lettuce'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/reloading/JrebelSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/reloading/JrebelSpec.groovy
@@ -1,9 +1,15 @@
 package io.micronaut.starter.feature.reloading
 
+import io.micronaut.core.version.SemanticVersion
+import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import spock.lang.Unroll
 
-class JrebelSpec extends BeanContextSpec  implements CommandOutputFixture {
+class JrebelSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature jrebel contains links to micronaut docs'() {
         when:
@@ -13,5 +19,29 @@ class JrebelSpec extends BeanContextSpec  implements CommandOutputFixture {
         then:
         readme
         readme.contains("https://docs.micronaut.io/latest/guide/index.html#jrebel")
+    }
+
+    @Unroll
+    void 'test jrebel with Gradle for language=#language'(Language language) {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['jrebel'])
+                .render()
+
+        String applyPlugin = 'id("org.zeroturnaround.gradle.jrebel") version "'
+
+        then:
+        template.contains(applyPlugin)
+
+        when:
+        Optional<SemanticVersion> semanticVersionOptional = parseCommunityGradlePluginVersion('org.zeroturnaround.gradle.jrebel', template).map(SemanticVersion::new)
+
+        then:
+        noExceptionThrown()
+        semanticVersionOptional.isPresent()
+
+        where:
+        language << Language.values()
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/rss/RssItunesSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/rss/RssItunesSpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.rss
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class RssItunesSpec extends BeanContextSpec implements CommandOutputFixture {
+class RssItunesSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature rss-itunes-podcast contains links to micronaut docs'() {
         when:
@@ -23,7 +22,10 @@ class RssItunesSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle rss-itunes-podcast feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['rss-itunes-podcast'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['rss-itunes-podcast'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.rss:micronaut-itunespodcast")')
@@ -35,7 +37,10 @@ class RssItunesSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven rss-itunes-podcast feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['rss-itunes-podcast'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['rss-itunes-podcast'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/rss/RssSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/rss/RssSpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.rss
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class RssSpec extends BeanContextSpec  implements CommandOutputFixture {
+class RssSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature rss contains links to micronaut docs'() {
         when:
@@ -23,7 +22,10 @@ class RssSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test gradle rss feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['rss'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['rss'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.rss:micronaut-rss")')
@@ -35,7 +37,10 @@ class RssSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test maven rss feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['rss'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['rss'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJavaOneSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJavaOneSpec.groovy
@@ -1,17 +1,17 @@
 package io.micronaut.starter.feature.rxjava
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.Category
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
-import io.micronaut.starter.feature.Category
 
-class RxJavaOneSpec extends BeanContextSpec  implements CommandOutputFixture {
+class RxJavaOneSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature rxjava1 contains links to micronaut docs'() {
         when:
@@ -44,7 +44,10 @@ class RxJavaOneSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'dependency is included with maven and feature rxjava1 for language=#language'(Language language) {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['rxjava1'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['rxjava1'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""
@@ -61,7 +64,10 @@ class RxJavaOneSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'dependency is included with gradle and feature rxjava1 for language=#language'(Language language) {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['rxjava1'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['rxjava1'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.rxjava1:micronaut-rxjava1")')

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJavaThreeSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJavaThreeSpec.groovy
@@ -1,17 +1,17 @@
 package io.micronaut.starter.feature.rxjava
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class RxJavaThreeSpec extends BeanContextSpec implements CommandOutputFixture {
+class RxJavaThreeSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature rxjava3 contains links to micronaut docs'() {
         when:
@@ -44,7 +44,10 @@ class RxJavaThreeSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'dependency is included with maven and feature rxjava3 for language=#language'(Language language) {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['rxjava3'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['rxjava3'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""
@@ -61,7 +64,10 @@ class RxJavaThreeSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'dependency is included with gradle and feature rxjava3 for language=#language'(Language language) {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['rxjava3'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['rxjava3'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.rxjava3:micronaut-rxjava3")')

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecurityJWTSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecurityJWTSpec.groovy
@@ -1,15 +1,14 @@
 package io.micronaut.starter.feature.security
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class SecurityJWTSpec extends BeanContextSpec  implements CommandOutputFixture {
+class SecurityJWTSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature security-jwt contains links to micronaut docs'() {
         when:
@@ -24,7 +23,10 @@ class SecurityJWTSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test gradle security-jwt feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['security-jwt'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['security-jwt'])
+                .render()
 
         then:
         template.contains("${getGradleAnnotationProcessorScope(language)}(\"io.micronaut.security:micronaut-security-annotations\")")
@@ -37,7 +39,10 @@ class SecurityJWTSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test maven security-jwt feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['security-jwt'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features( ['security-jwt'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""
@@ -72,8 +77,6 @@ class SecurityJWTSpec extends BeanContextSpec  implements CommandOutputFixture {
         where:
         language << Language.values().toList()
     }
-
-
 
     void 'test security-jwt configuration'() {
         when:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecurityLdapSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecurityLdapSpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.security
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class SecurityLdapSpec extends BeanContextSpec implements CommandOutputFixture {
+class SecurityLdapSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature security-ldap contains links to micronaut docs'() {
         when:
@@ -23,7 +22,10 @@ class SecurityLdapSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle security-ldap feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['security-ldap'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['security-ldap'])
+                .render()
 
         then:
         template.contains("${getGradleAnnotationProcessorScope(language)}(\"io.micronaut.security:micronaut-security-annotations\")")
@@ -36,7 +38,10 @@ class SecurityLdapSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven security-ldap feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['security-ldap'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['security-ldap'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecurityOauth2Spec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecurityOauth2Spec.groovy
@@ -1,15 +1,14 @@
 package io.micronaut.starter.feature.security
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class SecurityOauth2Spec extends BeanContextSpec implements CommandOutputFixture {
+class SecurityOauth2Spec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature security-oauth2 contains links to micronaut docs'() {
         when:
@@ -24,7 +23,10 @@ class SecurityOauth2Spec extends BeanContextSpec implements CommandOutputFixture
     @Unroll
     void 'test gradle security-oauth2 feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['security-oauth2'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['security-oauth2'])
+                .render()
 
         then:
         template.contains("${getGradleAnnotationProcessorScope(language)}(\"io.micronaut.security:micronaut-security-annotations\")")
@@ -37,7 +39,10 @@ class SecurityOauth2Spec extends BeanContextSpec implements CommandOutputFixture
     @Unroll
     void 'test maven security-oauth2 feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['security-oauth2'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['security-oauth2'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecuritySessionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecuritySessionSpec.groovy
@@ -1,17 +1,14 @@
 package io.micronaut.starter.feature.security
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import io.micronaut.starter.options.Options
 import spock.lang.Unroll
 
-class SecuritySessionSpec extends BeanContextSpec implements CommandOutputFixture {
+class SecuritySessionSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature security-session contains links to micronaut docs'() {
         when:
@@ -27,7 +24,10 @@ class SecuritySessionSpec extends BeanContextSpec implements CommandOutputFixtur
     @Unroll
     void 'test gradle security-session feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['security-session'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['security-session'])
+                .render()
 
         then:
         template.contains("${getGradleAnnotationProcessorScope(language)}(\"io.micronaut.security:micronaut-security-annotations\")")
@@ -40,7 +40,10 @@ class SecuritySessionSpec extends BeanContextSpec implements CommandOutputFixtur
     @Unroll
     void 'test gradle security-session removes http-session feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['http-session','security-session'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['http-session', 'security-session'])
+                .render()
 
         then:
         !template.contains('implementation("io.micronaut.security:micronaut-session")')
@@ -52,7 +55,10 @@ class SecuritySessionSpec extends BeanContextSpec implements CommandOutputFixtur
     @Unroll
     void 'test maven security-session feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['security-session'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['security-session'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""
@@ -91,11 +97,10 @@ class SecuritySessionSpec extends BeanContextSpec implements CommandOutputFixtur
     @Unroll
     void 'test maven security-session removes http-session feature for language=#language'() {
         when:
-        def context = buildGeneratorContext(
-                ['http-session','security-session'],
-                new Options(language, BuildTool.MAVEN), ApplicationType.DEFAULT)
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(),
-                context.getFeatures(), context.getBuildProperties().getProperties()).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['http-session','security-session'])
+                .language(language)
+                .render()
 
         then:
         !template.contains("micronaut-session")
@@ -103,7 +108,6 @@ class SecuritySessionSpec extends BeanContextSpec implements CommandOutputFixtur
         where:
         language << Language.values().toList()
     }
-
 
     void 'test security-session configuration'() {
         when:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecuritySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/security/SecuritySpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.security
 
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class SecuritySpec extends BeanContextSpec implements CommandOutputFixture {
+class SecuritySpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature security contains links to micronaut docs'() {
         when:
@@ -23,7 +22,10 @@ class SecuritySpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle security feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['security'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['security'])
+                .render()
 
         then:
         template.contains("${getGradleAnnotationProcessorScope(language)}(\"io.micronaut.security:micronaut-security-annotations\")")
@@ -36,7 +38,10 @@ class SecuritySpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven security feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['security'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['security'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/server/ServerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/server/ServerSpec.groovy
@@ -1,18 +1,19 @@
 package io.micronaut.starter.feature.server
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class ServerSpec extends BeanContextSpec {
+class ServerSpec extends ApplicationContextSpec {
 
     @Unroll
     void 'test gradle server feature #serverFeature'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures([serverFeature]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features( [serverFeature])
+                .render()
 
         then:
         template.contains(dependency)
@@ -28,7 +29,9 @@ class ServerSpec extends BeanContextSpec {
     @Unroll
     void 'test maven server feature #serverFeature'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures([serverFeature]), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features([serverFeature])
+                .render()
 
         then:
         template.contains("""
@@ -40,7 +43,10 @@ class ServerSpec extends BeanContextSpec {
 """)
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures([serverFeature], Language.KOTLIN), []).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(Language.KOTLIN)
+                .features([serverFeature])
+                .render()
 
         then:
         template.contains("""
@@ -52,7 +58,10 @@ class ServerSpec extends BeanContextSpec {
 """)
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures([serverFeature], Language.GROOVY), []).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(Language.GROOVY)
+                .features([serverFeature])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringBootSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringBootSpec.groovy
@@ -1,17 +1,17 @@
 package io.micronaut.starter.feature.spring
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class SpringBootSpec extends BeanContextSpec {
+class SpringBootSpec extends ApplicationContextSpec {
 
     @Shared
     @Subject
@@ -54,7 +54,10 @@ class SpringBootSpec extends BeanContextSpec {
     @Unroll
     void 'test spring-boot with Gradle for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-boot'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['spring-boot'])
+                .language(language)
+                .render()
 
         then:
         template.contains("${getGradleAnnotationProcessorScope(language)}(\"io.micronaut.spring:micronaut-spring-boot\")")
@@ -67,7 +70,9 @@ class SpringBootSpec extends BeanContextSpec {
 
     void 'test maven spring-boot feature'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-boot'], Language.JAVA), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['spring-boot'])
+                .render()
 
         then:
         template.contains("""
@@ -91,7 +96,10 @@ class SpringBootSpec extends BeanContextSpec {
 """)
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-boot'], Language.KOTLIN), []).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['spring-boot'])
+                .language(Language.KOTLIN)
+                .render()
 
         then:
         template.contains("""
@@ -115,7 +123,10 @@ class SpringBootSpec extends BeanContextSpec {
 """) == 2
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-boot'], Language.GROOVY), []).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['spring-boot'])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains("""
@@ -137,13 +148,19 @@ class SpringBootSpec extends BeanContextSpec {
 
     void 'test spring-web and spring-boot only add spring-boot-starter-web dependency once'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-boot'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['spring-boot'])
+                .language(language)
+                .render()
 
         then:
         template.count('implementation("org.springframework.boot:spring-boot-starter-web")') == 1
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-boot'], language), []).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['spring-boot'])
+                .language(language)
+                .render()
 
         then:
         template.count("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringDataJdbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringDataJdbcSpec.groovy
@@ -1,17 +1,17 @@
 package io.micronaut.starter.feature.spring
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class SpringDataJdbcSpec extends BeanContextSpec {
+class SpringDataJdbcSpec extends ApplicationContextSpec {
 
     @Shared
     @Subject
@@ -55,7 +55,10 @@ class SpringDataJdbcSpec extends BeanContextSpec {
     @Unroll
     void 'test spring-data-jdbc with Gradle for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-data-jdbc'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['spring-data-jdbc'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.data:micronaut-data-spring")')
@@ -68,7 +71,10 @@ class SpringDataJdbcSpec extends BeanContextSpec {
     @Unroll
     void 'test maven spring-data-jdbc feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-data-jdbc'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['spring-data-jdbc'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringDataJpaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringDataJpaSpec.groovy
@@ -1,17 +1,17 @@
 package io.micronaut.starter.feature.spring
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class SpringDataJpaSpec extends BeanContextSpec {
+class SpringDataJpaSpec extends ApplicationContextSpec {
 
     @Shared
     @Subject
@@ -55,7 +55,10 @@ class SpringDataJpaSpec extends BeanContextSpec {
     @Unroll
     void 'test spring-data-jpa with Gradle for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-data-jpa'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['spring-data-jpa'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.data:micronaut-data-spring")')
@@ -69,7 +72,10 @@ class SpringDataJpaSpec extends BeanContextSpec {
     @Unroll
     void 'test maven spring-data-jpa feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-data-jpa'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['spring-data-jpa'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringSpec.groovy
@@ -1,17 +1,18 @@
 package io.micronaut.starter.feature.spring
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.core.version.SemanticVersion
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class SpringSpec extends BeanContextSpec  implements CommandOutputFixture {
+class SpringSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     @Shared
     @Subject
@@ -57,8 +58,10 @@ class SpringSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test spring with Gradle for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring'], language), false).render().toString()
-
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['spring'])
+                .language(language)
+                .render()
         then:
         template.contains("$scope(\"io.micronaut.spring:micronaut-spring-annotation\")")
         template.contains('implementation("org.springframework.boot:spring-boot-starter")')
@@ -72,7 +75,9 @@ class SpringSpec extends BeanContextSpec  implements CommandOutputFixture {
 
     void 'test maven spring feature'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring'], Language.JAVA), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['spring'])
+                .render()
 
         then:
         template.contains("""
@@ -91,7 +96,10 @@ class SpringSpec extends BeanContextSpec  implements CommandOutputFixture {
 """)
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring'], Language.KOTLIN), []).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['spring'])
+                .language(Language.KOTLIN)
+                .render()
 
         then:
         template.contains("""
@@ -110,7 +118,10 @@ class SpringSpec extends BeanContextSpec  implements CommandOutputFixture {
 """) == 2
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring'], Language.GROOVY), []).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['spring'])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains("""
@@ -128,5 +139,11 @@ class SpringSpec extends BeanContextSpec  implements CommandOutputFixture {
     </dependency>
 """)
 
+        when:
+        Optional<SemanticVersion> semanticVersionOptional = parsePropertySemanticVersion(template, "micronaut.spring.version")
+
+        then:
+        noExceptionThrown()
+        semanticVersionOptional.isPresent()
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringWebSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringWebSpec.groovy
@@ -1,17 +1,18 @@
 package io.micronaut.starter.feature.spring
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.core.version.SemanticVersion
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class SpringWebSpec extends BeanContextSpec {
+class SpringWebSpec extends ApplicationContextSpec {
 
     @Shared
     @Subject
@@ -63,7 +64,10 @@ class SpringWebSpec extends BeanContextSpec {
     @Unroll
     void 'test spring-web with Gradle for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-web'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['spring-web'])
+                .language(language)
+                .render()
 
         then:
         template.contains("$scope(\"io.micronaut.spring:micronaut-spring-web-annotation\")")
@@ -80,7 +84,9 @@ class SpringWebSpec extends BeanContextSpec {
 
     void 'test maven spring-web feature'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-web'], Language.JAVA), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['spring-web'])
+                .render()
 
         then:
         template.contains("""
@@ -109,7 +115,17 @@ class SpringWebSpec extends BeanContextSpec {
 """)
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-web'], Language.KOTLIN), []).render().toString()
+        Optional<SemanticVersion> semanticVersionOptional = parsePropertySemanticVersion(template, "micronaut.spring.version")
+
+        then:
+        noExceptionThrown()
+        semanticVersionOptional.isPresent()
+
+        when:
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['spring-web'])
+                .language(Language.KOTLIN)
+                .render()
 
         then:
         template.contains("""
@@ -138,7 +154,17 @@ class SpringWebSpec extends BeanContextSpec {
 """) == 2
 
         when:
-        template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['spring-web'], Language.GROOVY), []).render().toString()
+        semanticVersionOptional = parsePropertySemanticVersion(template, "micronaut.spring.version")
+
+        then:
+        noExceptionThrown()
+        semanticVersionOptional.isPresent()
+
+        when:
+        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['spring-web'])
+                .language(Language.GROOVY)
+                .render()
 
         then:
         template.contains("""
@@ -166,5 +192,11 @@ class SpringWebSpec extends BeanContextSpec {
     </dependency>
 """)
 
+        when:
+        semanticVersionOptional = parsePropertySemanticVersion(template, "micronaut.spring.version")
+
+        then:
+        noExceptionThrown()
+        semanticVersionOptional.isPresent()
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/stackdriver/CloudTraceSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/stackdriver/CloudTraceSpec.groovy
@@ -1,16 +1,16 @@
 package io.micronaut.starter.feature.stackdriver
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class CloudTraceSpec extends BeanContextSpec {
+class CloudTraceSpec extends ApplicationContextSpec {
 
     @Subject
     @Shared
@@ -45,7 +45,10 @@ class CloudTraceSpec extends BeanContextSpec {
     @Unroll
     void 'dependency is included with maven and feature cloudtrace for language=#language'(Language language) {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['gcp-cloud-trace'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['gcp-cloud-trace'])
+                .language(language)
+                .render()
 
         then:
         template.contains("""
@@ -62,7 +65,10 @@ class CloudTraceSpec extends BeanContextSpec {
     @Unroll
     void 'dependency is included with gradle and feature gcp-cloud-trace for language=#language'(Language language) {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['gcp-cloud-trace'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['gcp-cloud-trace'])
+                .language(language)
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.gcp:micronaut-gcp-tracing")')

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/AssertJSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/AssertJSpec.groovy
@@ -1,18 +1,17 @@
 package io.micronaut.starter.feature.test
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.feature.Category
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class AssertJSpec extends BeanContextSpec implements CommandOutputFixture {
+class AssertJSpec extends ApplicationContextSpec implements CommandOutputFixture {
     @Shared
     @Subject
     AssertJ assertj = beanContext.getBean(AssertJ)
@@ -35,8 +34,11 @@ class AssertJSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle assertj feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['assertj'],
-                language, TestFramework.JUNIT), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['assertj'])
+                .language(language)
+                .testFramework(TestFramework.JUNIT)
+                .render()
 
         then:
         template.contains('testImplementation("org.assertj:assertj-core")')
@@ -48,8 +50,11 @@ class AssertJSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle assertj feature fails for language=#language when test framework is not Junit'() {
         when:
-        buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['assertj'], language, testfw),
-                false).render().toString()
+        new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['assertj'])
+                .language(language)
+                .testFramework(testfw)
+                .render()
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -68,8 +73,11 @@ class AssertJSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven assertj feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['assertj'], language,
-                TestFramework.JUNIT), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['assertj'])
+                .language(language)
+                .testFramework(TestFramework.JUNIT)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/HamcrestSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/HamcrestSpec.groovy
@@ -1,18 +1,18 @@
 package io.micronaut.starter.feature.test
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class HamcrestSpec  extends BeanContextSpec implements CommandOutputFixture {
+class HamcrestSpec  extends ApplicationContextSpec implements CommandOutputFixture {
     @Shared
     @Subject
     Hamcrest hamcrest = beanContext.getBean(Hamcrest)
@@ -35,8 +35,11 @@ class HamcrestSpec  extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle hamcrest feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['hamcrest'],
-                language, TestFramework.JUNIT), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['hamcrest'])
+                .language(language)
+                .testFramework(TestFramework.JUNIT)
+                .render()
 
         then:
         template.contains('testImplementation("org.hamcrest:hamcrest")')
@@ -48,8 +51,11 @@ class HamcrestSpec  extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle hamcrest feature fails for language=#language when test framework is not Junit'() {
         when:
-        buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['hamcrest'], language, testfw),
-                false).render().toString()
+        new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['hamcrest'])
+                .language(language)
+                .testFramework(testfw)
+                .render()
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -68,8 +74,11 @@ class HamcrestSpec  extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven hamcrest feature fails for language=#language when test framework is not Junit'() {
         when:
-        pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['hamcrest'], language,
-                testfw), []).render().toString()
+        new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['hamcrest'])
+                .language(language)
+                .testFramework(testfw)
+                .render()
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -88,8 +97,11 @@ class HamcrestSpec  extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven hamcrest feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['hamcrest'], language,
-                TestFramework.JUNIT), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features(['hamcrest'])
+                .language(language)
+                .testFramework(TestFramework.JUNIT)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/JUnitSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/JUnitSpec.groovy
@@ -1,30 +1,36 @@
 package io.micronaut.starter.feature.test
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 
-class JUnitSpec extends BeanContextSpec {
+class JUnitSpec extends ApplicationContextSpec {
 
     void "test junit with different languages"() {
 
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures([]), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE).render()
 
         then:
         template.contains("testRuntime(\"junit5\")")
 
         when:
-        template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures([], Language.GROOVY, TestFramework.JUNIT), false).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(Language.GROOVY)
+                .testFramework(TestFramework.JUNIT)
+                .render()
 
         then:
         template.contains("testRuntime(\"junit5\")")
         !template.contains("testAnnotationProcessor")
 
         when:
-        template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures([], Language.KOTLIN, TestFramework.JUNIT), false).render().toString()
+        template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(Language.KOTLIN)
+                .testFramework(TestFramework.JUNIT)
+                .render()
 
         then:
         template.contains("testRuntime(\"junit5\")")

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/KoTestSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/KoTestSpec.groovy
@@ -1,20 +1,17 @@
 package io.micronaut.starter.feature.test
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.TestFramework
 
-class KoTestSpec extends BeanContextSpec {
+class KoTestSpec extends ApplicationContextSpec {
 
     void 'test maven configure unit tests'() {
-        given:
-        Features features = getFeatures([], null, TestFramework.KOTEST, BuildTool.MAVEN)
-
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), features, []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .testFramework(TestFramework.KOTEST)
+                .render()
 
         then:
         template.contains('''

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/MockitoSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/MockitoSpec.groovy
@@ -1,18 +1,17 @@
 package io.micronaut.starter.feature.test
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.feature.Category
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class MockitoSpec extends BeanContextSpec implements CommandOutputFixture {
+class MockitoSpec extends ApplicationContextSpec implements CommandOutputFixture {
     @Shared
     @Subject
     Mockito mockito = beanContext.getBean(Mockito)
@@ -35,8 +34,11 @@ class MockitoSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle mockito feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['mockito'],
-                language, TestFramework.JUNIT), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['mockito'])
+                .testFramework(TestFramework.JUNIT)
+                .render()
 
         then:
         template.contains('testImplementation("org.mockito:mockito-core")')
@@ -48,8 +50,11 @@ class MockitoSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle mockito feature fails for language=#language when test framework is not Junit'() {
         when:
-        buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['mockito'], language, testfw),
-                false).render().toString()
+        new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['mockito'])
+                .testFramework(testfw)
+                .render()
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -68,8 +73,11 @@ class MockitoSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven mockito feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['mockito'], language,
-                TestFramework.JUNIT), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['mockito'])
+                .testFramework(TestFramework.JUNIT)
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/SpockSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/SpockSpec.groovy
@@ -1,25 +1,18 @@
 package io.micronaut.starter.feature.test
 
-import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
-import io.micronaut.starter.options.BuildTool
-import io.micronaut.starter.options.JdkVersion
-import io.micronaut.starter.options.Language
-import io.micronaut.starter.options.Options
-import io.micronaut.starter.options.TestFramework
+import io.micronaut.starter.options.*
 import spock.lang.Issue
 
-class SpockSpec extends BeanContextSpec {
+class SpockSpec extends ApplicationContextSpec {
 
     void 'test maven configure unit tests'() {
-        given:
-        Features features = getFeatures([], null, TestFramework.SPOCK, BuildTool.MAVEN)
-
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), features, []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .testFramework(TestFramework.SPOCK)
+                .render()
 
         then:
         template.contains("""
@@ -38,12 +31,12 @@ class SpockSpec extends BeanContextSpec {
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-starter/issues/514")
-    void 'it is possible to create a #language application with #testFramework and JDK15'() {
-        given:
-        Options options = new Options(language, testFramework, BuildTool.GRADLE, JdkVersion.JDK_15)
-
+    void 'it is possible to create a #language application with #testFramework and JDK15'(Language language, TestFramework testFramework) {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures([], options), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .jdkVersion(JdkVersion.JDK_15)
+                .render()
 
         then:
         template.contains('''
@@ -59,11 +52,12 @@ java {
 
     @Issue("https://github.com/micronaut-projects/micronaut-starter/issues/514")
     void 'With Kotlin or KoTest and JDK15 the sourceCompatibility is JDK14'() {
-        given:
-        Options options = new Options(language, testFramework, BuildTool.GRADLE, JdkVersion.JDK_15)
-
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures([], options), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .jdkVersion(JdkVersion.JDK_15)
+                .testFramework(testFramework)
+                .render()
 
         then:
         template.contains("sourceCompatibility = JavaVersion.toVersion(\"14\")")

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/JaegerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/JaegerSpec.groovy
@@ -1,15 +1,14 @@
 package io.micronaut.starter.feature.tracing
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class JaegerSpec extends BeanContextSpec implements CommandOutputFixture {
+class JaegerSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature tracing-jaeger contains links to micronaut docs'() {
         when:
@@ -25,7 +24,10 @@ class JaegerSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle tracing-jaeger feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['tracing-jaeger'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['tracing-jaeger'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut:micronaut-tracing")')
@@ -38,7 +40,10 @@ class JaegerSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven tracing-jaeger feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['tracing-jaeger'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['tracing-jaeger'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/ZipkinSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/ZipkinSpec.groovy
@@ -1,15 +1,14 @@
 package io.micronaut.starter.feature.tracing
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class ZipkinSpec extends BeanContextSpec  implements CommandOutputFixture {
+class ZipkinSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature tracing-zipkin contains links to micronaut docs'() {
         when:
@@ -25,7 +24,10 @@ class ZipkinSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test gradle tracing-zipkin feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['tracing-zipkin'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['tracing-zipkin'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut:micronaut-tracing")')
@@ -40,7 +42,10 @@ class ZipkinSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test maven tracing-zipkin feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['tracing-zipkin'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['tracing-zipkin'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/vertx/VertxMySqlSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/vertx/VertxMySqlSpec.groovy
@@ -1,19 +1,21 @@
 package io.micronaut.starter.feature.vertx
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class VertxClientSpec extends BeanContextSpec {
+class VertxClientSpec extends ApplicationContextSpec {
 
     @Unroll
     void 'test gradle vertx-mysql-client feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['vertx-mysql-client'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['vertx-mysql-client'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.sql:micronaut-vertx-mysql-client")')
@@ -25,7 +27,10 @@ class VertxClientSpec extends BeanContextSpec {
     @Unroll
     void 'test maven vertx-mysql-client feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['vertx-mysql-client'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['vertx-mysql-client'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/vertx/VertxPgSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/vertx/VertxPgSpec.groovy
@@ -1,19 +1,21 @@
 package io.micronaut.starter.feature.vertx
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class VertxPgSpec extends BeanContextSpec {
+class VertxPgSpec extends ApplicationContextSpec {
 
     @Unroll
     void 'test gradle vertx-pg-client feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['vertx-pg-client'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['vertx-pg-client'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.sql:micronaut-vertx-pg-client")')
@@ -25,8 +27,10 @@ class VertxPgSpec extends BeanContextSpec {
     @Unroll
     void 'test maven vertx-pg-client feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['vertx-pg-client'], language), []).render().toString()
-
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['vertx-pg-client'])
+                .render()
         then:
         template.contains("""
     <dependency>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/FreemarkerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/FreemarkerSpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.view
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class FreemarkerSpec extends BeanContextSpec implements CommandOutputFixture {
+class FreemarkerSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature views-freemarker contains links to micronaut docs'() {
         when:
@@ -24,7 +23,10 @@ class FreemarkerSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle views-freemarker feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-freemarker'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['views-freemarker'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.views:micronaut-views-freemarker")')
@@ -36,7 +38,10 @@ class FreemarkerSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven views-freemarker feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-freemarker'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['views-freemarker'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/HandlebarsSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/HandlebarsSpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.view
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class HandlebarsSpec extends BeanContextSpec  implements CommandOutputFixture {
+class HandlebarsSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature views-handlebars contains links to micronaut docs'() {
         when:
@@ -24,7 +23,10 @@ class HandlebarsSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test gradle views-handlebars feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-handlebars'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['views-handlebars'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.views:micronaut-views-handlebars")')
@@ -36,7 +38,10 @@ class HandlebarsSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test maven views-handlebars feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-handlebars'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['views-handlebars'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/PebbleSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/PebbleSpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.view
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class PebbleSpec extends BeanContextSpec  implements CommandOutputFixture {
+class PebbleSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature views-pebble contains links to micronaut docs'() {
         when:
@@ -24,7 +23,10 @@ class PebbleSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test gradle views-pebble feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-pebble'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['views-pebble'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.views:micronaut-views-pebble")')
@@ -36,7 +38,10 @@ class PebbleSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test maven views-pebble feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-pebble'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['views-pebble'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/RockerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/RockerSpec.groovy
@@ -1,14 +1,14 @@
 package io.micronaut.starter.feature.view
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.core.version.SemanticVersion
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class RockerSpec extends BeanContextSpec implements CommandOutputFixture {
+class RockerSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature views-rocker contains links to micronaut docs'() {
         when:
@@ -24,11 +24,13 @@ class RockerSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle views-rocker feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-rocker'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['views-rocker'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.views:micronaut-views-rocker")')
-        template.contains('id("com.fizzed.rocker") version "1.3.0"')
         template.contains("""
 sourceSets {
     main {
@@ -39,6 +41,20 @@ sourceSets {
 }
 """)
 
+        when:
+        String pluginId = 'com.fizzed.rocker'
+        String applyPlugin = 'id("' + pluginId + '") version "'
+
+        then:
+        template.contains(applyPlugin)
+
+        when:
+        Optional<SemanticVersion> semanticVersionOptional = parseCommunityGradlePluginVersion(pluginId, template).map(SemanticVersion::new)
+
+        then:
+        noExceptionThrown()
+        semanticVersionOptional.isPresent()
+
         where:
         language << Language.values().toList()
     }
@@ -46,7 +62,10 @@ sourceSets {
     @Unroll
     void 'test maven views-rocker feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-rocker'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['views-rocker'])
+                .render()
 
         then:
         template.contains("""
@@ -79,5 +98,5 @@ sourceSets {
         where:
         language << Language.values().toList()
     }
-
 }
+

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/SoySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/SoySpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.view
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class SoySpec extends BeanContextSpec implements CommandOutputFixture {
+class SoySpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature views-soy contains links to micronaut docs'() {
         when:
@@ -24,7 +23,10 @@ class SoySpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle views-soy feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-soy'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['views-soy'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.views:micronaut-views-soy")')
@@ -36,7 +38,10 @@ class SoySpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven views-soy feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-soy'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['views-soy'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/ThymeleafSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/ThymeleafSpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.view
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class ThymeleafSpec extends BeanContextSpec implements CommandOutputFixture {
+class ThymeleafSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature views-thymeleaf contains links to micronaut docs'() {
         when:
@@ -24,7 +23,10 @@ class ThymeleafSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test gradle views-thymeleaf feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-thymeleaf'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['views-thymeleaf'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.views:micronaut-views-thymeleaf")')
@@ -36,7 +38,10 @@ class ThymeleafSpec extends BeanContextSpec implements CommandOutputFixture {
     @Unroll
     void 'test maven views-thymeleaf feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-thymeleaf'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['views-thymeleaf'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/VelocitySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/VelocitySpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.view
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class VelocitySpec extends BeanContextSpec  implements CommandOutputFixture {
+class VelocitySpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature views-velocity contains links to micronaut docs'() {
         when:
@@ -24,7 +23,10 @@ class VelocitySpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test gradle views-velocity feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-velocity'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['views-velocity'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.views:micronaut-views-velocity")')
@@ -36,7 +38,10 @@ class VelocitySpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test maven views-velocity feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['views-velocity'], language), []).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['views-velocity'])
+                .render()
 
         then:
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/xml/JacksonXmlSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/xml/JacksonXmlSpec.groovy
@@ -1,14 +1,13 @@
 package io.micronaut.starter.feature.xml
 
-import io.micronaut.starter.BeanContextSpec
-import io.micronaut.starter.application.ApplicationType
-import io.micronaut.starter.feature.build.gradle.templates.buildGradle
-import io.micronaut.starter.feature.build.maven.templates.pom
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class JacksonXmlSpec extends BeanContextSpec  implements CommandOutputFixture {
+class JacksonXmlSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature jackson-xml contains links to micronaut docs'() {
         when:
@@ -24,7 +23,10 @@ class JacksonXmlSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test gradle jackson-xml feature for language=#language'() {
         when:
-        String template = buildGradle.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['jackson-xml'], language), false).render().toString()
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['jackson-xml'])
+                .render()
 
         then:
         template.contains('implementation("io.micronaut.xml:micronaut-jackson-xml")')
@@ -36,8 +38,10 @@ class JacksonXmlSpec extends BeanContextSpec  implements CommandOutputFixture {
     @Unroll
     void 'test maven jackson-xml feature for language=#language'() {
         when:
-        String template = pom.template(ApplicationType.DEFAULT, buildProject(), getFeatures(['jackson-xml'], language), []).render().toString()
-
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['jackson-xml'])
+                .render()
         then:
         template.contains("""
     <dependency>

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/feature/dekorate/DekorateSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/feature/dekorate/DekorateSpec.groovy
@@ -38,7 +38,6 @@ class DekorateSpec extends CommandSpec {
                 [Language.JAVA, Language.KOTLIN]].combinations()
     }
 
-
     @Unroll
     void "test maven dekorate service #feature.name with #language on default platform"(Feature feature, Language language) {
         when:


### PR DESCRIPTION
Almost every test was coupled to the rocker templates for both maven and Gradle. Modifying the arguments to those rocker files meant changing every test. I need to modify those rocker files in a future PR. 

The goal of this PR is to encapsulate the logic to call those templates in a single file `BuildBuilder` and also create nice fluid API so that tests can verify different scenarios in an easy way. 

Moreover, this PR adds:
 
- missing test that for Groovy language the Groovy Gradle plugin is applied
- missing test that for Spock even if Java or Kotlin  the Groovy Gradle plugin is applied
- some verifications that the Gradle plugin version resolved is a semantic version
- test for grpc gradle plugin
- missing test for Log4j2
- missing test for Shade plugin
- missing test for jrebel gradle plugin


I am passing the BuildBuilder constructor the application context because I will use it in a future PR. It is not used in this PR but it will in the next PR. 