### PR TITLE
Fix the mongo spec.

### DIFF
--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataMongoSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataMongoSpec.groovy
@@ -88,7 +88,7 @@ class DataMongoSpec extends ApplicationContextSpec implements CommandOutputFixtu
         }
 
         def testContainersDependencies = project.dependencies.dependency.findAll { it.groupId.text() == 'org.testcontainers' }
-        testContainersDependencies.size == 3
+        testContainersDependencies.size() == 3
         testContainersDependencies.scope*.text().unique() == ['test']
         testContainersDependencies.artifactId*.text().sort() == expectedTestcontainersArtifacts
 


### PR DESCRIPTION
We missed parenthesis on the call to get the size of a List.

On the 3.4.x branch, this is ok, and the size method is called (I'm guessing due to some Spock
magic -- but I cannot prove it currently)

On the 3.5.x branch, this weird behavior no longer works, so we just get a list of 3 empty elements.

Strangely, only on Java 17

This fix is applied to the 3.4.x branch (as it's wrong there, and just works due to some edge case
and merging it up to 3.5.x will fix the test over there)