### PR TITLE
Remove reference to jcenter from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Snaphots are automatically published to [Sonatype OSSRH](https://s01.oss.sonatyp
 
 See the documentation in the [Micronaut Docs](https://docs.micronaut.io/latest/guide/index.html#usingsnapshots) for how to configure your build to use snapshots.
 
-Releases are published to JCenter and Maven Central via [Github Actions](https://github.com/micronaut-projects/micronaut-starter/actions).
+Releases are published to Maven Central via [Github Actions](https://github.com/micronaut-projects/micronaut-starter/actions).
 
 A release is performed with the following steps:
 


### PR DESCRIPTION
jcenter publishing was removed in 88c27c4a5999aa5c8b6ca3935df6e97a669a29d6