### PR TITLE
Add spring-boot-annotation as annotationProcessor dependency

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/spring/SpringBoot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/spring/SpringBoot.java
@@ -53,7 +53,7 @@ public class SpringBoot extends SpringFeature {
     public void apply(GeneratorContext generatorContext) {
         Dependency.Builder springBoot = Dependency.builder()
                 .groupId("io.micronaut.spring")
-                .artifactId("micronaut-spring-boot")
+                .artifactId("micronaut-spring-boot-annotation")
                 .versionProperty("micronaut.spring.version")
                 .template();
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringBootSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringBootSpec.groovy
@@ -60,7 +60,7 @@ class SpringBootSpec extends ApplicationContextSpec {
                 .render()
 
         then:
-        template.contains("${getGradleAnnotationProcessorScope(language)}(\"io.micronaut.spring:micronaut-spring-boot\")")
+        template.contains("${getGradleAnnotationProcessorScope(language)}(\"io.micronaut.spring:micronaut-spring-boot-annotation\")")
         template.contains('implementation("org.springframework.boot:spring-boot-starter-web")')
         template.contains('runtimeOnly("io.micronaut.spring:micronaut-spring-boot")')
 
@@ -92,7 +92,7 @@ class SpringBootSpec extends ApplicationContextSpec {
         template.contains("""
             <path>
               <groupId>io.micronaut.spring</groupId>
-              <artifactId>micronaut-spring-boot</artifactId>
+              <artifactId>micronaut-spring-boot-annotation</artifactId>
               <version>\${micronaut.spring.version}</version>
             </path>
 """)
@@ -127,7 +127,7 @@ class SpringBootSpec extends ApplicationContextSpec {
         template.count('''\
                <annotationProcessorPath>
                  <groupId>io.micronaut.spring</groupId>
-                 <artifactId>micronaut-spring-boot</artifactId>
+                 <artifactId>micronaut-spring-boot-annotation</artifactId>
                  <version>${micronaut.spring.version}</version>
                </annotationProcessorPath>
 ''') == 2


### PR DESCRIPTION
Add spring-boot-annotation as annotationProcessor dependency during project generation with spring-boot feature.

When using starter to generate a project with the spring-boot feature, it adds the dependency:

`
    annotationProcessor("io.micronaut.spring:micronaut-spring-annotation")
`

(Also same for `testAnnotationProcessor`.) However, what is needed is `micronaut-spring-boot-annotation`, in order to have the following annotation mappers included:

[https://github.com/micronaut-projects/micronaut-spring/blob/master/spring-boot-annotation/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper]()
