### PR TITLE
Remove JDK 17 limit from GraalVM feature

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/graalvm/GraalVMFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/graalvm/GraalVMFeatureValidator.java
@@ -41,8 +41,8 @@ public class GraalVMFeatureValidator implements FeatureValidator {
                 throw new IllegalArgumentException("GraalVM is not supported in Groovy applications");
             }
 
-            if (options.getJavaVersion().majorVersion() > JdkVersion.JDK_11.majorVersion()) {
-                throw new IllegalArgumentException("GraalVM with native image only supports up to JDK 11");
+            if (options.getJavaVersion().majorVersion() > JdkVersion.JDK_17.majorVersion()) {
+                throw new IllegalArgumentException("GraalVM with native image only supports up to JDK 17");
             }
         }
     }


### PR DESCRIPTION
It is not currently possible to create a JDK 17 application with the GraalVM feature selected which is confusing users