### PR TITLE
Show micronaut 3.0 on the SDKMAN list of available versions

### DIFF
--- a/starter-cli/build.gradle
+++ b/starter-cli/build.gradle
@@ -129,6 +129,8 @@ sdkman {
     version = project.version
     hashtag = "#micronautfw"
     platforms = [
+            // TODO:  Once graal native-image works for arm OSX, we should switch to building and publishing a non-rosetta release (https://github.com/oracle/graal/issues/2666)
+            "MAC_ARM64":"https://github.com/micronaut-projects/micronaut-starter/releases/download/v${project.version}/mn-darwin-amd64-v${project.version}.zip",
             "MAC_OSX":"https://github.com/micronaut-projects/micronaut-starter/releases/download/v${project.version}/mn-darwin-amd64-v${project.version}.zip",
             "WINDOWS_64":"https://github.com/micronaut-projects/micronaut-starter/releases/download/v${project.version}/mn-win-amd64-v${project.version}.zip",
             "LINUX_64":"https://github.com/micronaut-projects/micronaut-starter/releases/download/v${project.version}/mn-linux-amd64-v${project.version}.zip"


### PR DESCRIPTION
RE: https://github.com/sdkman/sdkman-cli/issues/996

Currently, when listing the available micronaut versions on a new Apple arm computer, you get a limited list (similar to this)

```
================================================================================
Available Micronaut Versions
================================================================================
                         1.2.11              1.1.3               1.0.0.RC2
     2.0.0.RC1           1.2.10              1.1.2               1.0.0.RC1
     2.0.0.M2            1.2.9               1.1.1               1.0.0.M4
     2.0.0.M1            1.2.8               1.1.0               1.0.0.M3
     1.3.7               1.2.7               1.1.0.RC2           1.0.0.M2
     1.3.6               1.2.6               1.1.0.RC1           1.0.0.M1
     1.3.5               1.2.5               1.1.0.M2
     1.3.4               1.2.4               1.1.0.M1
     1.3.3               1.2.3               1.0.5
     1.3.2               1.2.2               1.0.4
     1.3.1               1.2.1               1.0.3
     1.3.0               1.2.0               1.0.2
     1.3.0.RC1           1.2.0.RC2           1.0.1
     1.3.0.M2            1.2.0.RC1           1.0.0
     1.3.0.M1            1.1.4               1.0.0.RC3

================================================================================
+ - local version
* - installed
> - currently in use
================================================================================
```

I believe SDKMAN has added a new channel for MacArm64

https://github.com/sdkman/sdkman-candidates/blob/20317f77dec426c5c91a526b731291150a20da69/app/utils/Platform.scala#L31

This change will publish the Intel version of the native image to the Arm channel next time there is a release.

I have tested the amd64 image locally, and it works, and runs under Rosetta

![image](https://user-images.githubusercontent.com/49317/146205030-9c9ebca2-49af-4755-8482-3ef10200ded8.png)

Once the graalvm supports Arm64, we should update this to build and publish the correct native images to sdkman