### PR TITLE
Upgrade to Gradle plugin 3.4.0

### DIFF
--- a/.github/workflows/analytics-gcr-snapshot.yml
+++ b/.github/workflows/analytics-gcr-snapshot.yml
@@ -23,6 +23,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
       - name: Build Docker image
         run:
           ./gradlew jib --image=gcr.io/${{ secrets.GCLOUD_PROJECT }}/micronaut-starter-analytics:snapshot

--- a/.github/workflows/aws-lambda-snapshot.yml
+++ b/.github/workflows/aws-lambda-snapshot.yml
@@ -12,6 +12,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Run Tests
         run: ./gradlew starter-api:test starter-aws-lambda:test --refresh-dependencies
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+          GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
       - name: Build AWS Lambda
         run: |
           ./gradlew starter-aws-lambda:buildNativeLambda

--- a/.github/workflows/gcf-snapshot.yml
+++ b/.github/workflows/gcf-snapshot.yml
@@ -16,6 +16,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
       - name: Authenticate into Google Cloud Platform
         uses: google-github-actions/setup-gcloud@v0.2.1
         with:

--- a/.github/workflows/gcr-snapshot.yml
+++ b/.github/workflows/gcr-snapshot.yml
@@ -16,6 +16,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
       - name: Build Docker image
         run: |
           docker build . --tag gcr.io/${{ secrets.GCLOUD_PROJECT }}/${{ secrets.GCLOUD_SNAPSHOT_APP_NAME }}:snapshot -f DockerfileCloudRun

--- a/.github/workflows/gradle-func.yml
+++ b/.github/workflows/gradle-func.yml
@@ -34,6 +34,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
   test-core:
     runs-on: ubuntu-latest
     strategy:
@@ -60,6 +61,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
   test-aws:
     runs-on: ubuntu-latest
     strategy:
@@ -86,6 +88,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
   test-features:
     runs-on: ubuntu-latest
     strategy:
@@ -112,6 +115,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
   test-cloud:
     runs-on: ubuntu-latest
     strategy:
@@ -138,6 +142,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
   test-buildTool:
     runs-on: ubuntu-latest
     strategy:
@@ -164,3 +169,4 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,6 +34,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
       - name: Verify CLI
         run: |
           ./gradlew micronaut-cli:assemble

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,13 +4,13 @@ pluginManagement {
         mavenCentral()
     }
     plugins {
-        id 'io.micronaut.application' version '3.3.1'
+        id 'io.micronaut.application' version '3.4.0'
         id 'com.microsoft.azure.azurefunctions' version '1.4.0'
     }
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '5.1.1'
+    id 'io.micronaut.build.shared.settings' version '5.3.4'
 }
 
 rootProject.name = 'micronaut-starter'

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/micronautGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/micronautGradle.rocker.raw
@@ -26,6 +26,7 @@ micronaut {
         cacheEnvironment.set(true)
         optimizeClassLoading.set(true)
         deduceEnvironment.set(true)
+        optimizeNetty.set(true)
 }
 @if (dsl == GradleDsl.GROOVY) {
         version = '@(aotVersion)'
@@ -35,6 +36,7 @@ micronaut {
         cacheEnvironment = true
         optimizeClassLoading = true
         deduceEnvironment = true
+        optimizeNetty = true
 }
     }
 }

--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>io.micronaut.aot</groupId>
             <artifactId>micronaut-aot-core</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.camunda.bpm.assert</groupId>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>io.micronaut.gradle</groupId>
             <artifactId>micronaut-gradle-plugin</artifactId>
-            <version>3.3.1</version>
+            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/MicronautAotBuildPluginSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/MicronautAotBuildPluginSpec.groovy
@@ -14,7 +14,7 @@ import static io.micronaut.starter.options.BuildTool.MAVEN
 
 class MicronautAotBuildPluginSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
-    private static final String GRADLE_PLUGIN_VERSION = '3.3.1'
+    private static final String GRADLE_PLUGIN_VERSION = '3.4.0'
     private static final String AOT_PLUGIN = 'id("io.micronaut.aot") version "' + GRADLE_PLUGIN_VERSION + '"'
     private static final String APP_PLUGIN = 'id("io.micronaut.application") version "' + GRADLE_PLUGIN_VERSION + '"'
 
@@ -32,7 +32,8 @@ class MicronautAotBuildPluginSpec extends ApplicationContextSpec implements Comm
         output.contains('cacheEnvironment = true')
         output.contains('optimizeClassLoading = true')
         output.contains('deduceEnvironment = true')
-        output.contains("version = '1.0.0'")
+        output.contains('optimizeNetty = true')
+        output.contains("version = '1.1.0'")
 
         where:
         language << Language.values().toList()
@@ -52,7 +53,8 @@ class MicronautAotBuildPluginSpec extends ApplicationContextSpec implements Comm
         output.contains('cacheEnvironment.set(true)')
         output.contains('optimizeClassLoading.set(true)')
         output.contains('deduceEnvironment.set(true)')
-        output.contains('version.set("1.0.0")')
+        output.contains('optimizeNetty.set(true)')
+        output.contains('version.set("1.1.0")')
 
         where:
         language << Language.values().toList()


### PR DESCRIPTION
This commit bumps the Gradle plugin version to 3.4.0. It takes advantage of this to bump the Micronaut AOT version to 1.1.0.

Also bumps infrastructure (build plugins) to latest.