### PR TITLE
Create ATP feature (#737)

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/atp/Atp.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/atp/Atp.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.atp;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.feature.Category;
+import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.FeaturePhase;
+import io.micronaut.starter.feature.config.ApplicationConfiguration;
+import io.micronaut.starter.feature.database.jdbc.JdbcFeature;
+import io.micronaut.starter.feature.oraclecloud.OracleCloudSdk;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class Atp implements Feature {
+    private final OracleCloudSdk oracleCloudSdkFeature;
+
+    public Atp(OracleCloudSdk oracleCloudSdkFeature) {
+        this.oracleCloudSdkFeature = oracleCloudSdkFeature;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "oracle-cloud-atp";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Oracle Cloud ATP";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Provides integration with Oracle Cloud Autonomous Database";
+    }
+
+    @Override
+    public String getMicronautDocumentation() {
+        return "https://micronaut-projects.github.io/micronaut-oracle-cloud/latest/guide/#_micronaut_oraclecloud_atp";
+    }
+
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://www.oracle.com/autonomous-database/autonomous-transaction-processing/";
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
+    public int getOrder() {
+        // need to run after the jdbc feature
+        return FeaturePhase.DEFAULT.getOrder();
+    }
+
+    @Override
+    public String getCategory() {
+        return Category.CLOUD;
+    }
+
+    @Override
+    public void processSelectedFeatures(FeatureContext featureContext) {
+        if (!featureContext.isPresent(OracleCloudSdk.class)) {
+            featureContext.addFeature(oracleCloudSdkFeature);
+        }
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        generatorContext.addDependency(Dependency.builder()
+                .compile()
+                .groupId("io.micronaut.oraclecloud").artifactId("micronaut-oraclecloud-atp")
+                .build());
+
+        ApplicationConfiguration cfg = generatorContext.getConfiguration();
+
+        // remove old jdbc config
+        generatorContext.getFeature(JdbcFeature.class).ifPresent(jdbc -> {
+            cfg.remove(jdbc.getDriverKey());
+            cfg.remove(jdbc.getUrlKey());
+            cfg.remove(jdbc.getUsernameKey());
+            cfg.remove(jdbc.getPasswordKey());
+        });
+
+        cfg.put("datasources.default.ocid", "");
+        cfg.put("datasources.default.walletPassword", "");
+        cfg.put("datasources.default.username", "");
+        cfg.put("datasources.default.password", "");
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/oraclecloud/OracleCloudSdk.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/oraclecloud/OracleCloudSdk.java
@@ -69,5 +69,6 @@ public class OracleCloudSdk implements Feature {
                 .groupId("io.micronaut.oraclecloud")
                 .artifactId("micronaut-oraclecloud-sdk")
                 .compile());
+        generatorContext.getConfiguration().put("oci.config.profile", "DEFAULT");
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/atp/AtpSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/atp/AtpSpec.groovy
@@ -1,4 +1,4 @@
-package io.micronaut.starter.feature.oracecloud
+package io.micronaut.starter.feature.atp
 
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
@@ -7,27 +7,27 @@ import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class OracleCloudSdkSpec extends ApplicationContextSpec implements CommandOutputFixture {
+class AtpSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Unroll
-    void 'test Oracle Cloud SDK feature for language=#language'() {
+    void 'test ATP feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .features(['oracle-cloud-sdk'])
+                .features(['oracle-cloud-atp'])
                 .language(language)
                 .render()
         then:
-        template.contains('implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-sdk")')
+        template.contains('implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-atp")')
 
         where:
         language << Language.values().toList()
     }
 
     @Unroll
-    void 'test Oracle Cloud SDK feature for maven and language=#language'() {
+    void 'test ATP feature for maven and language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .features(['oracle-cloud-sdk'])
+                .features(['oracle-cloud-atp'])
                 .language(language)
                 .render()
 
@@ -35,7 +35,7 @@ class OracleCloudSdkSpec extends ApplicationContextSpec implements CommandOutput
         template.contains("""
     <dependency>
       <groupId>io.micronaut.oraclecloud</groupId>
-      <artifactId>micronaut-oraclecloud-sdk</artifactId>
+      <artifactId>micronaut-oraclecloud-atp</artifactId>
       <scope>compile</scope>
     </dependency>
 """)
@@ -43,13 +43,28 @@ class OracleCloudSdkSpec extends ApplicationContextSpec implements CommandOutput
         language << Language.values().toList()
     }
 
-    void 'test Oracle Cloud SDK config file'() {
+    void 'test ATP config file'() {
         when:
-        def output = generate(['oracle-cloud-sdk'])
+        def output = generate(['oracle-cloud-atp'])
         def config = output["src/main/resources/application.yml"]
 
         then:
-        config.contains('oci.config.profile: DEFAULT')
+        config.contains("""
+datasources:
+  default:
+    ocid: ''
+    walletPassword: ''
+    username: ''
+    password: ''
+""")
     }
 
+    void 'test ATP config file no jdbc config'() {
+        when:
+        def output = generate(['jdbc-hikari', 'oracle-cloud-atp'])
+        def config = output["src/main/resources/application.yml"]
+
+        then:
+        !config.contains('driverClassName')
+    }
 }


### PR DESCRIPTION
This PR adds an ATP feature similar to [the guide](https://guides.micronaut.io/latest/micronaut-oracle-autonomous-db-gradle-java.html). 

The commit also adds a default empty config for the new ATP feature and the oracle cloud feature. I put the new config into the main application.yml instead of a separate application-oraclecloud.yml so that it's used out-of-the-box and doesn't lead to confusion for users unfamiliar with micronaut environments. 