### PR TITLE
Upgrade to Micronaut Gradle Plugin 3.0.2

### DIFF
--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>io.micronaut.gradle</groupId>
             <artifactId>micronaut-gradle-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>


### PR DESCRIPTION
The 3.0.2 release of the Micronaut Gradle plugin makes sure to use latest log4j.