### PR TITLE
As of 3.5.0, GRPC is now a micronaut bom property

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -235,7 +235,7 @@ protobuf {
     }
     plugins {
         id("grpc") {
-            artifact = "io.grpc:protoc-gen-grpc-java:@VersionInfo.getBomVersion("grpc")"
+            artifact = "io.grpc:protoc-gen-grpc-java:@VersionInfo.getBomVersion("micronaut.grpc")"
         }
     }
     generateProtoTasks {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -251,7 +251,7 @@ protobuf {
 protobuf {
     protoc { artifact = "com.google.protobuf:protoc:@VersionInfo.getBomVersion("protobuf")" }
     plugins {
-        grpc { artifact = "io.grpc:protoc-gen-grpc-java:@VersionInfo.getBomVersion("grpc")" }
+        grpc { artifact = "io.grpc:protoc-gen-grpc-java:@VersionInfo.getBomVersion("micronaut.grpc")" }
     }
     generateProtoTasks {
         all()*.plugins { grpc {} }


### PR DESCRIPTION
So it has changed in `micronaut-versions.properties` from 'grpc' to 'micronaut.grpc'