### PR TITLE
Enable dependabot for Maven so dependencies are updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,12 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "starter-core/src/main/resources"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR changes dependabot updates to a weekly basis and enables it to update our [internal pom.xml](https://github.com/micronaut-projects/micronaut-starter/blob/2.4.x/starter-core/src/main/resources/pom.xml). It will start sending PRs to update those dependencies so if we get them from there programmatically with the new APIs we don't need to manually update them anymore. This is helpful for example with out Gradle plugin.