### PR TITLE
Fix show null values in PreviewDTO

### DIFF
--- a/starter-api/src/main/resources/META-INF/native-image/io.micronaut.starter.api/micronaut-starter-api/reflect-config.json
+++ b/starter-api/src/main/resources/META-INF/native-image/io.micronaut.starter.api/micronaut-starter-api/reflect-config.json
@@ -43,4 +43,10 @@
 },{
 "name" : "org.apache.commons.compress.archivers.zip.ResourceAlignmentExtraField",
 "allDeclaredConstructors" : true
-}]
+},{
+"name":"io.micronaut.starter.api.preview.PreviewDTO",
+"allDeclaredFields":true,
+"allDeclaredMethods":true,
+"allDeclaredConstructors":true
+}
+]


### PR DESCRIPTION
This PRs includes the `null` values in `PreviewDTO` response so the UI will be able to show the binary files when doing a preview:

![image](https://user-images.githubusercontent.com/559192/121661065-1a529880-caa4-11eb-928b-83ba6a50b35c.png)

It seems that our Jackson module that uses BeanIntrospection is missing something regarding `@JsonInclude` because the fix is add the class to GraalVM reflect-config.
@jameskleeh you mentioned we have support for it and this [test probes it](https://github.com/micronaut-projects/micronaut-core/blob/a6c0bae9431e0cc072b3d6940e11c168986ebb2e/runtime/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy#L98-L116), so not really sure what's going on.

