### PR TITLE
Add the Gradle Plugin portal as a repository for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,17 @@
 version: 2
+registries:
+  gradle-plugin-portal:
+    type: maven-repository
+    url: https://plugins.gradle.org/m2
+    username: dummy # Required by dependabot
+    password: dummy # Required by dependabot
 updates:
+  - package-ecosystem: "gradle-plugins"
+    directory: "/"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "daily"
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot doesn't see

```
        <dependency>
            <groupId>com.gradle</groupId>
            <artifactId>gradle-enterprise-gradle-plugin</artifactId>
            <version>3.8.1</version>
        </dependency>
```

(from our POM) In maven central, so doesn't suggest updates to the plugin version to keep us up to date.

This change ([suggested in slack](https://github.com/gradle/wrapper-upgrade-gradle-plugin/blob/main/.github/dependabot.yml#L3-L14)) adds the Gradle Plugin Portal as a known repository for dependabot, so it should keep us up to date.