### PR TITLE
fix: replaces com.fizzed with nu.studer rocker

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/view/Rocker.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/view/Rocker.java
@@ -59,9 +59,9 @@ public class Rocker implements ViewFeature, MicronautServerDependent {
                 .artifactId("micronaut-views-rocker")
                 .compile());
         generatorContext.addBuildPlugin(GradlePlugin.builder()
-                .id("com.fizzed.rocker")
+                .id("nu.studer.rocker")
                 .extension(new RockerWritable(gradlePluginRocker.template(rockerSrcDir(generatorContext))))
-                .lookupArtifactId("rocker-gradle-plugin")
+                .lookupArtifactId("gradle-rocker-plugin")
                 .build());
         String mavenPluginArtifactId = "rocker-maven-plugin";
         Coordinate coordinate = generatorContext.resolveCoordinate(mavenPluginArtifactId);

--- a/starter-core/src/main/java/io/micronaut/starter/feature/view/gradlePluginRocker.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/view/gradlePluginRocker.rocker.raw
@@ -1,8 +1,10 @@
 @args(String path)
-sourceSets {
-    main {
-        rocker {
-            srcDir("@path")
+
+rocker {
+    configurations {
+        main {
+            templateDir = file("@path")
+            outputDir = file("src/generated/rocker")
         }
     }
 }

--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -103,9 +103,9 @@
             <version>1.3.0</version>
         </dependency>
         <dependency>
-            <groupId>com.fizzed</groupId>
-            <artifactId>rocker-gradle-plugin</artifactId>
-            <version>1.3.0</version>
+            <groupId>nu.studer</groupId>
+            <artifactId>gradle-rocker-plugin</artifactId>
+            <version>3.0.4</version>
         </dependency>
         <dependency>
             <groupId>gradle.plugin.com.github.jengelman.gradle.plugins</groupId>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/RockerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/RockerSpec.groovy
@@ -32,17 +32,18 @@ class RockerSpec extends ApplicationContextSpec implements CommandOutputFixture 
         then:
         template.contains('implementation("io.micronaut.views:micronaut-views-rocker")')
         template.contains('''\
-sourceSets {
-    main {
-        rocker {
-            srcDir("src/main/resources")
+rocker {
+    configurations {
+        main {
+            templateDir = file("src/main/resources")
+            outputDir = file("src/generated/rocker")
         }
     }
 }
 ''')
 
         when:
-        String pluginId = 'com.fizzed.rocker'
+        String pluginId = 'nu.studer.rocker'
         String applyPlugin = 'id("' + pluginId + '") version "'
 
         then:

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/feature/views/RockerSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/feature/views/RockerSpec.groovy
@@ -1,0 +1,41 @@
+package io.micronaut.starter.core.test.feature.views
+
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.test.CommandSpec
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.Unroll
+
+class RockerSpec  extends CommandSpec {
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "rockerViews"
+    }
+
+    @Unroll
+    void "test maven views-rocker with #language"(Language language) {
+        when:
+        generateProject(language, BuildTool.MAVEN, ["views-rocker"])
+        String output = executeMaven("compile")
+
+        then:
+        output?.contains("BUILD SUCCESS")
+
+        where:
+        language << Language.values()
+    }
+
+    @Unroll
+    void "test gradle views-rocker with #language"(Language language) {
+        when:
+        generateProject(language, BuildTool.GRADLE, ["views-rocker"])
+        BuildResult result = executeGradle("compileJava")
+
+        then:
+        result?.output?.contains("BUILD SUCCESS")
+
+        where:
+        language << Language.values()
+    }
+}


### PR DESCRIPTION
Closes #901

Replaces Gradle plugin:

https://plugins.gradle.org/plugin/com.fizzed.rocker

with:

https://plugins.gradle.org/plugin/nu.studer.rocker

`fizzed` is not Gradle 7 compatible.

It adds a functional test. 