### PR TITLE
Enable functional tests for JDK 16

### DIFF
--- a/.github/workflows/gradle-func.yml
+++ b/.github/workflows/gradle-func.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11']
+        java: ['8', '11', '16']
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11']
+        java: ['8', '11', '16']
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2

--- a/.github/workflows/gradle-func.yml
+++ b/.github/workflows/gradle-func.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11']
+        java: ['8', '11', '16']
     steps:
       - uses: actions/checkout@v2.3.4
 #      - uses: actions/cache@v2
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11']
+        java: ['8', '11', '16']
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11']
+        java: ['8', '11', '16']
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11']
+        java: ['8', '11', '16']
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2


### PR DESCRIPTION
This enables functional tests for JDK 16, however is failing right now since Kotlin is not compatible and all the Kotlin builds are failing.