### PR TITLE
Update Camunda projects to versions built with Micronaut 3.3

### DIFF
--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -25,17 +25,17 @@
         <dependency>
             <groupId>info.novatec</groupId>
             <artifactId>micronaut-camunda-bpm-feature</artifactId>
-            <version>2.3.2</version>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>info.novatec</groupId>
             <artifactId>micronaut-camunda-external-client-feature</artifactId>
-            <version>2.2.0</version>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>info.novatec</groupId>
             <artifactId>micronaut-zeebe-client-feature</artifactId>
-            <version>1.1.1</version>
+            <version>1.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
I'm the lead developer of the Micronaut Camunda Integration Projects. This PR only effects newly created projects because the camunda modules are not in the BOM. So this new version upgrade only affects new users creating applications with Launch.

Please merge this PR. It updates all features to versions built with Micronaut 3.3.0