### PR TITLE
Switch to using BOM versions of the depenendencies

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/other/template/readme.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/other/template/readme.rocker.raw
@@ -6,6 +6,7 @@ Feature feature
 
 @if (feature.getMicronautDocumentation() != null || feature.getThirdPartyDocumentation() != null) {
 
+
 ## Feature @feature.getName() documentation
 
     @if (feature.getMicronautDocumentation() != null) {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/gradle/GradleSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/gradle/GradleSpec.groovy
@@ -93,7 +93,6 @@ class GradleSpec extends BeanContextSpec implements CommandOutputFixture {
         dsl                     | fileName           | configuration
         BuildTool.GRADLE        | 'build.gradle'     | 'graalvmNative.toolchainDetection = false'
         BuildTool.GRADLE_KOTLIN | 'build.gradle.kts' | 'graalvmNative.toolchainDetection.set(false)'
-
     }
 
 }

--- a/starter-web-servlet/build.gradle
+++ b/starter-web-servlet/build.gradle
@@ -15,11 +15,11 @@ dependencies {
     implementation project(":starter-api")
     implementation "io.micronaut:micronaut-inject"
 
-    implementation("io.micronaut.servlet:micronaut-servlet-engine:1.0.0.M3")
-    developmentOnly "io.micronaut.servlet:micronaut-http-server-jetty:1.0.0.M3"
+    developmentOnly "io.micronaut.servlet:micronaut-http-server-jetty"
 
     runtimeOnly "ch.qos.logback:logback-classic:1.2.3"
-    testImplementation "io.micronaut.servlet:micronaut-http-server-jetty:1.0.0.M3"
+
+    testImplementation "io.micronaut.servlet:micronaut-http-server-jetty"
     testCompileOnly "io.micronaut:micronaut-inject-groovy"
     testImplementation "io.micronaut.test:micronaut-test-spock"
     testImplementation "io.micronaut:micronaut-http-client"

--- a/starter-web-servlet/build.gradle
+++ b/starter-web-servlet/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation project(":starter-api")
     implementation "io.micronaut:micronaut-inject"
 
-    developmentOnly "io.micronaut.servlet:micronaut-http-server-jetty"
+    implementation "io.micronaut.servlet:micronaut-http-server-jetty"
 
     runtimeOnly "ch.qos.logback:logback-classic:1.2.3"
 

--- a/starter-web-servlet/build.gradle
+++ b/starter-web-servlet/build.gradle
@@ -15,10 +15,10 @@ dependencies {
     implementation project(":starter-api")
     implementation "io.micronaut:micronaut-inject"
 
-    implementation "io.micronaut.servlet:micronaut-http-server-jetty"
+    implementation("io.micronaut.servlet:micronaut-servlet-engine:3.1.0")
+    developmentOnly "io.micronaut.servlet:micronaut-http-server-jetty"
 
     runtimeOnly "ch.qos.logback:logback-classic:1.2.3"
-
     testImplementation "io.micronaut.servlet:micronaut-http-server-jetty"
     testCompileOnly "io.micronaut:micronaut-inject-groovy"
     testImplementation "io.micronaut.test:micronaut-test-spock"


### PR DESCRIPTION
We no longer need to specify `io.micronaut.servlet:micronaut-servlet-engine` as it's
pulled by `io.micronaut.servlet:micronaut-http-server-jetty`

Hopefully improves the test flakiness 🤞