### PR TITLE
build: update log4j to 2.17.0

### DIFF
--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -125,17 +125,17 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/elasticsearch/ElasticsearchSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/elasticsearch/ElasticsearchSpec.groovy
@@ -76,8 +76,8 @@ class ElasticsearchSpec extends ApplicationContextSpec  implements CommandOutput
 
         then:
         template.contains('runtimeOnly("org.slf4j:log4j-over-slf4j:1.7.30")')
-        template.contains('implementation("org.apache.logging.log4j:log4j-api:2.16.0")')
-        template.contains('implementation("org.apache.logging.log4j:log4j-core:2.16.0")')
+        template.contains('implementation("org.apache.logging.log4j:log4j-api:2.17.0")')
+        template.contains('implementation("org.apache.logging.log4j:log4j-core:2.17.0")')
 
         where:
         language << Language.values().toList() - Language.GROOVY
@@ -105,7 +105,7 @@ class ElasticsearchSpec extends ApplicationContextSpec  implements CommandOutput
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.16.0</version>
+      <version>2.17.0</version>
       <scope>compile</scope>
     </dependency>
 """)
@@ -113,7 +113,7 @@ class ElasticsearchSpec extends ApplicationContextSpec  implements CommandOutput
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.16.0</version>
+      <version>2.17.0</version>
       <scope>compile</scope>
     </dependency>
 """)


### PR DESCRIPTION
> The Log4j team has been made aware of a security vulnerability, CVE-2021-45105, that has been addressed in Log4j 2.17.0 for Java 8 and up.
> Summary: Apache Log4j2 does not always protect from infinite recursion in lookup evaluation.