### PR TITLE
Kapt dependencies in Maven seem to require an order

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
@@ -51,7 +51,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -80,7 +79,7 @@ public class GeneratorContext implements DependencyContext {
     private final ApplicationType command;
     private final Features features;
     private final Options options;
-    private final Set<Dependency> dependencies = new LinkedHashSet<>();
+    private final Set<Dependency> dependencies = new HashSet<>();
 
     private final Set<BuildPlugin> buildPlugins = new HashSet<>();
 

--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Priority.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Priority.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.build.dependencies;
+
+import io.micronaut.core.order.Ordered;
+
+public enum Priority {
+
+    LOMBOK,
+    MICRONAUT_INJECT_JAVA,
+    MICRONAUT_DATA_PROCESSOR;
+
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + ordinal();
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
@@ -44,24 +44,29 @@ public class MavenBuildCreator {
      *
      * This comparator ensures that the order is as follows (if they exist):
      *
+     * - lombok
      * - micronaut-inject
      * - micronaut-inject-java
      * - micronaut-data-processor
      * - other dependencies
      */
     private static final Comparator<? super Coordinate> PROCESSOR_COMPARATOR = (o1, o2) -> {
-        if (MICRONAUT_INJECT.equals(o1.getArtifactId())) {
+        if ("lombok".equals(o1.getArtifactId()) && "org.projectlombok".equals(o1.getGroupId())) {
             return Integer.MIN_VALUE;
-        } else if (MICRONAUT_INJECT.equals(o2.getArtifactId())) {
+        } else if ("lombok".equals(o2.getArtifactId()) && "org.projectlombok".equals(o2.getGroupId())) {
             return Integer.MAX_VALUE;
-        } else if (MICRONAUT_INJECT_JAVA.equals(o1.getArtifactId())) {
+        } else if (MICRONAUT_INJECT.equals(o1.getArtifactId())) {
             return Integer.MIN_VALUE + 1;
-        } else if (MICRONAUT_INJECT_JAVA.equals(o2.getArtifactId())) {
+        } else if (MICRONAUT_INJECT.equals(o2.getArtifactId())) {
             return Integer.MAX_VALUE - 1;
-        } else if (MICRONAUT_DATA_PROCESSOR.equals(o1.getArtifactId())) {
+        } else if (MICRONAUT_INJECT_JAVA.equals(o1.getArtifactId())) {
             return Integer.MIN_VALUE + 2;
-        } else if (MICRONAUT_DATA_PROCESSOR.equals(o2.getArtifactId())) {
+        } else if (MICRONAUT_INJECT_JAVA.equals(o2.getArtifactId())) {
             return Integer.MAX_VALUE - 2;
+        } else if (MICRONAUT_DATA_PROCESSOR.equals(o1.getArtifactId())) {
+            return Integer.MIN_VALUE + 3;
+        } else if (MICRONAUT_DATA_PROCESSOR.equals(o2.getArtifactId())) {
+            return Integer.MAX_VALUE - 3;
         } else {
             return Coordinate.COMPARATOR.compare(o1, o2);
         }

--- a/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
@@ -23,54 +23,17 @@ import io.micronaut.starter.build.dependencies.Coordinate;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.DependencyCoordinate;
 import io.micronaut.starter.build.dependencies.Phase;
+import io.micronaut.starter.build.dependencies.Priority;
 import io.micronaut.starter.build.dependencies.Source;
 import io.micronaut.starter.options.Language;
 import jakarta.inject.Singleton;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Singleton
 public class MavenBuildCreator {
-
-    private static final String MICRONAUT_INJECT_JAVA = "micronaut-inject-java";
-    private static final String MICRONAUT_INJECT = "micronaut-inject";
-    private static final String MICRONAUT_DATA_PROCESSOR = "micronaut-data-processor";
-
-    /**
-     * For Maven annotation processing, the dependencies must be in a specific order, as in Maven, the first wins no matter what.
-     *
-     * This comparator ensures that the order is as follows (if they exist):
-     *
-     * - lombok
-     * - micronaut-inject
-     * - micronaut-inject-java
-     * - micronaut-data-processor
-     * - other dependencies
-     */
-    private static final Comparator<? super Coordinate> PROCESSOR_COMPARATOR = (o1, o2) -> {
-        if ("lombok".equals(o1.getArtifactId()) && "org.projectlombok".equals(o1.getGroupId())) {
-            return Integer.MIN_VALUE;
-        } else if ("lombok".equals(o2.getArtifactId()) && "org.projectlombok".equals(o2.getGroupId())) {
-            return Integer.MAX_VALUE;
-        } else if (MICRONAUT_INJECT.equals(o1.getArtifactId())) {
-            return Integer.MIN_VALUE + 1;
-        } else if (MICRONAUT_INJECT.equals(o2.getArtifactId())) {
-            return Integer.MAX_VALUE - 1;
-        } else if (MICRONAUT_INJECT_JAVA.equals(o1.getArtifactId())) {
-            return Integer.MIN_VALUE + 2;
-        } else if (MICRONAUT_INJECT_JAVA.equals(o2.getArtifactId())) {
-            return Integer.MAX_VALUE - 2;
-        } else if (MICRONAUT_DATA_PROCESSOR.equals(o1.getArtifactId())) {
-            return Integer.MIN_VALUE + 3;
-        } else if (MICRONAUT_DATA_PROCESSOR.equals(o2.getArtifactId())) {
-            return Integer.MAX_VALUE - 3;
-        } else {
-            return Coordinate.COMPARATOR.compare(o1, o2);
-        }
-    };
 
     @NonNull
     public MavenBuild create(GeneratorContext generatorContext) {
@@ -101,8 +64,9 @@ public class MavenBuildCreator {
 
         Coordinate injectJava = Dependency.builder()
                 .groupId("io.micronaut")
-                .artifactId(MICRONAUT_INJECT_JAVA)
+                .artifactId("micronaut-inject-java")
                 .versionProperty("micronaut.version")
+                .order(Priority.MICRONAUT_INJECT_JAVA.getOrder())
                 .buildCoordinate(true);
         Coordinate validation = Dependency.builder()
                 .groupId("io.micronaut")
@@ -126,8 +90,8 @@ public class MavenBuildCreator {
             annotationProcessorsCoordinates.add(mnGraal);
         }
 
-        annotationProcessorsCoordinates.sort(PROCESSOR_COMPARATOR);
-        testAnnotationProcessorsCoordinates.sort(PROCESSOR_COMPARATOR);
+        annotationProcessorsCoordinates.sort(Coordinate.COMPARATOR);
+        testAnnotationProcessorsCoordinates.sort(Coordinate.COMPARATOR);
 
         List<MavenPlugin> plugins = generatorContext.getBuildPlugins()
                 .stream()

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataJdbc.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataJdbc.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.feature.database;
 
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.Priority;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.database.jdbc.JdbcFeature;
 
@@ -62,7 +63,8 @@ public class DataJdbc implements DataFeature {
                 .groupId("io.micronaut.data")
                 .artifactId("micronaut-data-processor")
                 .versionProperty("micronaut.data.version")
-                .annotationProcessor());
+                .order(Priority.MICRONAUT_DATA_PROCESSOR.getOrder())
+                .annotationProcessor(true));
         generatorContext.addDependency(Dependency.builder()
                 .groupId("io.micronaut.data")
                 .artifactId("micronaut-data-jdbc")

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataJpa.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataJpa.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.feature.database;
 
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.Priority;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.database.jdbc.JdbcFeature;
 
@@ -62,7 +63,8 @@ public class DataJpa implements JpaFeature, DataFeature {
                 .groupId("io.micronaut.data")
                 .artifactId("micronaut-data-processor")
                 .versionProperty("micronaut.data.version")
-                .annotationProcessor());
+                .order(Priority.MICRONAUT_DATA_PROCESSOR.getOrder())
+                .annotationProcessor(true));
         generatorContext.addDependency(Dependency.builder()
                 .groupId("io.micronaut.data")
                 .artifactId("micronaut-data-hibernate-jpa")

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongoFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongoFeature.java
@@ -18,6 +18,7 @@ package io.micronaut.starter.feature.database;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.Priority;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.Language;
@@ -49,7 +50,8 @@ public abstract class DataMongoFeature extends TestContainersFeature implements 
 
         if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
             generatorContext.addDependency(Dependency.builder()
-                    .annotationProcessor()
+                    .order(Priority.MICRONAUT_DATA_PROCESSOR.getOrder())
+                    .annotationProcessor(true)
                     .groupId(MICRONAUT_DATA_GROUP)
                     .artifactId(MICRONAUT_DATA_PROCESSOR_ARTIFACT)
                     .versionProperty(MICRONAUT_DATA_VERSION));

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/DataR2dbc.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/DataR2dbc.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.Priority;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.database.Data;
@@ -53,7 +54,8 @@ public class DataR2dbc implements R2dbcFeature {
                 .groupId("io.micronaut.data")
                 .artifactId("micronaut-data-processor")
                 .versionProperty("micronaut.data.version")
-                .annotationProcessor());
+                .order(Priority.MICRONAUT_DATA_PROCESSOR.getOrder())
+                .annotationProcessor(true));
         generatorContext.addDependency(Dependency.builder()
                 .groupId("io.micronaut.data")
                 .artifactId("micronaut-data-r2dbc")

--- a/starter-core/src/main/java/io/micronaut/starter/feature/other/ProjectLombok.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/other/ProjectLombok.java
@@ -15,10 +15,10 @@
  */
 package io.micronaut.starter.feature.other;
 
-import io.micronaut.core.order.Ordered;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.Priority;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.LanguageSpecificFeature;
 import io.micronaut.starter.options.Language;
@@ -74,7 +74,9 @@ public class ProjectLombok implements LanguageSpecificFeature {
                 .artifactId("lombok")
                 .template();
 
-        generatorContext.addDependency(lombok.versionProperty("lombok.version").order(Ordered.HIGHEST_PRECEDENCE).annotationProcessor(true));
+        generatorContext.addDependency(
+                lombok.versionProperty("lombok.version").order(Priority.LOMBOK.getOrder()).annotationProcessor(true)
+        );
         generatorContext.addDependency(lombok.compileOnly());
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataMongoSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataMongoSpec.groovy
@@ -122,6 +122,7 @@ class DataMongoSpec extends ApplicationContextSpec implements CommandOutputFixtu
             case Language.KOTLIN:
                 def mavenPlugin = project.build.plugins.plugin.find { it.artifactId.text() == 'kotlin-maven-plugin' }
                 def artifacts = mavenPlugin.executions.execution.find { it.id.text() == 'kapt' }.configuration.annotationProcessorPaths.annotationProcessorPath.artifactId*.text()
+                assert artifacts.indexOf("micronaut-inject-java") == 0
                 assert artifacts.contains("micronaut-data-document-processor")
                 assert artifacts.contains("micronaut-data-processor")
                 // data processor must come before the document processor because Maven


### PR DESCRIPTION
A method was renamed in https://github.com/micronaut-projects/micronaut-core/pull/7051

But as some annotation libs pull in older versions of inject-java, Maven fails if they are
earlier in the dependency list.

This was found investigating here https://github.com/micronaut-projects/micronaut-guides/issues/918

I suspect it's also causing the other Kotlin failures in guides.

This also reverts some of the changes here https://github.com/micronaut-projects/micronaut-starter/pull/1146
when we had the same issue with Mongo-Data processing in Maven

I need to test building the guides against a snapshot of this.