### PR TITLE
refactor: moves dependency to feature assertj

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dependencies.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dependencies.rocker.raw
@@ -275,9 +275,6 @@ dependencies {
     @dependency.template("io.micronaut","micronaut-function", "testImplementation", null)
     }
 }
-@if (features.contains("assertj")) {
-    @dependency.template("org.assertj","assertj-core", "testImplementation", null)
-}
 @if (features.contains("hamcrest")) {
     @dependency.template("org.hamcrest","hamcrest", "testImplementation", null)
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -408,9 +408,6 @@ MavenBuild mavenBuild
 @dependency.template("org.junit.jupiter", "junit-jupiter-api", "test", null)
 @dependency.template("org.junit.jupiter", "junit-jupiter-engine", "test", null)
 @dependency.template("io.micronaut.test", "micronaut-test-junit5", "test", null)
-    @if (features.contains("assertj")) {
-@dependency.template("org.assertj", "assertj-core", "test", null)
-    }
     @if (features.contains("hamcrest")) {
 @dependency.template("org.hamcrest", "hamcrest", "test", null)
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/AssertJ.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/AssertJ.java
@@ -16,6 +16,8 @@
 package io.micronaut.starter.feature.test;
 
 import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
 
@@ -42,6 +44,14 @@ public class AssertJ implements Feature {
     @Override
     public boolean supports(ApplicationType applicationType) {
         return true;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        generatorContext.addDependency(Dependency.builder()
+                .groupId("org.assertj")
+                .artifactId("assertj-core")
+                .test());
     }
 
     @Override


### PR DESCRIPTION
Not sure why we were adding the dependency before in maven only if junit was the framework. We did not have any check for Gradle. 