### PR TITLE
Upgrade to Gradle plugin 3.1.1

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/Gradle.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/Gradle.java
@@ -90,11 +90,6 @@ public class Gradle implements BuildFeature {
                 build
         )));
 
-        // Disable Gradle Toolchain by default until users can set a specific GraalVM version
-        generatorContext.getBuildProperties().put("org.gradle.java.installations.auto-download", "false");
-        generatorContext.getBuildProperties().put("org.gradle.java.installations.auto-detect", "false");
-        generatorContext.getBuildProperties().put("org.gradle.java.installations.fromEnv", "JAVA_HOME");
-
         generatorContext.addTemplate("gitignore", new RockerTemplate(".gitignore", gitignore.template()));
         generatorContext.addTemplate("projectProperties", new RockerTemplate("gradle.properties", gradleProperties.template(generatorContext.getBuildProperties().getProperties())));
         String settingsFile = buildTool == BuildTool.GRADLE ? "settings.gradle" : "settings.gradle.kts";

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -229,6 +229,14 @@ tasks {
 }
 }
 
+@if (applicationType == ApplicationType.DEFAULT || features.contains("oracle-function")) {
+    @if(gradleBuild.getDsl() == GradleDsl.KOTLIN) {
+graalvmNative.toolchainDetection.set(false)
+    } else {
+graalvmNative.toolchainDetection = false
+    }
+}
+
 @if (features.contains("oracle-function")) {
 @if (features.contains("oracle-function-http")) {
 graalvmNative {

--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>io.micronaut.gradle</groupId>
             <artifactId>micronaut-gradle-plugin</artifactId>
-            <version>3.0.2</version>
+            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/gradle/GradleSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/gradle/GradleSpec.groovy
@@ -7,9 +7,10 @@ import io.micronaut.starter.build.gradle.GradleBuild
 import io.micronaut.starter.feature.build.gradle.templates.gradleProperties
 import io.micronaut.starter.feature.build.gradle.templates.settingsGradle
 import io.micronaut.starter.fixture.CommandOutputFixture
-import io.micronaut.starter.options.*
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
 import spock.lang.Issue
-import spock.lang.PendingFeature
 import spock.lang.Unroll
 
 class GradleSpec extends BeanContextSpec implements CommandOutputFixture {
@@ -63,19 +64,36 @@ class GradleSpec extends BeanContextSpec implements CommandOutputFixture {
         buildGradle.contains("tasks")
     }
 
-    void 'disable Gradle Toolchain by default (language=#language)'() {
+    void 'disable Gradle Toolchain by default (dsl = #dsl)'() {
         when:
-        def output = generate(ApplicationType.DEFAULT, new Options(language, BuildTool.GRADLE))
-        def gradleProperties = output["gradle.properties"]
+        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, dsl))
+        def buildGradle = output[fileName]
 
         then:
-        gradleProperties
-        gradleProperties.contains("org.gradle.java.installations.auto-download=false")
-        gradleProperties.contains("org.gradle.java.installations.auto-detect=false")
-        gradleProperties.contains("org.gradle.java.installations.fromEnv=JAVA_HOME")
+        buildGradle
+        buildGradle.contains(configuration)
 
         where:
-        language << Language.values()
+        dsl                     | fileName           | configuration
+        BuildTool.GRADLE        | 'build.gradle'     | 'graalvmNative.toolchainDetection = false'
+        BuildTool.GRADLE_KOTLIN | 'build.gradle.kts' | 'graalvmNative.toolchainDetection.set(false)'
+
+    }
+
+    void 'disable Gradle Toolchain by default for Oracle function (dsl = #dsl)'() {
+        when:
+        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, dsl), ['oracle-function'])
+        def buildGradle = output[fileName]
+
+        then:
+        buildGradle
+        buildGradle.contains(configuration)
+
+        where:
+        dsl                     | fileName           | configuration
+        BuildTool.GRADLE        | 'build.gradle'     | 'graalvmNative.toolchainDetection = false'
+        BuildTool.GRADLE_KOTLIN | 'build.gradle.kts' | 'graalvmNative.toolchainDetection.set(false)'
+
     }
 
 }


### PR DESCRIPTION
This upgrades to the latest Gradle plugin version and replaces the global toolchain disabling with a GraalVM specific toolchain disabling mechanism.