### PR TITLE
Add the micronaut-data-processor to the Maven annotation processors

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -79,7 +80,7 @@ public class GeneratorContext implements DependencyContext {
     private final ApplicationType command;
     private final Features features;
     private final Options options;
-    private final Set<Dependency> dependencies = new HashSet<>();
+    private final Set<Dependency> dependencies = new LinkedHashSet<>();
 
     private final Set<BuildPlugin> buildPlugins = new HashSet<>();
 

--- a/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
@@ -88,9 +88,6 @@ public class MavenBuildCreator {
             annotationProcessorsCoordinates.add(mnGraal);
         }
 
-        annotationProcessorsCoordinates.sort(Coordinate.COMPARATOR);
-        testAnnotationProcessorsCoordinates.sort(Coordinate.COMPARATOR);
-
         List<MavenPlugin> plugins = generatorContext.getBuildPlugins()
                 .stream()
                 .filter(MavenPlugin.class::isInstance)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongo.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongo.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Experimental;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.options.BuildTool;
 import jakarta.inject.Singleton;
 
 /**
@@ -29,6 +30,9 @@ import jakarta.inject.Singleton;
 @Experimental
 @Singleton
 public class DataMongo implements DataFeature {
+
+    private static final String MICRONAUT_DATA_GROUP = "io.micronaut.data";
+    private static final String MICRONAUT_DATA_VERSION = "micronaut.data.version";
 
     // TODO: Need to support either sync or async
     private final MongoSync mongoSync;
@@ -49,16 +53,23 @@ public class DataMongo implements DataFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
+            generatorContext.addDependency(Dependency.builder()
+                    .annotationProcessor()
+                    .groupId(MICRONAUT_DATA_GROUP)
+                    .artifactId("micronaut-data-processor")
+                    .versionProperty(MICRONAUT_DATA_VERSION));
+        }
         generatorContext.addDependency(Dependency.builder()
                 .annotationProcessor()
-                .groupId("io.micronaut.data")
+                .groupId(MICRONAUT_DATA_GROUP)
                 .artifactId("micronaut-data-document-processor")
-                .versionProperty("micronaut.data.version"));
+                .versionProperty(MICRONAUT_DATA_VERSION));
         generatorContext.addDependency(Dependency.builder()
                 .compile()
-                .groupId("io.micronaut.data")
+                .groupId(MICRONAUT_DATA_GROUP)
                 .artifactId("micronaut-data-mongodb")
-                .versionProperty("micronaut.data.version"));
+                .versionProperty(MICRONAUT_DATA_VERSION));
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/DataR2dbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/DataR2dbcSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.starter.feature.database.r2dbc
 
+import groovy.xml.XmlParser
 import io.micronaut.core.version.SemanticVersion
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
@@ -89,54 +90,26 @@ class DataR2dbcSpec extends ApplicationContextSpec implements CommandOutputFixtu
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .features(["data-r2dbc"])
                 .render()
+        def project = new XmlParser().parseText(template)
 
         then:
-        //src/main
-        template.contains('''
-            <path>
-              <groupId>io.micronaut.data</groupId>
-              <artifactId>micronaut-data-processor</artifactId>
-              <version>${micronaut.data.version}</version>
-            </path>
-          </annotationProcessorPaths>
-''')
+        with(project.build.plugins.plugin.find { it.artifactId.text() == "maven-compiler-plugin" }) {
+            def artifacts = configuration.annotationProcessorPaths.path.collect { "${it.groupId.text()}:${it.artifactId.text()}".toString() }
+            artifacts.contains("io.micronaut.data:micronaut-data-processor")
+        }
+        with(project.dependencies.dependency.find { it.artifactId.text() == "micronaut-data-r2dbc" }) {
+            scope.text() == 'compile'
+            groupId.text() == 'io.micronaut.data'
+        }
+        !project.dependencies.dependency.find { it.artifactId.text() == "micronaut-r2dbc-core" }
+        with(project.dependencies.dependency.find { it.artifactId.text() == "r2dbc-h2" }) {
+            scope.text() == 'runtime'
+            groupId.text() == 'io.r2dbc'
+        }
+        !project.dependencies.dependency.find { it.artifactId.text() == "h2" }
 
-        template.contains('''
-    <dependency>
-      <groupId>io.micronaut.data</groupId>
-      <artifactId>micronaut-data-r2dbc</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''')
-        !template.contains('''
-    <dependency>
-      <groupId>io.micronaut.r2dbc</groupId>
-      <artifactId>micronaut-r2dbc-core</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''')
-        template.contains('''
-    <dependency>
-      <groupId>io.r2dbc</groupId>
-      <artifactId>r2dbc-h2</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-''')
-        !template.contains('''
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-''')
         jdbcFeature.name == 'jdbc-hikari'
-        !template.contains('''
-    <dependency>
-      <groupId>io.micronaut.sql</groupId>
-      <artifactId>micronaut-jdbc-hikari</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''')
+        !project.dependencies.dependency.find { it.artifactId.text() == "micronaut-jdbc-hikari" }
 
         when:
         Optional<SemanticVersion> semanticVersionOptional = parsePropertySemanticVersion(template, "micronaut.data.version")
@@ -151,54 +124,30 @@ class DataR2dbcSpec extends ApplicationContextSpec implements CommandOutputFixtu
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .features(["data-r2dbc", "flyway"])
                 .render()
+        def project = new XmlParser().parseText(template)
 
         then:
         //src/main
-        template.contains('''
-            <path>
-              <groupId>io.micronaut.data</groupId>
-              <artifactId>micronaut-data-processor</artifactId>
-              <version>${micronaut.data.version}</version>
-            </path>
-          </annotationProcessorPaths>
-''')
+        with(project.build.plugins.plugin.find { it.artifactId.text() == "maven-compiler-plugin" }) {
+            def artifacts = configuration.annotationProcessorPaths.path.collect { "${it.groupId.text()}:${it.artifactId.text()}".toString() }
+            artifacts.contains("io.micronaut.data:micronaut-data-processor")
+        }
+        with(project.dependencies.dependency.find { it.artifactId.text() == "micronaut-data-r2dbc" }) {
+            scope.text() == 'compile'
+            groupId.text() == 'io.micronaut.data'
+        }
+        !project.dependencies.dependency.find { it.artifactId.text() == "micronaut-r2dbc-core" }
+        with(project.dependencies.dependency.find { it.artifactId.text() == "r2dbc-h2" }) {
+            scope.text() == 'runtime'
+            groupId.text() == 'io.r2dbc'
+        }
+        with(project.dependencies.dependency.find { it.artifactId.text() == "h2" }) {
+            scope.text() == 'runtime'
+            groupId.text() == 'com.h2database'
+        }
 
-        template.contains('''
-    <dependency>
-      <groupId>io.micronaut.data</groupId>
-      <artifactId>micronaut-data-r2dbc</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''')
-        !template.contains('''
-    <dependency>
-      <groupId>io.micronaut.r2dbc</groupId>
-      <artifactId>micronaut-r2dbc-core</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''')
-        template.contains('''
-    <dependency>
-      <groupId>io.r2dbc</groupId>
-      <artifactId>r2dbc-h2</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-''')
-        template.contains('''
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-''')
         jdbcFeature.name == 'jdbc-hikari'
-        !template.contains('''
-    <dependency>
-      <groupId>io.micronaut.sql</groupId>
-      <artifactId>micronaut-jdbc-hikari</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''')
+        !project.dependencies.dependency.find { it.artifactId.text() == "micronaut-jdbc-hikari" }
 
         when:
         Optional<SemanticVersion> semanticVersionOptional = parsePropertySemanticVersion(template, "micronaut.data.version")


### PR DESCRIPTION
When building a MongoDB Micronaut Data application, if the micronaut-data-processor is not
specified, then the Repository introspection is missing the Mongo Queries.

This is fixed by adding the transient "micronaut-data-processor" in to the list of
annotation processors, but ONLY if it is added before the micronaut-data-document-processor.

If it is added after, we seem to get a NPE from the data-processor. I am going to raise an
issue for this in the micronaut-data project.