### PR TITLE
feat: add zeebe feature

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/camunda/Zeebe.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/camunda/Zeebe.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.camunda;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.feature.Category;
+import io.micronaut.starter.feature.Feature;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class Zeebe implements Feature {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "zeebe";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Zeebe Worker";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Implement Zeebe Workers for Camunda Cloud or a local broker";
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return applicationType == ApplicationType.DEFAULT;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        generatorContext.addDependency(Dependency.builder()
+                .lookupArtifactId("micronaut-zeebe-client-feature")
+                .compile());
+    }
+
+    @Override
+    public String getCategory() {
+        return Category.BPM;
+    }
+
+    @Override
+    @Nullable
+    public String getThirdPartyDocumentation() {
+        return "https://github.com/camunda-community-hub/micronaut-zeebe-client";
+    }
+
+}

--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -28,6 +28,11 @@
             <version>2.1.0</version>
         </dependency>
         <dependency>
+            <groupId>info.novatec</groupId>
+            <artifactId>micronaut-zeebe-client-feature</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-bom</artifactId>
             <version>1.5.21</version>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/ZeebeSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/ZeebeSpec.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.camunda
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import spock.lang.Unroll
+
+class ZeebeSpec extends ApplicationContextSpec implements CommandOutputFixture {
+
+    void 'test readme.md with feature zeebe contains links to micronaut docs'() {
+        when:
+        def output = generate(['zeebe'])
+        def readme = output["README.md"]
+
+        then:
+        readme
+        readme.contains("https://github.com/camunda-community-hub/micronaut-camunda-bpm")
+    }
+
+    @Unroll
+    void 'test gradle zeebe feature for language=#language'() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['zeebe'])
+                .render()
+
+        then:
+        template.count('implementation("info.novatec:micronaut-zeebe-client-feature:') == 1
+
+        where:
+        language << Language.values().toList()
+    }
+
+    @Unroll
+    void 'test maven zeebe feature for language=#language'() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['zeebe'])
+                .render()
+
+        then:
+        template.count('''\
+    <dependency>
+      <groupId>info.novatec</groupId>
+      <artifactId>micronaut-zeebe-client-feature</artifactId>
+ ''') == 1
+        where:
+        language << Language.values().toList()
+    }
+}


### PR DESCRIPTION
I'm the lead developer of the Micronaut Camunda Integration Project.

Apart from the already existing "camunda" feature (see #704) we also have another project which integrates Micronaut and Zeebe from Camunda. Please add this to Micronaut Launch as well.

Please merge this PR.

I tested the following:
`./gradlew micronaut-cli:run --args="create-app --list-features"` -> Looks good, feature is listed

Both the following look good
`./gradlew micronaut-cli:run --args="create-app --features=zeebe temp3"`
`./gradlew micronaut-cli:run --args="create-app --build=maven --features=zeebe temp3m"`

and build successfully.