### PR TITLE
Use JDK17 on CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '16']
+        java: ['8', '11', '17']
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2.1.6


### PR DESCRIPTION
This should fix all the tests failing like this one:

```
io.micronaut.starter.cli.feature.database.CreateRepositorySpec test creating a repository - groovy FAILED

  java.lang.IllegalArgumentException: Unsupported JDK version: 16. Supported values are [8, 11, 17]
```

Because JDK16 is not supported anymore in Starter.