### PR TITLE
feat: add camunda-external-worker feature

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/camunda/CamundaExternalWorker.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/camunda/CamundaExternalWorker.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.camunda;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.feature.Category;
+import io.micronaut.starter.feature.Feature;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class CamundaExternalWorker implements Feature {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "camunda-external-worker";
+    }
+
+    @Override
+    public String getTitle() {
+        return "External Worker for Camunda (Workflow Engine)";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Allows to implement External Workers (for Camunda Workflow Engine) in your Micronaut applications.";
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return applicationType == ApplicationType.DEFAULT;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        generatorContext.getConfiguration().put("camunda.external-client.base-url", "http://localhost:8080/engine-rest");
+        generatorContext.addDependency(Dependency.builder()
+                .lookupArtifactId("micronaut-camunda-external-client-feature")
+                .compile());
+    }
+
+    @Override
+    public String getCategory() {
+        return Category.BPM;
+    }
+
+    @Override
+    @Nullable
+    public String getThirdPartyDocumentation() {
+        return "https://github.com/camunda-community-hub/micronaut-camunda-external-client";
+    }
+
+}

--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -23,6 +23,11 @@
             <version>0.23.0</version>
         </dependency>
         <dependency>
+            <groupId>info.novatec</groupId>
+            <artifactId>micronaut-camunda-external-client-feature</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-bom</artifactId>
             <version>1.4.32</version>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/CamundaExternalWorkerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/CamundaExternalWorkerSpec.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.camunda
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.application.generator.GeneratorContext
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import spock.lang.Unroll
+
+class CamundaExternalWorkerSpec extends ApplicationContextSpec implements CommandOutputFixture {
+
+    void 'test readme.md with feature camunda-external-worker contains links to micronaut docs'() {
+        when:
+        def output = generate(['camunda-external-worker'])
+        def readme = output["README.md"]
+
+        then:
+        readme
+        readme.contains("https://github.com/camunda-community-hub/micronaut-camunda-external-client")
+    }
+
+    @Unroll
+    void 'test gradle camunda-external-worker feature for language=#language'() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['camunda-external-worker'])
+                .render()
+
+        then:
+        template.count('implementation("info.novatec:micronaut-camunda-external-client-feature:') == 1
+
+        where:
+        language << Language.values().toList()
+    }
+
+    @Unroll
+    void 'test maven camunda-external-worker feature for language=#language'() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['camunda-external-worker'])
+                .render()
+
+        then:
+        template.count('''\
+    <dependency>
+      <groupId>info.novatec</groupId>
+      <artifactId>micronaut-camunda-external-client-feature</artifactId>
+ ''') == 1
+        where:
+        language << Language.values().toList()
+    }
+
+    void 'test camunda-external-worker configuration'() {
+        when:
+        GeneratorContext commandContext = buildGeneratorContext(['camunda-external-worker'])
+
+        then:
+        commandContext.configuration.get('camunda.external-client.base-url'.toString()) == "http://localhost:8080/engine-rest"
+    }
+}


### PR DESCRIPTION
I'm the lead developer of the Micronaut Camunda Integration Project.

Apart from the already existing "camunda" feature (see #704) we also have a second project which integrates Micronaut and Camunda External Task Workers. Please add this to Micronaut Launch as well.

Please merge this PR.