### PR TITLE
feat: add developmentOnly dependencies

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Dependency.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Dependency.java
@@ -225,6 +225,10 @@ public final class Dependency {
             }
         }
 
+        public Builder developmentOnly() {
+            return scope(Scope.DEVELOPMENT_ONLY);
+        }
+
         public Builder compile() {
             return scope(Scope.COMPILE);
         }

--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Phase.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Phase.java
@@ -18,6 +18,7 @@ package io.micronaut.starter.build.dependencies;
 public enum Phase {
     ANNOTATION_PROCESSING,
     COMPILATION,
+    DEVELOPMENT,
     RUNTIME,
     OPENREWRITE
 }

--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Scope.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Scope.java
@@ -23,9 +23,9 @@ import java.util.List;
 import java.util.Objects;
 
 public class Scope {
-
     public static final Scope ANNOTATION_PROCESSOR = new Scope(Source.MAIN, Collections.singletonList(Phase.ANNOTATION_PROCESSING));
     public static final Scope COMPILE = new Scope(Source.MAIN, Arrays.asList(Phase.COMPILATION, Phase.RUNTIME));
+    public static final Scope DEVELOPMENT_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.DEVELOPMENT));
     public static final Scope COMPILE_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.COMPILATION));
     public static final Scope RUNTIME = new Scope(Source.MAIN, Collections.singletonList(Phase.RUNTIME));
     public static final Scope TEST = new Scope(Source.TEST, Arrays.asList(Phase.COMPILATION, Phase.RUNTIME));

--- a/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleConfiguration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleConfiguration.java
@@ -36,7 +36,8 @@ public enum GradleConfiguration implements Ordered {
     TEST_IMPLEMENTATION("testImplementation", 8),
     TEST_COMPILE_ONLY("testCompileOnly", 9),
     TEST_RUNTIME_ONLY("testRuntimeOnly", 10),
-    OPENREWRITE("rewrite", 11);
+    DEVELOPMENT_ONLY("developmentOnly", 11),
+    OPENREWRITE("rewrite", 12);
 
     private final String configurationName;
     private final int order;
@@ -92,8 +93,10 @@ public enum GradleConfiguration implements Ordered {
                 if (scope.getPhases().contains(Phase.OPENREWRITE)) {
                     return Optional.of(GradleConfiguration.OPENREWRITE);
                 }
+                if (scope.getPhases().contains(Phase.DEVELOPMENT)) {
+                    return Optional.of(GradleConfiguration.DEVELOPMENT_ONLY);
+                }
                 break;
-
             case TEST:
                 if (scope.getPhases().contains(Phase.ANNOTATION_PROCESSING)) {
                     if (language == Language.JAVA) {

--- a/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenScope.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenScope.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.starter.build.dependencies.Phase;
 import io.micronaut.starter.build.dependencies.Scope;
+import io.micronaut.starter.build.gradle.GradleConfiguration;
 
 import java.util.Optional;
 
@@ -61,8 +62,10 @@ public enum MavenScope implements Ordered {
                 if (scope.getPhases().contains(Phase.COMPILATION)) {
                     return Optional.of(MavenScope.PROVIDED);
                 }
+                if (scope.getPhases().contains(Phase.DEVELOPMENT)) {
+                    return Optional.of(MavenScope.COMPILE);
+                }
                 break;
-
             case TEST:
                 return Optional.of(MavenScope.TEST);
             default:

--- a/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenScope.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenScope.java
@@ -59,11 +59,8 @@ public enum MavenScope implements Ordered {
                     }
                     return Optional.of(MavenScope.RUNTIME);
                 }
-                if (scope.getPhases().contains(Phase.COMPILATION)) {
+                if (scope.getPhases().contains(Phase.COMPILATION) || scope.getPhases().contains(Phase.DEVELOPMENT)) {
                     return Optional.of(MavenScope.PROVIDED);
-                }
-                if (scope.getPhases().contains(Phase.DEVELOPMENT)) {
-                    return Optional.of(MavenScope.COMPILE);
                 }
                 break;
             case TEST:

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/GradleConfigurationSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/GradleConfigurationSpec.groovy
@@ -7,19 +7,38 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class GradleConfigurationSpec extends Specification {
-    void "GradleConfiguration::toString() returns the gradle configuration"() {
+    @Unroll
+    void "GradleConfiguration::toString() returns the gradle configuration"(GradleConfiguration gradleConfiguration, String expected) {
         expect:
-        'runtimeOnly' == GradleConfiguration.RUNTIME_ONLY.toString()
+        expected == gradleConfiguration.toString()
+
+        where:
+        expected                  | gradleConfiguration
+        'runtimeOnly'             | GradleConfiguration.RUNTIME_ONLY
+        'developmentOnly'         | GradleConfiguration.DEVELOPMENT_ONLY
+        'testImplementation'      | GradleConfiguration.TEST_IMPLEMENTATION
+        'implementation'          | GradleConfiguration.IMPLEMENTATION
+        'runtimeOnly'             | GradleConfiguration.RUNTIME_ONLY
+        'compileOnly'             | GradleConfiguration.COMPILE_ONLY
+        'testCompileOnly'         | GradleConfiguration.TEST_COMPILE_ONLY
+        'kapt'                    | GradleConfiguration.KAPT
+        'kaptTest'                | GradleConfiguration.TEST_KAPT
+        'rewrite'                 |  GradleConfiguration.OPENREWRITE
+        'annotationProcessor'     | GradleConfiguration.ANNOTATION_PROCESSOR
+        'testAnnotationProcessor' | GradleConfiguration.TEST_ANNOTATION_PROCESSOR
+        'api'                     |GradleConfiguration.API
     }
 
     @Unroll("#description")
     void "it is possible to adapt from source and phases to Gradle configuration"(Source source,
                                                                                   List<Phase> phases, GradleConfiguration configuration,
                                                                                   String description) {
+        expect:
         configuration == GradleConfiguration.of(new Scope(source, phases), Language.JAVA, TestFramework.JUNIT).get()
 
         where:
         source      | phases                              || configuration
+        Source.MAIN | [Phase.DEVELOPMENT]                 || GradleConfiguration.DEVELOPMENT_ONLY
         Source.MAIN | [Phase.RUNTIME, Phase.COMPILATION]  || GradleConfiguration.IMPLEMENTATION
         Source.MAIN | [Phase.RUNTIME]                     || GradleConfiguration.RUNTIME_ONLY
         Source.TEST | [Phase.RUNTIME]                     || GradleConfiguration.TEST_RUNTIME_ONLY

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/MavenScopeSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/MavenScopeSpec.groovy
@@ -20,6 +20,7 @@ class MavenScopeSpec extends Specification {
 
         where:
         source      | phases                              || scope
+        Source.MAIN | [Phase.DEVELOPMENT]                 || MavenScope.COMPILE
         Source.MAIN | [Phase.RUNTIME, Phase.COMPILATION]  || MavenScope.COMPILE
         Source.MAIN | [Phase.RUNTIME]                     || MavenScope.RUNTIME
         Source.MAIN | [Phase.COMPILATION]                 || MavenScope.PROVIDED


### PR DESCRIPTION
This allows a feature to contribute a development only dependency. 