### PR TITLE
Fix snapshot lambda action

### DIFF
--- a/.github/workflows/aws-lambda-snapshot.yml
+++ b/.github/workflows/aws-lambda-snapshot.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build AWS Lambda
         run: |
           ./gradlew starter-aws-lambda:buildNativeLambda
-          cp starter-aws-lambda/build/libs/*-lambda.zip build/function.zip
+          cp starter-aws-lambda/build/libs/*-lambda.zip starter-aws-lambda/build/libs/function.zip
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
@@ -27,4 +27,4 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: ${{ secrets.AWS_REGION }}
           function_name: micronaut-starter-snapshot
-          zip_file: build/function.zip
+          zip_file: starter-aws-lambda/build/libs/function.zip

--- a/.github/workflows/aws-lambda-snapshot.yml
+++ b/.github/workflows/aws-lambda-snapshot.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build AWS Lambda
         run: |
           ./gradlew starter-aws-lambda:buildNativeLambda
-          cp starter-aws-lambda/build/libs/*-lambda.zip starter-aws-lambda/build/libs/function.zip
+          cp starter-aws-lambda/build/libs/*-lambda.zip starter-aws-lambda/build/function.zip
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
@@ -27,4 +27,4 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: ${{ secrets.AWS_REGION }}
           function_name: micronaut-starter-snapshot
-          zip_file: starter-aws-lambda/build/libs/function.zip
+          zip_file: starter-aws-lambda/build/function.zip


### PR DESCRIPTION
The latest build does not necessarily create a `build` directory at root project level

This fix stops using that path, and instead uses build folder inside the `starter-aws-lambda` directory