### PR TITLE
Publish build scans on ge.micraunaut.io

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,12 @@
-plugins {
-    id "com.gradle.enterprise" version "3.2.1"
-}
-gradleEnterprise {
-    buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
     }
+}
+
+plugins {
+    id 'io.micronaut.build.shared.settings' version '4.1.4'
 }
 
 rootProject.name = 'micronaut-starter'


### PR DESCRIPTION
The previous version was publishing build scans on the public scan
server. Now that we have a dedicated Gradle Enterprise instance it's
better to publish there since we will have more features available.