### PR TITLE
Handle sync or async mongo features with data-mongodb

### DIFF
--- a/starter-core/build.gradle
+++ b/starter-core/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'com.typesafe:config:1.4.1'
     implementation 'org.apache.commons:commons-compress:1.21'
     testImplementation("org.codehaus.groovy:groovy-xml")
+    testImplementation("org.codehaus.groovy:groovy-yaml")
 }
 
 def micronautVersionInfo = tasks.register("micronautVersionInfo", io.micronaut.internal.starter.tasks.WriteMicronautVersionInfoTask) {

--- a/starter-core/build.gradle
+++ b/starter-core/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     implementation 'com.typesafe:config:1.4.1'
     implementation 'org.apache.commons:commons-compress:1.21'
     testImplementation("org.codehaus.groovy:groovy-xml")
-    testImplementation("org.codehaus.groovy:groovy-yaml")
 }
 
 def micronautVersionInfo = tasks.register("micronautVersionInfo", io.micronaut.internal.starter.tasks.WriteMicronautVersionInfoTask) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongo.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongo.java
@@ -34,7 +34,6 @@ public class DataMongo implements DataFeature {
     private static final String MICRONAUT_DATA_GROUP = "io.micronaut.data";
     private static final String MICRONAUT_DATA_VERSION = "micronaut.data.version";
 
-    // TODO: Need to support either sync or async
     private final MongoSync mongoSync;
 
     public DataMongo(MongoSync mongoSync) {
@@ -70,11 +69,16 @@ public class DataMongo implements DataFeature {
                 .groupId(MICRONAUT_DATA_GROUP)
                 .artifactId("micronaut-data-mongodb")
                 .versionProperty(MICRONAUT_DATA_VERSION));
+        if (generatorContext.isFeaturePresent(MongoSync.class) && generatorContext.isFeaturePresent(MongoReactive.class)) {
+            generatorContext.getConfiguration().put("micronaut.data.mongodb.driver-type", "reactive");
+        }
     }
 
     @Override
     public void processSelectedFeatures(FeatureContext featureContext) {
-        featureContext.addFeature(mongoSync);
+        if (!featureContext.isPresent(MongoReactive.class)) {
+            featureContext.addFeature(mongoSync);
+        }
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongo.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongo.java
@@ -38,11 +38,6 @@ public class DataMongo extends DataMongoFeature {
         return "data-mongodb";
     }
 
-    @Override
-    public String getMicronautDocumentation() {
-        return "https://micronaut-projects.github.io/micronaut-data/latest/guide/#mongo";
-    }
-
     @NonNull
     @Override
     public String getDescription() {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongoFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongoFeature.java
@@ -30,11 +30,11 @@ public abstract class DataMongoFeature implements DataFeature {
     private static final String MONGODB_GROUP = "org.mongodb";
     private static final String MICRONAUT_DATA_GROUP = "io.micronaut.data";
     private static final String MICRONAUT_DATA_VERSION = "micronaut.data.version";
-    public static final String MICRONAUT_DATA_PROCESSOR_ARTIFACT = "micronaut-data-processor";
-    public static final String MICRONAUT_DATA_DOCUMENT_PROCESSOR_ARTIFACT = "micronaut-data-document-processor";
-    public static final String MICRONAUT_DATA_MONGODB_ARTIFACT = "micronaut-data-mongodb";
-    public static final String MONGODB_URI_CONFIGURATION_KEY = "mongodb.uri";
-    public static final String MONGODB_URI_CONFIGURATION_VALUE = "mongodb://${MONGO_HOST:localhost}:${MONGO_PORT:27017}/mydb";
+    private static final String MICRONAUT_DATA_PROCESSOR_ARTIFACT = "micronaut-data-processor";
+    private static final String MICRONAUT_DATA_DOCUMENT_PROCESSOR_ARTIFACT = "micronaut-data-document-processor";
+    private static final String MICRONAUT_DATA_MONGODB_ARTIFACT = "micronaut-data-mongodb";
+    private static final String MONGODB_URI_CONFIGURATION_KEY = "mongodb.uri";
+    private static final String MONGODB_URI_CONFIGURATION_VALUE = "mongodb://${MONGO_HOST:localhost}:${MONGO_PORT:27017}/mydb";
 
     private final Data data;
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongoFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongoFeature.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.database;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.options.Language;
+
+/**
+ * Base class for our data-mongo features.
+ */
+public abstract class DataMongoFeature implements DataFeature {
+
+    private static final String MONGODB_GROUP = "org.mongodb";
+    private static final String MICRONAUT_DATA_GROUP = "io.micronaut.data";
+    private static final String MICRONAUT_DATA_VERSION = "micronaut.data.version";
+    private final Data data;
+
+    protected DataMongoFeature(Data data) {
+        this.data = data;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        generatorContext.getConfiguration().put("mongodb.uri", "mongodb://${MONGO_HOST:localhost}:${MONGO_PORT:27017}/mydb");
+
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
+            generatorContext.addDependency(Dependency.builder()
+                    .annotationProcessor()
+                    .groupId(MICRONAUT_DATA_GROUP)
+                    .artifactId("micronaut-data-processor")
+                    .versionProperty(MICRONAUT_DATA_VERSION));
+        }
+        generatorContext.addDependency(Dependency.builder()
+                .annotationProcessor()
+                .groupId(MICRONAUT_DATA_GROUP)
+                .artifactId("micronaut-data-document-processor")
+                .versionProperty(MICRONAUT_DATA_VERSION));
+        generatorContext.addDependency(Dependency.builder()
+                .compile()
+                .groupId(MICRONAUT_DATA_GROUP)
+                .artifactId("micronaut-data-mongodb")
+                .versionProperty(MICRONAUT_DATA_VERSION));
+
+        // Needs to be an implementation dependency for the Groovy compiler
+        if (generatorContext.getLanguage() == Language.GROOVY) {
+            generatorContext.addDependency(Dependency.builder()
+                    .compile()
+                    .groupId(MONGODB_GROUP)
+                    .artifactId(mongoArtifact()));
+        } else {
+            generatorContext.addDependency(Dependency.builder()
+                    .runtime()
+                    .groupId(MONGODB_GROUP)
+                    .artifactId(mongoArtifact()));
+        }
+    }
+
+    @Override
+    public void processSelectedFeatures(FeatureContext featureContext) {
+        featureContext.addFeature(data);
+    }
+
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://docs.mongodb.com";
+    }
+
+    @NonNull
+    protected abstract String mongoArtifact();
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongoReactive.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongoReactive.java
@@ -19,23 +19,21 @@ import io.micronaut.core.annotation.NonNull;
 import jakarta.inject.Singleton;
 
 /**
- * Add support for Micronaut Data MongoDB. 
- 
- * @author graemerocher
+ * Add support for Micronaut Data MongoDB Reactive.
  */
 @Singleton
-public class DataMongo extends DataMongoFeature {
+public class DataMongoReactive extends DataMongoFeature {
 
-    private static final String SYNC_MONGODB_ARTIFACT = "mongodb-driver-sync";
+    private static final String ASYNC_MONGODB_ARTIFACT = "mongodb-driver-reactivestreams";
 
-    public DataMongo(Data data) {
+    public DataMongoReactive(Data data) {
         super(data);
     }
 
     @NonNull
     @Override
     public String getName() {
-        return "data-mongodb";
+        return "data-mongodb-async";
     }
 
     @Override
@@ -46,17 +44,17 @@ public class DataMongo extends DataMongoFeature {
     @NonNull
     @Override
     public String getDescription() {
-        return "Adds support for defining synchronous data repositories for MongoDB";
+        return "Adds support for defining asynchronous data repositories for MongoDB";
     }
 
     @Override
     public String getTitle() {
-        return "Micronaut Data MongoDB";
+        return "Micronaut Data MongoDB Async";
     }
 
     @NonNull
     @Override
     protected String mongoArtifact() {
-        return SYNC_MONGODB_ARTIFACT;
+        return ASYNC_MONGODB_ARTIFACT;
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongoReactive.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongoReactive.java
@@ -36,11 +36,6 @@ public class DataMongoReactive extends DataMongoFeature {
         return "data-mongodb-async";
     }
 
-    @Override
-    public String getMicronautDocumentation() {
-        return "https://micronaut-projects.github.io/micronaut-data/latest/guide/#mongo";
-    }
-
     @NonNull
     @Override
     public String getDescription() {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
@@ -85,7 +85,9 @@ public class TestContainers implements Feature {
             generatorContext.addDependency(testContainerTestDependency(testArtifactId));
         });
 
-        if (generatorContext.isFeaturePresent(MongoFeature.class)) {
+        if (generatorContext.isFeaturePresent(MongoFeature.class) ||
+                generatorContext.isFeaturePresent(DataMongoFeature.class) ||
+                generatorContext.isFeaturePresent(DataMongoReactive.class)) {
             generatorContext.addDependency(testContainerTestDependency("mongodb"));
         }
     }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataMongoSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataMongoSpec.groovy
@@ -1,7 +1,6 @@
 package io.micronaut.starter.feature.database
 
 import groovy.xml.XmlParser
-import groovy.yaml.YamlSlurper
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.application.generator.GeneratorContext
@@ -12,35 +11,49 @@ import io.micronaut.starter.options.Options
 
 class DataMongoSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
-    void "test add data-mongodb feature for Gradle"() {
+    void "test adding #feature results in the correct build for a Gradle app in #language"() {
         when:
-        def output = generate(['data-mongodb'])
+        def output = generate(ApplicationType.DEFAULT, new Options(language, BuildTool.GRADLE), [feature])
         def readme = output["README.md"]
         def build = output['build.gradle']
 
         then:
         readme
-        readme.contains("https://micronaut-projects.github.io/micronaut-mongodb/latest/guide/index.html")
         readme.contains("https://micronaut-projects.github.io/micronaut-data/latest/guide/#mongo")
         readme.contains("https://docs.mongodb.com")
+
         build.contains('implementation("io.micronaut.data:micronaut-data-mongodb')
-        build.contains('annotationProcessor("io.micronaut.data:micronaut-data-document-processor')
-        // By default, we grab the sync drivers
-        build.contains('implementation("io.micronaut.mongodb:micronaut-mongo-sync')
+        if (language == Language.KOTLIN) {
+            assert build.contains('kapt("io.micronaut.data:micronaut-data-document-processor")')
+        } else if (language == Language.JAVA) {
+            assert build.contains('annotationProcessor("io.micronaut.data:micronaut-data-document-processor")')
+        } else {
+            assert build.contains('compileOnly("io.micronaut.data:micronaut-data-document-processor")')
+        }
+
+        build.contains($/${gradleConfiguration}("org.mongodb:${driver}")/$)
 
         // We only add this to maven projects
         !build.contains('annotationProcessor("io.micronaut.data:micronaut-data-processor')
+
+        where:
+        feature              | gradleConfiguration | driver                           | language
+        'data-mongodb'       | 'runtimeOnly'       | 'mongodb-driver-sync'            | Language.JAVA
+        'data-mongodb'       | 'runtimeOnly'       | 'mongodb-driver-sync'            | Language.KOTLIN
+        'data-mongodb'       | 'implementation'    | 'mongodb-driver-sync'            | Language.GROOVY
+        'data-mongodb-async' | 'runtimeOnly'       | 'mongodb-driver-reactivestreams' | Language.JAVA
+        'data-mongodb-async' | 'runtimeOnly'       | 'mongodb-driver-reactivestreams' | Language.KOTLIN
+        'data-mongodb-async' | 'implementation'    | 'mongodb-driver-reactivestreams' | Language.GROOVY
     }
 
-    void "test add data-mongodb feature for Maven"() {
+    void "test adding #feature results in the correct build for a Maven app in #language"() {
         when:
-        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.MAVEN), ['data-mongodb'])
+        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.MAVEN), [feature])
         def readme = output["README.md"]
         def project = new XmlParser().parseText(output['pom.xml'])
 
         then:
         readme
-        readme.contains("https://micronaut-projects.github.io/micronaut-mongodb/latest/guide/index.html")
         readme.contains("https://micronaut-projects.github.io/micronaut-data/latest/guide/#mongo")
         readme.contains("https://docs.mongodb.com")
 
@@ -49,9 +62,9 @@ class DataMongoSpec extends ApplicationContextSpec implements CommandOutputFixtu
             groupId.text() == 'io.micronaut.data'
         }
 
-        with(project.dependencies.dependency.find { it.artifactId.text() == "micronaut-mongo-sync" }) {
-            scope.text() == 'compile'
-            groupId.text() == 'io.micronaut.mongodb'
+        with(project.dependencies.dependency.find { it.artifactId.text() == driver }) {
+            scope.text() == 'runtime'
+            groupId.text() == 'org.mongodb'
         }
 
         with(project.build.plugins.plugin.find { it.artifactId.text() == "maven-compiler-plugin" }) {
@@ -61,128 +74,27 @@ class DataMongoSpec extends ApplicationContextSpec implements CommandOutputFixtu
             // data processor must come before the document processor because Maven
             artifacts.indexOf("micronaut-data-document-processor") > artifacts.indexOf("micronaut-data-processor")
         }
+
+        where:
+        feature              | driver                           | language
+        'data-mongodb'       | 'mongodb-driver-sync'            | Language.JAVA
+        'data-mongodb'       | 'mongodb-driver-sync'            | Language.KOTLIN
+        'data-mongodb'       | 'mongodb-driver-sync'            | Language.GROOVY
+        'data-mongodb-async' | 'mongodb-driver-reactivestreams' | Language.JAVA
+        'data-mongodb-async' | 'mongodb-driver-reactivestreams' | Language.KOTLIN
+        'data-mongodb-async' | 'mongodb-driver-reactivestreams' | Language.GROOVY
     }
 
-    void "dependencies are present for gradle with data-mongodb and both mongo-reactive and mongo-sync"() {
+    void "test config for #feature"() {
         when:
-        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.GRADLE), ['data-mongodb', 'mongo-reactive', 'mongo-sync'])
-        def build = output.'build.gradle'
-        def application = new YamlSlurper().parseText(output.'src/main/resources/application.yml')
-
-        then:
-        build.contains('implementation("io.micronaut.mongodb:micronaut-mongo-reactive")')
-        build.contains('implementation("io.micronaut.mongodb:micronaut-mongo-sync")')
-        build.contains('testImplementation("org.testcontainers:mongodb")')
-
-        and: 'both were chosen, but we choose reactive for the user'
-        application.micronaut.data.mongodb.'driver-type' == 'reactive'
-    }
-
-    void "dependencies are present for gradle with data-mongodb and just mongo-reactive"() {
-        when:
-        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.GRADLE), ['data-mongodb', 'mongo-reactive'])
-        def build = output.'build.gradle'
-        def application = new YamlSlurper().parseText(output.'src/main/resources/application.yml')
-
-        then:
-        build.contains('implementation("io.micronaut.mongodb:micronaut-mongo-reactive")')
-        // Sync driver is omitted
-        !build.contains('implementation("io.micronaut.mongodb:micronaut-mongo-sync")')
-        build.contains('testImplementation("org.testcontainers:mongodb")')
-
-        and: 'no need to set the driver type'
-        application.micronaut?.data?.mongodb?.'driver-type' == null
-    }
-
-    void "adding mongo-sync to a gradle build makes no difference to the build script"() {
-        when:
-        def noSync = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.GRADLE), ['data-mongodb'])
-        def sync = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.GRADLE), ['data-mongodb', 'mongo-sync'])
-
-        then:
-        noSync.'build.gradle'
-        noSync.'build.gradle' == sync.'build.gradle'
-        noSync.'src/main/resources/application.yml'
-        noSync.'src/main/resources/application.yml' == sync.'src/main/resources/application.yml'
-    }
-
-    void "dependencies are present for maven with data-mongodb and both mongo-reactive and mongo-sync"() {
-        when:
-        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.MAVEN), ['data-mongodb', 'mongo-reactive', 'mongo-sync'])
-        def project = new XmlParser().parseText(output.'pom.xml')
-        def application = new YamlSlurper().parseText(output.'src/main/resources/application.yml')
-
-        then:
-        with(project.dependencies.dependency.find { it.artifactId.text() == "micronaut-mongo-reactive" }) {
-            scope.text() == 'compile'
-            groupId.text() == 'io.micronaut.mongodb'
-        }
-        with(project.dependencies.dependency.find { it.artifactId.text() == "mongodb" }) {
-            scope.text() == 'test'
-            groupId.text() == 'org.testcontainers'
-        }
-
-        and: 'mongo-sync is pulled in, as it was requested as a feature'
-        with(project.dependencies.dependency.find { it.artifactId.text() == "micronaut-mongo-sync" }) {
-            scope.text() == 'compile'
-            groupId.text() == 'io.micronaut.mongodb'
-        }
-
-        and: 'both were chosen, but we choose reactive for the user'
-        application.micronaut.data.mongodb.'driver-type' == 'reactive'
-    }
-
-    void "dependencies are present for maven with data-mongodb and just mongo-reactive"() {
-        when:
-        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.MAVEN), ['data-mongodb', 'mongo-reactive'])
-        def project = new XmlParser().parseText(output.'pom.xml')
-        def application = new YamlSlurper().parseText(output.'src/main/resources/application.yml')
-
-        then:
-        with(project.dependencies.dependency.find { it.artifactId.text() == "micronaut-mongo-reactive" }) {
-            scope.text() == 'compile'
-            groupId.text() == 'io.micronaut.mongodb'
-        }
-        with(project.dependencies.dependency.find { it.artifactId.text() == "mongodb" }) {
-            scope.text() == 'test'
-            groupId.text() == 'org.testcontainers'
-        }
-
-        and: 'mongo-sync is excluded as we chose reactive'
-        project.dependencies.dependency.find { it.artifactId.text() == "micronaut-mongo-sync" } == null
-
-        and: 'no need to set the driver type'
-        application.micronaut?.data?.mongodb?.'driver-type' == null
-    }
-
-    void "adding mongo-sync to a maven build makes no difference to the pom"() {
-        when:
-        def noSync = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.MAVEN), ['data-mongodb'])
-        def sync = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.MAVEN), ['data-mongodb', 'mongo-sync'])
-
-        then:
-        noSync.'pom.xml'
-        noSync.'pom.xml' == sync.'pom.xml'
-        noSync.'src/main/resources/application.yml'
-        noSync.'src/main/resources/application.yml' == sync.'src/main/resources/application.yml'
-    }
-
-    void "test config for #features"() {
-        when:
-        GeneratorContext ctx = buildGeneratorContext(featureList)
+        GeneratorContext ctx = buildGeneratorContext([feature])
 
         then:
         with(ctx.getConfiguration()) {
             get("mongodb.uri") == 'mongodb://${MONGO_HOST:localhost}:${MONGO_PORT:27017}/mydb'
-            get('micronaut.data.mongodb.driver-type') == driverType
         }
 
         where:
-        featureList                                      | driverType
-        ['data-mongodb', 'mongo-sync']                   | null
-        ['data-mongodb', 'mongo-reactive']               | null
-        ['data-mongodb', 'mongo-sync', 'mongo-reactive'] | 'reactive'
-
-        features = featureList.dropRight(1).join(", ") + (featureList.size() > 1 ? " and " : '') + featureList.last()
+        feature << ['data-mongodb', 'data-mongodb-async']
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataMongoSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataMongoSpec.groovy
@@ -1,0 +1,188 @@
+package io.micronaut.starter.feature.database
+
+import groovy.xml.XmlParser
+import groovy.yaml.YamlSlurper
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.application.generator.GeneratorContext
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+
+class DataMongoSpec extends ApplicationContextSpec implements CommandOutputFixture {
+
+    void "test add data-mongodb feature for Gradle"() {
+        when:
+        def output = generate(['data-mongodb'])
+        def readme = output["README.md"]
+        def build = output['build.gradle']
+
+        then:
+        readme
+        readme.contains("https://micronaut-projects.github.io/micronaut-mongodb/latest/guide/index.html")
+        readme.contains("https://micronaut-projects.github.io/micronaut-data/latest/guide/#mongo")
+        readme.contains("https://docs.mongodb.com")
+        build.contains('implementation("io.micronaut.data:micronaut-data-mongodb')
+        build.contains('annotationProcessor("io.micronaut.data:micronaut-data-document-processor')
+        // By default, we grab the sync drivers
+        build.contains('implementation("io.micronaut.mongodb:micronaut-mongo-sync')
+
+        // We only add this to maven projects
+        !build.contains('annotationProcessor("io.micronaut.data:micronaut-data-processor')
+    }
+
+    void "test add data-mongodb feature for Maven"() {
+        when:
+        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.MAVEN), ['data-mongodb'])
+        def readme = output["README.md"]
+        def project = new XmlParser().parseText(output['pom.xml'])
+
+        then:
+        readme
+        readme.contains("https://micronaut-projects.github.io/micronaut-mongodb/latest/guide/index.html")
+        readme.contains("https://micronaut-projects.github.io/micronaut-data/latest/guide/#mongo")
+        readme.contains("https://docs.mongodb.com")
+
+        with(project.dependencies.dependency.find { it.artifactId.text() == "micronaut-data-mongodb" }) {
+            scope.text() == 'compile'
+            groupId.text() == 'io.micronaut.data'
+        }
+
+        with(project.dependencies.dependency.find { it.artifactId.text() == "micronaut-mongo-sync" }) {
+            scope.text() == 'compile'
+            groupId.text() == 'io.micronaut.mongodb'
+        }
+
+        with(project.build.plugins.plugin.find { it.artifactId.text() == "maven-compiler-plugin" }) {
+            def artifacts = configuration.annotationProcessorPaths.path.artifactId*.text()
+            artifacts.contains("micronaut-data-document-processor")
+            artifacts.contains("micronaut-data-processor")
+            // data processor must come before the document processor because Maven
+            artifacts.indexOf("micronaut-data-document-processor") > artifacts.indexOf("micronaut-data-processor")
+        }
+    }
+
+    void "dependencies are present for gradle with data-mongodb and both mongo-reactive and mongo-sync"() {
+        when:
+        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.GRADLE), ['data-mongodb', 'mongo-reactive', 'mongo-sync'])
+        def build = output.'build.gradle'
+        def application = new YamlSlurper().parseText(output.'src/main/resources/application.yml')
+
+        then:
+        build.contains('implementation("io.micronaut.mongodb:micronaut-mongo-reactive")')
+        build.contains('implementation("io.micronaut.mongodb:micronaut-mongo-sync")')
+        build.contains('testImplementation("org.testcontainers:mongodb")')
+
+        and: 'both were chosen, but we choose reactive for the user'
+        application.micronaut.data.mongodb.'driver-type' == 'reactive'
+    }
+
+    void "dependencies are present for gradle with data-mongodb and just mongo-reactive"() {
+        when:
+        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.GRADLE), ['data-mongodb', 'mongo-reactive'])
+        def build = output.'build.gradle'
+        def application = new YamlSlurper().parseText(output.'src/main/resources/application.yml')
+
+        then:
+        build.contains('implementation("io.micronaut.mongodb:micronaut-mongo-reactive")')
+        // Sync driver is omitted
+        !build.contains('implementation("io.micronaut.mongodb:micronaut-mongo-sync")')
+        build.contains('testImplementation("org.testcontainers:mongodb")')
+
+        and: 'no need to set the driver type'
+        application.micronaut?.data?.mongodb?.'driver-type' == null
+    }
+
+    void "adding mongo-sync to a gradle build makes no difference to the build script"() {
+        when:
+        def noSync = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.GRADLE), ['data-mongodb'])
+        def sync = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.GRADLE), ['data-mongodb', 'mongo-sync'])
+
+        then:
+        noSync.'build.gradle'
+        noSync.'build.gradle' == sync.'build.gradle'
+        noSync.'src/main/resources/application.yml'
+        noSync.'src/main/resources/application.yml' == sync.'src/main/resources/application.yml'
+    }
+
+    void "dependencies are present for maven with data-mongodb and both mongo-reactive and mongo-sync"() {
+        when:
+        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.MAVEN), ['data-mongodb', 'mongo-reactive', 'mongo-sync'])
+        def project = new XmlParser().parseText(output.'pom.xml')
+        def application = new YamlSlurper().parseText(output.'src/main/resources/application.yml')
+
+        then:
+        with(project.dependencies.dependency.find { it.artifactId.text() == "micronaut-mongo-reactive" }) {
+            scope.text() == 'compile'
+            groupId.text() == 'io.micronaut.mongodb'
+        }
+        with(project.dependencies.dependency.find { it.artifactId.text() == "mongodb" }) {
+            scope.text() == 'test'
+            groupId.text() == 'org.testcontainers'
+        }
+
+        and: 'mongo-sync is pulled in, as it was requested as a feature'
+        with(project.dependencies.dependency.find { it.artifactId.text() == "micronaut-mongo-sync" }) {
+            scope.text() == 'compile'
+            groupId.text() == 'io.micronaut.mongodb'
+        }
+
+        and: 'both were chosen, but we choose reactive for the user'
+        application.micronaut.data.mongodb.'driver-type' == 'reactive'
+    }
+
+    void "dependencies are present for maven with data-mongodb and just mongo-reactive"() {
+        when:
+        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.MAVEN), ['data-mongodb', 'mongo-reactive'])
+        def project = new XmlParser().parseText(output.'pom.xml')
+        def application = new YamlSlurper().parseText(output.'src/main/resources/application.yml')
+
+        then:
+        with(project.dependencies.dependency.find { it.artifactId.text() == "micronaut-mongo-reactive" }) {
+            scope.text() == 'compile'
+            groupId.text() == 'io.micronaut.mongodb'
+        }
+        with(project.dependencies.dependency.find { it.artifactId.text() == "mongodb" }) {
+            scope.text() == 'test'
+            groupId.text() == 'org.testcontainers'
+        }
+
+        and: 'mongo-sync is excluded as we chose reactive'
+        project.dependencies.dependency.find { it.artifactId.text() == "micronaut-mongo-sync" } == null
+
+        and: 'no need to set the driver type'
+        application.micronaut?.data?.mongodb?.'driver-type' == null
+    }
+
+    void "adding mongo-sync to a maven build makes no difference to the pom"() {
+        when:
+        def noSync = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.MAVEN), ['data-mongodb'])
+        def sync = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.MAVEN), ['data-mongodb', 'mongo-sync'])
+
+        then:
+        noSync.'pom.xml'
+        noSync.'pom.xml' == sync.'pom.xml'
+        noSync.'src/main/resources/application.yml'
+        noSync.'src/main/resources/application.yml' == sync.'src/main/resources/application.yml'
+    }
+
+    void "test config for #features"() {
+        when:
+        GeneratorContext ctx = buildGeneratorContext(featureList)
+
+        then:
+        with(ctx.getConfiguration()) {
+            get("mongodb.uri") == 'mongodb://${MONGO_HOST:localhost}:${MONGO_PORT:27017}/mydb'
+            get('micronaut.data.mongodb.driver-type') == driverType
+        }
+
+        where:
+        featureList                                      | driverType
+        ['data-mongodb', 'mongo-sync']                   | null
+        ['data-mongodb', 'mongo-reactive']               | null
+        ['data-mongodb', 'mongo-sync', 'mongo-reactive'] | 'reactive'
+
+        features = featureList.dropRight(1).join(", ") + (featureList.size() > 1 ? " and " : '') + featureList.last()
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MongoSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MongoSpec.groovy
@@ -7,18 +7,23 @@ import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
+import spock.lang.Unroll
 
 class MongoSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
-    void 'test readme.md with feature mongo-sync contains links to micronaut and 3rd party docs'() {
+    @Unroll
+    void 'test readme.md with feature #feature contains links to micronaut and 3rd party docs'(String feature) {
         when:
-        def output = generate(['mongo-sync'])
+        def output = generate([feature])
         def readme = output["README.md"]
 
         then:
         readme
         readme.contains("https://micronaut-projects.github.io/micronaut-mongodb/latest/guide/index.html")
         readme.contains("https://docs.mongodb.com")
+
+        where:
+        feature << ['mongo-sync', 'mongo-reactive']
     }
 
     void "test mongo sync features"() {
@@ -56,17 +61,6 @@ class MongoSpec extends ApplicationContextSpec implements CommandOutputFixture {
             scope.text() == 'test'
             groupId.text() == 'org.testcontainers'
         }
-    }
-
-    void 'test readme with feature mongo-reactive contains links to micronaut and 3rd party docs'() {
-        when:
-        def output = generate(['mongo-reactive'])
-        def readme = output["README.md"]
-
-        then:
-        readme
-        readme.contains("https://micronaut-projects.github.io/micronaut-mongodb/latest/guide/index.html")
-        readme.contains("https://docs.mongodb.com")
     }
 
     void "test mongo reactive features"() {


### PR DESCRIPTION
- If neither sync nor reactive are added, auto-add sync
- If reactive is added, don't auto-add sync
- If both features are requests, set the data config to choose reactive
- Adding the sync feature is the same as just adding data-mongodb
- Split the data-mongodb tests out from the base mongodb one

Fixes #1151 