### PR TITLE
remove micronaut-runtime dependency for Java and Kotlin features

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/Java.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/Java.java
@@ -16,8 +16,6 @@
 package io.micronaut.starter.feature.lang.java;
 
 import io.micronaut.starter.application.ApplicationType;
-import io.micronaut.starter.application.generator.GeneratorContext;
-import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.ApplicationFeature;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeatureContext;
@@ -51,14 +49,6 @@ public class Java implements LanguageFeature {
                     .findFirst()
                     .ifPresent(featureContext::addFeature);
         }
-    }
-
-    @Override
-    public void apply(GeneratorContext generatorContext) {
-        generatorContext.addDependency(Dependency.builder()
-                .groupId("io.micronaut")
-                .artifactId("micronaut-runtime")
-                .compile());
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/Kotlin.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/Kotlin.java
@@ -67,10 +67,6 @@ public class Kotlin implements LanguageFeature {
         generatorContext.addDependency(kotlin.artifactId("kotlin-stdlib-jdk8"));
         generatorContext.addDependency(kotlin.artifactId("kotlin-reflect"));
         generatorContext.addDependency(Dependency.builder()
-                .groupId("io.micronaut")
-                .artifactId("micronaut-runtime")
-                .compile());
-        generatorContext.addDependency(Dependency.builder()
                 .groupId("io.micronaut.kotlin")
                 .artifactId("micronaut-kotlin-runtime")
                 .compile());


### PR DESCRIPTION
Build includes it transitively for:

Server: https://github.com/micronaut-projects/micronaut-core/blob/3.4.x/http-server/build.gradle#L12
Function: https://github.com/micronaut-projects/micronaut-core/blob/3.4.x/function/build.gradle#L12
CLI: https://github.com/micronaut-projects/micronaut-picocli/blob/master/picocli/build.gradle#L10
Messaging: https://github.com/micronaut-projects/micronaut-core/blob/3.4.x/messaging/build.gradle#L12
GRPC https://github.com/micronaut-projects/micronaut-grpc/issues/489