### PR TITLE
Made Micronaut Console runtime dependency

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/console/Console.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/console/Console.java
@@ -87,7 +87,7 @@ public class Console implements AgoraPulseFeature {
     private void addDependency(GeneratorContext generatorContext) {
         generatorContext.addDependency(Dependency.builder()
                 .lookupArtifactId(ARTIFACT_ID)
-                .developmentOnly());
+                .runtime());
 
         if (generatorContext.getLanguage() == Language.JAVA) {
             addGroovyDependency(generatorContext);
@@ -103,7 +103,7 @@ public class Console implements AgoraPulseFeature {
         Dependency.Builder groovy = Dependency.builder()
                 .groupId("org.codehaus.groovy")
                 .artifactId("groovy")
-                .developmentOnly();
+                .runtime();
         generatorContext.addDependency(groovy);
     }
 
@@ -116,7 +116,7 @@ public class Console implements AgoraPulseFeature {
                 .version("${kotlinVersion}")
                 .template();
 
-        generatorContext.addDependency(kotlin.artifactId("kotlin-scripting-jsr223").developmentOnly());
+        generatorContext.addDependency(kotlin.artifactId("kotlin-scripting-jsr223").runtime());
     }
 
     private void addExampleCode(GeneratorContext generatorContext, String secret) {


### PR DESCRIPTION
Please, depending on result of this conversation https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/466 make the Micronaut Console working out of the box for `./gradlew run` task. 