### PR TITLE
Update zeebe to 1.1.1 - fixing log4shell vulnerability

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/camunda/Camunda.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/camunda/Camunda.java
@@ -52,7 +52,7 @@ public class Camunda implements Feature {
 
     @Override
     public String getDescription() {
-        return "We're bringing process automation to Micronaut: Embed the Camunda Workflow Engine into your Micronaut application.";
+        return "Bringing process automation to Micronaut: Embed the Camunda Platform Workflow Engine";
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/camunda/CamundaExternalWorker.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/camunda/CamundaExternalWorker.java
@@ -40,7 +40,7 @@ public class CamundaExternalWorker implements Feature {
 
     @Override
     public String getDescription() {
-        return "We're bringing process automation to Micronaut: Implement Camunda External Workers for the Camunda Platform.";
+        return "Bringing process automation to Micronaut: Implement Camunda External Workers for the Camunda Platform";
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/camunda/Zeebe.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/camunda/Zeebe.java
@@ -40,7 +40,7 @@ public class Zeebe implements Feature {
 
     @Override
     public String getDescription() {
-        return "We're bringing cloud native process automation to Micronaut: Implement Zeebe Workers for Camunda Cloud or a local broker.";
+        return "Bringing cloud native process automation to Micronaut: Implement Zeebe Workers for Camunda Cloud or a local broker";
     }
 
     @Override

--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>info.novatec</groupId>
             <artifactId>micronaut-zeebe-client-feature</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
I'm the lead developer of the Micronaut Camunda Integration Projects. This PR only effects newly created projects because the camunda modules are not in the BOM. So this new version upgrade only affects new users creating applications with Launch.

Please merge this PR. It fixes the log4shell vulnerability in the transitive dependency zeebe.