### PR TITLE
Bump micronaut-camunda-bpm-feature to version 0.22.0

### DIFF
--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>info.novatec</groupId>
             <artifactId>micronaut-camunda-bpm-feature</artifactId>
-            <version>0.21.0</version>
+            <version>0.22.0</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
I'm the maintainer of https://github.com/NovatecConsulting/micronaut-camunda-bpm

Please bump micronaut-camunda-bpm-feature to version 0.22.0