### PR TITLE
gradle plugins support for build imports

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleBuild.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleBuild.java
@@ -24,8 +24,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class GradleBuild {
@@ -93,5 +96,17 @@ public class GradleBuild {
                     }
                 });
         return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    @NonNull
+    public Set<String> getPluginsImports() {
+        Set<String> imports = new HashSet<>();
+        for (GradlePlugin p : plugins) {
+            Set<String> pluginImports = p.getBuildImports();
+            if (pluginImports != null) {
+                imports.addAll(pluginImports);
+            }
+        }
+        return imports.stream().map(it -> it + System.lineSeparator()).collect(Collectors.toSet());
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradlePlugin.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradlePlugin.java
@@ -24,7 +24,10 @@ import io.micronaut.starter.build.dependencies.LookupFailedException;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.template.Writable;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 public class GradlePlugin implements BuildPlugin {
 
@@ -34,6 +37,7 @@ public class GradlePlugin implements BuildPlugin {
     private final Writable extension;
     private final Writable settingsExtension;
     private final boolean requiresLookup;
+    private final Set<String> buildImports;
     private final int order;
 
     public GradlePlugin(@NonNull String id,
@@ -42,7 +46,8 @@ public class GradlePlugin implements BuildPlugin {
                         @Nullable Writable extension,
                         @Nullable Writable settingsExtension,
                         boolean requiresLookup,
-                        int order) {
+                        int order,
+                        Set<String> buildImports) {
         this.id = id;
         this.version = version;
         this.artifactId = artifactId;
@@ -50,6 +55,12 @@ public class GradlePlugin implements BuildPlugin {
         this.settingsExtension = settingsExtension;
         this.requiresLookup = requiresLookup;
         this.order = order;
+        this.buildImports = buildImports;
+    }
+
+    @Nullable
+    public Set<String> getBuildImports() {
+        return buildImports;
     }
 
     @NonNull
@@ -93,7 +104,7 @@ public class GradlePlugin implements BuildPlugin {
     public BuildPlugin resolved(CoordinateResolver coordinateResolver) {
         Coordinate coordinate = coordinateResolver.resolve(artifactId)
                 .orElseThrow(() -> new LookupFailedException(artifactId));
-        return new GradlePlugin(id, coordinate.getVersion(), null, extension, settingsExtension, false, order);
+        return new GradlePlugin(id, coordinate.getVersion(), null, extension, settingsExtension, false, order, buildImports);
     }
 
     @Override
@@ -126,12 +137,19 @@ public class GradlePlugin implements BuildPlugin {
         private Writable settingsExtension;
         private boolean requiresLookup;
         private int order = 0;
+        private Set<String> buildImports = new HashSet<>();
 
         private Builder() { }
 
         @NonNull
         public GradlePlugin.Builder id(@NonNull String id) {
             this.id = id;
+            return this;
+        }
+
+        @NonNull
+        public GradlePlugin.Builder buildImports(String ...imports) {
+            this.buildImports.addAll(Arrays.asList(imports));
             return this;
         }
 
@@ -167,7 +185,7 @@ public class GradlePlugin implements BuildPlugin {
         }
 
         public GradlePlugin build() {
-            return new GradlePlugin(id, version, artifactId, extension, settingsExtension, requiresLookup, order);
+            return new GradlePlugin(id, version, artifactId, extension, settingsExtension, requiresLookup, order, buildImports);
         }
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautBuildPlugin.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautBuildPlugin.java
@@ -100,6 +100,7 @@ public class MicronautBuildPlugin implements Feature {
         }
         return builder.id(id);
     }
+
     protected MicronautApplicationGradlePlugin.Builder micronautGradleApplicationPluginBuilder(GeneratorContext generatorContext) {
         MicronautApplicationGradlePlugin.Builder builder = micronautGradleApplicationPluginBuilder(generatorContext, MicronautApplicationGradlePlugin.Builder.APPLICATION);
         if (generatorContext.getFeatures().contains(AwsLambda.FEATURE_NAME_AWS_LAMBDA) && (

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -15,10 +15,9 @@ Features features,
 GradleBuild gradleBuild
 )
 
-@if (features.contains("grpc") && gradleBuild.getDsl() == GradleDsl.KOTLIN) {
-import com.google.protobuf.gradle.*
+@for (String importLine : gradleBuild.getPluginsImports()) {
+@(importLine)
 }
-
 plugins {
 @for (GradlePlugin gradlePlugin : gradleBuild.getPlugins()) {
     id("@gradlePlugin.getId()") @(gradlePlugin.getVersion() != null ? "version \"" + gradlePlugin.getVersion() + "\"" : "")

--- a/starter-core/src/main/java/io/micronaut/starter/feature/grpc/Grpc.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/grpc/Grpc.java
@@ -17,7 +17,9 @@ package io.micronaut.starter.feature.grpc;
 
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.BuildPlugin;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.gradle.GradleDsl;
 import io.micronaut.starter.build.gradle.GradlePlugin;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.DefaultFeature;
@@ -27,6 +29,8 @@ import io.micronaut.starter.options.Options;
 import io.micronaut.starter.template.RockerTemplate;
 
 import jakarta.inject.Singleton;
+
+import java.util.Optional;
 import java.util.Set;
 
 @Singleton
@@ -46,11 +50,19 @@ public class Grpc implements DefaultFeature {
                 .compile());
         if (generatorContext.getBuildTool().isGradle()) {
             generatorContext.addHelpLink("Protobuf Gradle Plugin", "https://plugins.gradle.org/plugin/com.google.protobuf");
-            generatorContext.addBuildPlugin(GradlePlugin.builder()
-                    .id("com.google.protobuf")
-                    .lookupArtifactId("protobuf-gradle-plugin")
-                    .build());
+            generatorContext.addBuildPlugin(gradlePlugin(generatorContext));
         }
+    }
+
+    private BuildPlugin gradlePlugin(GeneratorContext generatorContext) {
+        GradlePlugin.Builder builder = GradlePlugin.builder()
+                .id("com.google.protobuf")
+                .lookupArtifactId("protobuf-gradle-plugin");
+        Optional<GradleDsl> gradleDslOptional = generatorContext.getBuildTool().getGradleDsl();
+        if (gradleDslOptional.isPresent() && gradleDslOptional.get() == GradleDsl.KOTLIN) {
+            builder.buildImports("import com.google.protobuf.gradle.*");
+        }
+        return builder.build();
     }
 
     @Override


### PR DESCRIPTION
This change allows a GradlePlugin to contribute imports at the top of the build file. 

This way we can get rid of coupling in `buildGradle.rocker.raw` such as: 

```
 @if (features.contains("grpc") && gradleBuild.getDsl() == GradleDsl.KOTLIN) {
 import com.google.protobuf.gradle.*
 ```