### PR TITLE
Fix CLI native image generation

### DIFF
--- a/.github/workflows/mn-linux-snapshot.yml
+++ b/.github/workflows/mn-linux-snapshot.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v2.3.4
       - name: Install GraalVM
         env:
-          GRAAL_VERSION: 21.0.0.2
+          GRAAL_VERSION: 21.1.0
           GRAAL_OS: linux-amd64
         run: ./install-graal.sh
       - name: Install Native Image

--- a/.github/workflows/mn-macos-snapshot.yml
+++ b/.github/workflows/mn-macos-snapshot.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v2.3.4
       - name: Install GraalVM
         env:
-          GRAAL_VERSION: 21.0.0.2
+          GRAAL_VERSION: 21.1.0
           GRAAL_OS: darwin-amd64
         run: ./install-graal.sh
       - name: Install Native Image

--- a/.github/workflows/mn-windows-snapshot.yml
+++ b/.github/workflows/mn-windows-snapshot.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: ayltai/setup-graalvm@v1
         with:
           java-version: 8
-          graalvm-version: 21.0.0.2
+          graalvm-version: 21.1.0
           native-image: true
       - name: Build JAR File
         shell: powershell

--- a/.github/workflows/mn-windows-snapshot.yml
+++ b/.github/workflows/mn-windows-snapshot.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: microsoft/setup-msbuild@v1
       - uses: ayltai/setup-graalvm@v1
         with:
-          java-version: 8
+          java-version: 11
           graalvm-version: 21.1.0
           native-image: true
       - name: Build JAR File

--- a/install-graal.sh
+++ b/install-graal.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-GRAAL_FILENAME="graalvm-ce-java8-${GRAAL_OS}-${GRAAL_VERSION}.tar.gz"
+GRAAL_FILENAME="graalvm-ce-java11-${GRAAL_OS}-${GRAAL_VERSION}.tar.gz"
 
 mkdir tmp
 curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAAL_VERSION}/${GRAAL_FILENAME} -o tmp/${GRAAL_FILENAME}
-tar -zxvf tmp/${GRAAL_FILENAME} -C tmp && mv tmp/graalvm-ce-java8-${GRAAL_VERSION} graalvm
+tar -zxvf tmp/${GRAAL_FILENAME} -C tmp && mv tmp/graalvm-ce-java11-${GRAAL_VERSION} graalvm
 rm -rf tmp/*

--- a/starter-cli/build.gradle
+++ b/starter-cli/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     implementation "org.fusesource.jansi:jansi:1.18"
     implementation "org.yaml:snakeyaml:1.28"
 
+    implementation "jakarta.inject:jakarta.inject-api:2.0.0"
+
     implementation 'org.shredzone.acme4j:acme4j-client:2.11'
     implementation 'org.shredzone.acme4j:acme4j-utils:2.10'
 


### PR DESCRIPTION
Fix CLI native image generation: https://github.com/micronaut-projects/micronaut-starter/runs/2688761956?check_suite_focus=true#step:7:152

When https://github.com/micronaut-projects/micronaut-core/pull/5503 gets merged we can remove the dependency on jakarta.inject that this PR adds and use `jakarta.inject.Provider` in Starter.