### PR TITLE
remove SnakeCaseStrategy as it is surplus

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/client/github/oauth/AccessToken.java
+++ b/starter-core/src/main/java/io/micronaut/starter/client/github/oauth/AccessToken.java
@@ -17,8 +17,6 @@ package io.micronaut.starter.client.github.oauth;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.micronaut.core.annotation.Introspected;
 
 import javax.validation.constraints.NotNull;
@@ -28,7 +26,6 @@ import javax.validation.constraints.NotNull;
  * @since 2.2
  */
 @Introspected
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class AccessToken {
 
     private final String tokenType;

--- a/starter-core/src/main/java/io/micronaut/starter/client/github/v3/GitHubRepository.java
+++ b/starter-core/src/main/java/io/micronaut/starter/client/github/v3/GitHubRepository.java
@@ -17,8 +17,6 @@ package io.micronaut.starter.client.github.v3;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Nullable;
 
@@ -30,7 +28,6 @@ import io.micronaut.core.annotation.Nullable;
  * @since 2.2
  */
 @Introspected
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GitHubRepository {
     private final String name;
     private final String description;


### PR DESCRIPTION
#999 push to github doesn't work even without 2FA. Here is a stack trace:

```
ERROR i.m.r.intercept.RecoveryInterceptor - Type [io.micronaut.starter.client.github.oauth.GitHubOAuthClient$Intercepted] executed with error: Error decoding HTTP response body: Error decoding stream for type [class io.micronaut.starter.client.github.oauth.AccessToken]: Class com.fasterxml.jackson.databind.PropertyNamingStrategies$SnakeCaseStrategy has no default (no arg) constructor
```

Removing ```@JsonNaming``` should fix the problem.