### PR TITLE
fix: update rocker templates for azure raw function

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionGroovyJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionGroovyJunit.rocker.raw
@@ -16,7 +16,7 @@ class FunctionTest {
     @@Test
     void testFunction() {
         new Function().withCloseable { Function function ->
-            assert function.echo("test", null) == 'test'
+            assert function.hello(HttpRequest.builder().build(), null).body == 'Hello World'
         }
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionHttpRequestJava.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionHttpRequestJava.rocker.raw
@@ -1,0 +1,139 @@
+@import io.micronaut.starter.application.Project
+
+@args (
+Project project
+)
+
+@if (project.getPackageName() != null) {
+package @project.getPackageName();
+}
+
+import com.microsoft.azure.functions.HttpMethod;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.HttpStatus;
+import com.microsoft.azure.functions.HttpStatusType;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class HttpRequest implements HttpRequestMessage<Optional<String>> {
+
+    private final URI uri;
+
+    private final HttpMethod httpMethod;
+
+    private final Map<String, String> headers;
+
+    private final Map<String, String> queryParameters;
+
+    private final Object body;
+
+    private HttpRequest(URI uri,
+                       HttpMethod httpMethod,
+                       Map<String, String> headers,
+                       Map<String, String> queryParameters,
+                       Object body) {
+        this.uri = uri;
+        this.httpMethod = httpMethod;
+        this.headers = headers;
+        this.queryParameters = queryParameters;
+        this.body = body;
+    }
+
+    @@Override
+    public URI getUri() {
+        return this.uri;
+    }
+
+    @@Override
+    public HttpMethod getHttpMethod() {
+        return this.httpMethod;
+    }
+
+    @@Override
+    public Map<String, String> getHeaders() {
+        return this.headers;
+    }
+
+    @@Override
+    public Map<String, String> getQueryParameters() {
+        return this.queryParameters;
+    }
+
+    @@Override
+    public Optional<String> getBody() {
+        return bodyAsString(this.body);
+    }
+
+    @@Override
+    public HttpResponseMessage.Builder createResponseBuilder(HttpStatus status) {
+        return new ResponseBuilder().status(status);
+    }
+
+    @@Override
+    public HttpResponseMessage.Builder createResponseBuilder(HttpStatusType status) {
+        return new ResponseBuilder().status(status);
+    }
+
+    private Optional<String> bodyAsString(Object body) {
+        if (body instanceof byte[]) {
+            return Optional.of(new String((byte[]) body, StandardCharsets.UTF_8));
+        } else if (body != null) {
+            return Optional.of(body.toString());
+        }
+        return Optional.empty();
+    }
+
+    public static Builder builder() {
+        return new HttpRequest.Builder();
+    }
+
+    public static class Builder {
+        private URI uri;
+
+        private HttpMethod httpMethod;
+
+        private Map<String, String> headers;
+
+        private Map<String, String> queryParameters;
+
+        private Object body;
+
+        public Builder uri(URI uri) {
+            this.uri = uri;
+            return this;
+        }
+
+        public Builder httpMethod(HttpMethod httpMethod) {
+            this.httpMethod = httpMethod;
+            return this;
+        }
+
+        public Builder header(String header, String value) {
+            if (headers == null) {
+                headers = new HashMap<>();
+            }
+            this.headers.put(header, value);
+            return this;
+        }
+
+        public Builder query(String name, String value) {
+            if (queryParameters == null) {
+                queryParameters = new HashMap<>();
+            }
+            this.queryParameters.put(name, value);
+            return this;
+        }
+
+        public HttpRequestMessage<Optional<String>> build() {
+            return new HttpRequest(uri, httpMethod,
+                    headers == null ? Collections.emptyMap() : headers,
+                    queryParameters == null ? Collections.emptyMap() : queryParameters,
+                    body);
+        }
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionJavaJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionJavaJunit.rocker.raw
@@ -17,7 +17,7 @@ public class FunctionTest {
     @@Test
     public void testFunction() throws Exception {
         try (Function function = new Function()) {
-            assertEquals("test", function.echo("test", null));
+            assertEquals("Hello World", function.hello(HttpRequest.builder().build(), null).getBody());
         }
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionKoTest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionKoTest.rocker.raw
@@ -15,8 +15,8 @@ class FunctionTest : StringSpec({
 
     "test function" {
        Function().use { function ->
-           val response = function.echo("test", null)
-           response shouldBe "test"
+           val response = function.hello(HttpRequest.builder().build(), null).body
+           response shouldBe "Hello World"
         }
     }
 })

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionKotlinJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionKotlinJunit.rocker.raw
@@ -10,14 +10,15 @@ package @project.getPackageName();
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions
+import @(project.getPackageName()).HttpRequest
 
 class FunctionTest {
 
     @@Test
     fun testFunction() {
         Function().use { function ->
-           val response = function.echo("test", null)
-           Assertions.assertEquals("test", response)
+           val response =  function.hello(HttpRequest.builder().build(), null).body
+           Assertions.assertEquals("Hello World", response)
         }
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionResponseBuilderJava.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionResponseBuilderJava.rocker.raw
@@ -1,0 +1,68 @@
+@import io.micronaut.starter.application.Project
+
+@args (
+Project project
+)
+
+@if (project.getPackageName() != null) {
+package @project.getPackageName();
+}
+
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.HttpStatus;
+import com.microsoft.azure.functions.HttpStatusType;
+import io.micronaut.core.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ResponseBuilder implements HttpResponseMessage.Builder, HttpResponseMessage {
+
+    private HttpStatusType status = HttpStatus.OK;
+    private final Map<String, List<String>> headers = new LinkedHashMap<>(3);
+    private Object body;
+
+    @@Override
+    public HttpResponseMessage.Builder status(HttpStatusType status) {
+        this.status = status;
+        return this;
+    }
+
+    @@Override
+    public HttpResponseMessage.Builder header(String key, String value) {
+        headers.computeIfAbsent(key, (k) -> new ArrayList<>()).add(value);
+        return this;
+    }
+
+    @@Override
+    public HttpResponseMessage.Builder body(Object body) {
+        this.body = body;
+        return this;
+    }
+
+    @@Override
+    public HttpResponseMessage build() {
+        return this;
+    }
+
+    @@Override
+    public HttpStatusType getStatus() {
+        return status;
+    }
+
+    @@Override
+    public String getHeader(String key) {
+        List<String> v = headers.get(key);
+        if (CollectionUtils.isNotEmpty(v)) {
+            return v.iterator().next();
+        }
+        return null;
+    }
+
+    @@Override
+    public Object getBody() {
+        return this.body;
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionSpock.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionSpock.rocker.raw
@@ -17,6 +17,6 @@ class FunctionSpec extends Specification {
 
     void "test function"() {
         expect:"The response is correct"
-        function.echo("test", null) == 'test'
+        function.hello(HttpRequest.builder().build(), null).body == 'Hello World'
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionTriggerGroovy.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionTriggerGroovy.rocker.raw
@@ -5,22 +5,33 @@ Project project
 )
 
 @if (project.getPackageName() != null) {
-package @project.getPackageName();
+package @project.getPackageName()
 }
 
-import com.microsoft.azure.functions.annotation.*
-import com.microsoft.azure.functions.*
+import com.microsoft.azure.functions.HttpStatus
+import com.microsoft.azure.functions.ExecutionContext
+import com.microsoft.azure.functions.HttpRequestMessage
+import com.microsoft.azure.functions.HttpMethod
+import com.microsoft.azure.functions.HttpResponseMessage
+import com.microsoft.azure.functions.annotation.AuthorizationLevel
+import com.microsoft.azure.functions.annotation.FunctionName
+import com.microsoft.azure.functions.annotation.HttpTrigger
 import io.micronaut.azure.function.AzureFunction
+import java.util.Optional
 
-/**
- * Azure Functions with HTTP Trigger.
- */
-class Function extends AzureFunction {
-    String echo(
-        @@HttpTrigger(name = "req", methods = HttpMethod.POST, authLevel = AuthorizationLevel.ANONYMOUS)
-        String req,
-        ExecutionContext context) {
-        context?.getLogger()?.info("Executing Function: ${getClass().getName()}");
-        return String.format(req)
+public class Function extends AzureFunction {
+    @@FunctionName("HttpTrigger")
+    public HttpResponseMessage echo(
+            @@HttpTrigger(
+                    name = "req",
+                    methods = [HttpMethod.GET],
+                    route = "{*route}",
+                    authLevel = AuthorizationLevel.ANONYMOUS)
+                    HttpRequestMessage<Optional<String>> request,
+            ExecutionContext context) {
+        if (context != null) {
+            context.logger.info("Executing Function: " + getClass().name)
+        }
+        request.createResponseBuilder(HttpStatus.OK).body("Hello World").build()
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionTriggerGroovy.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionTriggerGroovy.rocker.raw
@@ -21,7 +21,7 @@ import java.util.Optional
 
 public class Function extends AzureFunction {
     @@FunctionName("HttpTrigger")
-    public HttpResponseMessage echo(
+    public HttpResponseMessage hello(
             @@HttpTrigger(
                     name = "req",
                     methods = [HttpMethod.GET],

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionTriggerJava.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionTriggerJava.rocker.raw
@@ -21,7 +21,7 @@ import java.util.Optional;
 
 public class Function extends AzureFunction {
     @@FunctionName("HttpTrigger")
-    public HttpResponseMessage echo(
+    public HttpResponseMessage hello(
             @@HttpTrigger(
                     name = "req",
                     methods = {HttpMethod.GET},

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionTriggerJava.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionTriggerJava.rocker.raw
@@ -8,21 +8,30 @@ Project project
 package @project.getPackageName();
 }
 
-import com.microsoft.azure.functions.annotation.*;
-import com.microsoft.azure.functions.*;
+import com.microsoft.azure.functions.HttpStatus;
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpMethod;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.annotation.AuthorizationLevel;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.HttpTrigger;
 import io.micronaut.azure.function.AzureFunction;
+import java.util.Optional;
 
-/**
- * Azure Functions with HTTP Trigger.
- */
 public class Function extends AzureFunction {
-    public String echo(
-        @@HttpTrigger(name = "req", methods = HttpMethod.POST, authLevel = AuthorizationLevel.ANONYMOUS)
-        String req,
-        ExecutionContext context) {
+    @@FunctionName("HttpTrigger")
+    public HttpResponseMessage echo(
+            @@HttpTrigger(
+                    name = "req",
+                    methods = {HttpMethod.GET},
+                    route = "{*route}",
+                    authLevel = AuthorizationLevel.ANONYMOUS)
+                    HttpRequestMessage<Optional<String>> request,
+            ExecutionContext context) {
         if (context != null) {
             context.getLogger().info("Executing Function: " + getClass().getName());
         }
-        return String.format(req);
+        return request.createResponseBuilder(HttpStatus.OK).body("Hello World").build();
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionTriggerKotlin.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionTriggerKotlin.rocker.raw
@@ -8,21 +8,29 @@ Project project
 package @project.getPackageName();
 }
 
-import com.microsoft.azure.functions.*
-import com.microsoft.azure.functions.annotation.*
+import com.microsoft.azure.functions.HttpStatus
+import com.microsoft.azure.functions.ExecutionContext
+import com.microsoft.azure.functions.HttpRequestMessage
+import com.microsoft.azure.functions.HttpMethod
+import com.microsoft.azure.functions.HttpResponseMessage
+import com.microsoft.azure.functions.annotation.AuthorizationLevel
+import com.microsoft.azure.functions.annotation.FunctionName
+import com.microsoft.azure.functions.annotation.HttpTrigger
 import io.micronaut.azure.function.AzureFunction
+import java.util.Optional
 
-/**
- * Azure Functions with HTTP Trigger.
- */
 class Function : AzureFunction() {
+    @@FunctionName("HttpTrigger")
     fun echo(
-            @@HttpTrigger(
-                    name = "req",
-                    methods = [HttpMethod.POST],
-                    authLevel = AuthorizationLevel.ANONYMOUS) req: String,
-            context: ExecutionContext?): String {
-        context?.logger?.info("Executing Function: ${javaClass.name}")
-        return String.format(req)
+        @@HttpTrigger(
+            name = "req",
+            methods = [HttpMethod.GET],
+            route = "{*route}",
+            authLevel = AuthorizationLevel.ANONYMOUS
+        ) request: HttpRequestMessage<Optional<String?>?>,
+        context: ExecutionContext?
+    ): HttpResponseMessage {
+        context?.logger?.info("Executing Function")
+        return request.createResponseBuilder(HttpStatus.OK).body("Hello World").build()
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionTriggerKotlin.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/raw/azureRawFunctionTriggerKotlin.rocker.raw
@@ -21,7 +21,7 @@ import java.util.Optional
 
 class Function : AzureFunction() {
     @@FunctionName("HttpTrigger")
-    fun echo(
+    fun hello(
         @@HttpTrigger(
             name = "req",
             methods = [HttpMethod.GET],

--- a/starter-core/src/main/java/io/micronaut/starter/options/TestFramework.java
+++ b/starter-core/src/main/java/io/micronaut/starter/options/TestFramework.java
@@ -42,16 +42,27 @@ public enum TestFramework {
     public String getSourcePath(String path, Language language) {
         switch (this) {
             case SPOCK:
-                return Language.GROOVY.getTestSrcDir() + path + "Spec." + Language.GROOVY.getExtension();
+                return Language.GROOVY.getTestSrcDir() + path + getTestFrameworkSuffix() + Language.GROOVY.getExtension();
             case KOTEST:
-                return Language.KOTLIN.getTestSrcDir() + path + "Test." + Language.KOTLIN.getExtension();
+                return Language.KOTLIN.getTestSrcDir() + path + getTestFrameworkSuffix() + Language.KOTLIN.getExtension();
             case JUNIT:
             default:
                 if (language != null) {
-                    return language.getTestSrcDir() + path + "Test."  + language.getExtension();
+                    return language.getTestSrcDir() + path + getTestFrameworkSuffix()  + language.getExtension();
                 } else {
-                    return Language.JAVA.getTestSrcDir() + "Test." + path + Language.JAVA.getExtension();
+                    return Language.JAVA.getTestSrcDir() + getTestFrameworkSuffix() + path + Language.JAVA.getExtension();
                 }
+        }
+    }
+
+    public String getTestFrameworkSuffix() {
+        switch (this) {
+            case SPOCK:
+                return "Spec.";
+            case JUNIT:
+            case KOTEST:
+            default:
+                return "Test.";
         }
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
@@ -82,9 +82,12 @@ class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOu
         output.containsKey("$srcDir/example/micronaut/Function.$extension".toString())
         output.get("$srcDir/example/micronaut/Function.$extension".toString())
                 .contains(" AzureFunction")
+        output.containsKey(Language.JAVA.testSrcDir + "/example/micronaut/HttpRequest.$Language.JAVA.extension".toString())
+        output.containsKey(Language.JAVA.testSrcDir + "/example/micronaut/ResponseBuilder.$Language.JAVA.extension".toString())
+
         output.containsKey("$testSrcDir/example/micronaut/FunctionTest.$extension".toString())
         output.get("$testSrcDir/example/micronaut/FunctionTest.$extension".toString())
-                .contains("function.echo")
+                .contains("function.hello")
 
         where:
         language << Language.values().toList()
@@ -102,7 +105,6 @@ class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOu
                 ['azure-function']
         )
         String build = output['build.gradle']
-        def readme = output["README.md"]
 
         then:
         build.contains('runtime("azure_function")')
@@ -112,18 +114,6 @@ class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOu
         !build.contains('implementation "io.micronaut:micronaut-http-client"')
         !build.contains('"com.github.johnrengelman.shadow"')
         !build.contains('shadowJar')
-        output.containsKey("${language.srcDir}/example/micronaut/Application.${extension}".toString())
-
-        readme?.contains("Micronaut and Azure Function")
-        output.containsKey("host.json")
-        output.containsKey("local.settings.json")
-        output.containsKey("$srcDir/example/micronaut/FooController.$extension".toString())
-        output.get("$srcDir/example/micronaut/Function.$extension".toString())
-                .contains(" AzureHttpFunction")
-        output.containsKey("$srcDir/example/micronaut/Function.$extension".toString())
-        output.containsKey("$testSrcDir/example/micronaut/FooFunctionTest.$extension".toString())
-        output.get("$testSrcDir/example/micronaut/FooFunctionTest.$extension".toString())
-                .contains("HttpRequestMessageBuilder")
 
         when:
         String pluginId = 'com.microsoft.azure.azurefunctions'
@@ -138,6 +128,40 @@ class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOu
         then:
         noExceptionThrown()
         semanticVersionOptional.isPresent()
+
+        where:
+        language << Language.values().toList()
+        extension << Language.extensions()
+        srcDir << Language.srcDirs()
+        testSrcDir << Language.testSrcDirs()
+    }
+
+    @Unroll
+    void 'test sources generated for azure function feature gradle and language=#language'(Language language,
+                                                                                           String extension,
+                                                                                           String srcDir,
+                                                                                           String testSrcDir) {
+        when:
+        def output = generate(
+                ApplicationType.DEFAULT,
+                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_8),
+                ['azure-function']
+        )
+        def readme = output["README.md"]
+
+        then:
+        output.containsKey("${language.srcDir}/example/micronaut/Application.${extension}".toString())
+
+        readme?.contains("Micronaut and Azure Function")
+        output.containsKey("host.json")
+        output.containsKey("local.settings.json")
+        output.containsKey("$srcDir/example/micronaut/FooController.$extension".toString())
+        output.get("$srcDir/example/micronaut/Function.$extension".toString())
+                .contains(" AzureHttpFunction")
+        output.containsKey("$srcDir/example/micronaut/Function.$extension".toString())
+        output.containsKey("$testSrcDir/example/micronaut/FooFunctionTest.$extension".toString())
+        output.get("$testSrcDir/example/micronaut/FooFunctionTest.$extension".toString())
+                .contains("HttpRequestMessageBuilder")
 
         where:
         language << Language.values().toList()


### PR DESCRIPTION
It did not work without `@FunctionName`not sure if it was always broken or we have changed anything. Do you know @graemerocher  ?

I've generated and run apps with three languages : 

```
./gradlew micronaut-cli:run --args="create-function-app --lang=java --build=gradle --features=azure-function temp"
./gradlew micronaut-cli:run --args="create-function-app --lang=groovy --build=gradle --features=azure-function temp"
./gradlew micronaut-cli:run --args="create-function-app --lang=kotlin --build=gradle --features=azure-function temp"
```

Then, I started the app:

```
cd starter-cli/temp
./gradlew azureFunctionsRun 
```

and hit the endpoint:

```
 curl localhost:7071/api/foo
Hello World
```