### PR TITLE
adds s3 notification event and scheduled event

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/diff/FeatureDiffer.java
+++ b/starter-core/src/main/java/io/micronaut/starter/diff/FeatureDiffer.java
@@ -50,6 +50,7 @@ public class FeatureDiffer {
      * @param project The project
      * @param applicationType The application type
      * @param options The options
+     * @param operatingSystem Operating System
      * @param features The features to diff
      * @param consoleOutput The console output
      * @throws Exception If something does wrong

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AmazonApiGateway.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AmazonApiGateway.java
@@ -18,12 +18,13 @@ package io.micronaut.starter.feature.aws;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.feature.Category;
+import io.micronaut.starter.feature.function.awslambda.AwsLambda;
 import jakarta.inject.Singleton;
 
 @Singleton
-public class AmazonApiGateway extends CdkFeature {
-    public AmazonApiGateway(Cdk cdk) {
-        super(cdk);
+public class AmazonApiGateway extends AwsLambdaRelatedFeature implements AwsApiFeature {
+    public AmazonApiGateway(AwsLambda awsLambda) {
+        super(awsLambda);
     }
 
     @Override
@@ -46,11 +47,6 @@ public class AmazonApiGateway extends CdkFeature {
     @Override
     public String getThirdPartyDocumentation() {
         return "https://aws.amazon.com/api-gateway/";
-    }
-
-    @Override
-    public String getCategory() {
-        return Category.CLOUD;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaEventFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaEventFeature.java
@@ -15,5 +15,18 @@
  */
 package io.micronaut.starter.feature.aws;
 
-public interface AwsApiFeature extends AwsLambdaEventFeature {
+import io.micronaut.starter.feature.Category;
+import io.micronaut.starter.feature.OneOfFeature;
+
+public interface AwsLambdaEventFeature extends OneOfFeature {
+
+    @Override
+    default Class<?> getFeatureClass() {
+        return AwsLambdaEventFeature.class;
+    }
+
+    @Override
+    default String getCategory() {
+        return Category.CLOUD;
+    }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaEventFunctionFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaEventFunctionFeature.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.aws;
+
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.function.awslambda.AwsLambda;
+
+/**
+ * An abstract class for {@link AwsLambdaEventFeature} which are applicable only for {@link ApplicationType#FUNCTION}.
+ */
+public abstract class AwsLambdaEventFunctionFeature implements AwsLambdaEventFeature {
+    private final AwsLambda awsLambda;
+
+    public AwsLambdaEventFunctionFeature(AwsLambda awsLambda) {
+        this.awsLambda = awsLambda;
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return applicationType == ApplicationType.FUNCTION;
+    }
+
+    @Override
+    public void processSelectedFeatures(FeatureContext featureContext) {
+        if (!featureContext.isPresent(AwsLambda.class)) {
+            featureContext.addFeature(awsLambda);
+        }
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaRelatedFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaRelatedFeature.java
@@ -15,20 +15,20 @@
  */
 package io.micronaut.starter.feature.aws;
 
-import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.function.awslambda.AwsLambda;
 
-/**
- * An abstract class for {@link AwsLambdaEventFeature} which are applicable only for {@link ApplicationType#FUNCTION}.
- */
-public abstract class AwsLambdaEventFunctionFeature extends AwsLambdaRelatedFeature {
+public abstract class AwsLambdaRelatedFeature implements AwsLambdaEventFeature {
+    private final AwsLambda awsLambda;
 
-    public AwsLambdaEventFunctionFeature(AwsLambda awsLambda) {
-        super(awsLambda);
+    public AwsLambdaRelatedFeature(AwsLambda awsLambda) {
+        this.awsLambda = awsLambda;
     }
 
     @Override
-    public boolean supports(ApplicationType applicationType) {
-        return applicationType == ApplicationType.FUNCTION;
+    public void processSelectedFeatures(FeatureContext featureContext) {
+        if (!featureContext.isPresent(AwsLambda.class)) {
+            featureContext.addFeature(awsLambda);
+        }
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaS3EventNotification.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaS3EventNotification.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.aws;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.feature.function.awslambda.AwsLambda;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class AwsLambdaS3EventNotification extends AwsLambdaEventFunctionFeature {
+    public static final String NAME = "aws-lambda-s3-event-notification";
+
+    public AwsLambdaS3EventNotification(AwsLambda awsLambda) {
+        super(awsLambda);
+    }
+    
+    @Override
+    @NonNull
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    @NonNull
+    public String getTitle() {
+        return "AWS S3 Notification Event";
+    }
+
+    @Override
+    @NonNull
+    public String getDescription() {
+        return "It creates a function handler that subscribes to a S3 notification event.";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaS3EventNotification.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaS3EventNotification.java
@@ -42,6 +42,6 @@ public class AwsLambdaS3EventNotification extends AwsLambdaEventFunctionFeature 
     @Override
     @NonNull
     public String getDescription() {
-        return "It creates a function handler that subscribes to a S3 notification event.";
+        return "Creates a function handler that subscribes to a S3 notification event.";
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaScheduledEvent.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaScheduledEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.aws;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.feature.function.awslambda.AwsLambda;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class AwsLambdaScheduledEvent extends AwsLambdaEventFunctionFeature {
+    public static final String NAME = "aws-lambda-scheduled-event";
+
+    public AwsLambdaScheduledEvent(AwsLambda awsLambda) {
+        super(awsLambda);
+    }
+    
+    @Override
+    @NonNull
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    @NonNull
+    public String getTitle() {
+        return "AWS Lambda Scheduled Event";
+    }
+
+    @Override
+    @NonNull
+    public String getDescription() {
+        return "It creates a function handler that subscribes to a scheduled event.";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaScheduledEvent.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaScheduledEvent.java
@@ -42,6 +42,6 @@ public class AwsLambdaScheduledEvent extends AwsLambdaEventFunctionFeature {
     @Override
     @NonNull
     public String getDescription() {
-        return "It creates a function handler that subscribes to a scheduled event.";
+        return "Creates a function handler that subscribes to a scheduled event.";
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
@@ -116,6 +116,8 @@ public class Cdk implements MultiProjectFeature {
         Language lang = Language.JAVA;
         generatorContext.addTemplate("cdk-appstacktest", new RockerTemplate(INFRA_MODULE, lang.getTestSrcDir() + "/{packagePath}/AppStackTest.java",
                 cdkappstacktest.template(generatorContext.getProject(), handler)));
+
+
         generatorContext.addTemplate("cdk-appstack", new RockerTemplate(INFRA_MODULE, lang.getSrcDir() + "/{packagePath}/AppStack.java",
                 cdkappstack.template(generatorContext.getFeatures(),
                         generatorContext.getProject(),
@@ -124,7 +126,7 @@ public class Cdk implements MultiProjectFeature {
                         Template.DEFAULT_MODULE,
                         generatorContext.getBuildTool().isGradle() ? "build/libs" : "target",
                         "micronaut-function",
-                        "micronaut-function-api",
+                        generatorContext.getFeatures().hasFeature(AwsApiFeature.class) ? "micronaut-function-api" : null,
                         "0.1",
                         handler,
                         generatorContext.getFeatures().hasGraalvm(),

--- a/starter-core/src/main/java/io/micronaut/starter/feature/awslambdacustomruntime/AwsLambdaCustomRuntime.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awslambdacustomruntime/AwsLambdaCustomRuntime.java
@@ -121,9 +121,9 @@ public class AwsLambdaCustomRuntime implements FunctionFeature, ApplicationFeatu
     private void addFunctionLambdaRuntime(GeneratorContext generatorContext, Project project) {
         String functionLambdaRuntime = generatorContext.getSourcePath("/{packagePath}/FunctionLambdaRuntime");
         generatorContext.addTemplate("functionLambdaRuntime", functionLambdaRuntime,
-                functionLambdaRuntimeJava.template(project),
-                functionLambdaRuntimeKotlin.template(project),
-                functionLambdaRuntimeGroovy.template(project));
+                functionLambdaRuntimeJava.template(generatorContext.getFeatures(), project),
+                functionLambdaRuntimeKotlin.template(generatorContext.getFeatures(), project),
+                functionLambdaRuntimeGroovy.template(generatorContext.getFeatures(), project));
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/awslambdacustomruntime/templates/functionLambdaRuntimeGroovy.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awslambdacustomruntime/templates/functionLambdaRuntimeGroovy.rocker.raw
@@ -1,8 +1,7 @@
 @import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Features;
 
-@args (
-Project project
-)
+@args (Features features, Project project)
 
 @if (project.getPackageName() != null) {
 package @project.getPackageName()
@@ -10,13 +9,24 @@ package @project.getPackageName()
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
+@if (features.contains("aws-lambda-scheduled-event")) {
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
+}
 import io.micronaut.function.aws.runtime.AbstractMicronautLambdaRuntime
 import java.net.MalformedURLException;
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import io.micronaut.core.annotation.Nullable
 
-class FunctionLambdaRuntime extends AbstractMicronautLambdaRuntime<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent, APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-
+@if (features.contains("aws-lambda-scheduled-event")) {
+class FunctionLambdaRuntime extends AbstractMicronautLambdaRuntime<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent, ScheduledEvent, Void>
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+class FunctionLambdaRuntime extends AbstractMicronautLambdaRuntime<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent, S3EventNotification, Void>
+} else {
+class FunctionLambdaRuntime extends AbstractMicronautLambdaRuntime<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent, APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>
+}
+{
     static void main(String[] args) {
         try {
             new FunctionLambdaRuntime().run(args)
@@ -25,10 +35,24 @@ class FunctionLambdaRuntime extends AbstractMicronautLambdaRuntime<APIGatewayPro
             e.printStackTrace()
         }
     }
-
+@if (features.contains("aws-lambda-scheduled-event")) {
+    @@Override
+    @@Nullable
+    protected RequestHandler<ScheduledEvent, Void> createRequestHandler(String... args) {
+        new FunctionRequestHandler()
+    }
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+    @@Override
+    @@Nullable
+    protected RequestHandler<S3EventNotification, Void> createRequestHandler(String... args) {
+        new FunctionRequestHandler()
+    }
+} else {
     @@Override
     @@Nullable
     protected RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> createRequestHandler(String... args) {
         new FunctionRequestHandler()
     }
+}
+
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/awslambdacustomruntime/templates/functionLambdaRuntimeJava.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awslambdacustomruntime/templates/functionLambdaRuntimeJava.rocker.raw
@@ -1,8 +1,7 @@
 @import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Features;
 
-@args (
-Project project
-)
+@args (Features features, Project project)
 
 @if (project.getPackageName() != null) {
 package @project.getPackageName();
@@ -10,13 +9,23 @@ package @project.getPackageName();
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+@if (features.contains("aws-lambda-scheduled-event")) {
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
+}
 import io.micronaut.function.aws.runtime.AbstractMicronautLambdaRuntime;
 import java.net.MalformedURLException;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import io.micronaut.core.annotation.Nullable;
-
-public class FunctionLambdaRuntime extends AbstractMicronautLambdaRuntime<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent, APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-
+@if (features.contains("aws-lambda-scheduled-event")) {
+public class FunctionLambdaRuntime extends AbstractMicronautLambdaRuntime<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent, ScheduledEvent, Void>
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+public class FunctionLambdaRuntime extends AbstractMicronautLambdaRuntime<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent, S3EventNotification, Void>
+} else {
+public class FunctionLambdaRuntime extends AbstractMicronautLambdaRuntime<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent, APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>
+}
+{
     public static void main(String[] args) {
         try {
             new FunctionLambdaRuntime().run(args);
@@ -26,9 +35,23 @@ public class FunctionLambdaRuntime extends AbstractMicronautLambdaRuntime<APIGat
         }
     }
 
+@if (features.contains("aws-lambda-scheduled-event")) {
+    @@Override
+    @@Nullable
+    protected RequestHandler<ScheduledEvent, Void> createRequestHandler(String... args) {
+        return new FunctionRequestHandler();
+    }
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+    @@Override
+    @@Nullable
+    protected RequestHandler<S3EventNotification, Void> createRequestHandler(String... args) {
+        return new FunctionRequestHandler();
+    }
+} else {
     @@Override
     @@Nullable
     protected RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> createRequestHandler(String... args) {
         return new FunctionRequestHandler();
     }
+}
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/awslambdacustomruntime/templates/functionLambdaRuntimeKotlin.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awslambdacustomruntime/templates/functionLambdaRuntimeKotlin.rocker.raw
@@ -1,8 +1,7 @@
 @import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Features;
 
-@args (
-Project project
-)
+@args (Features features, Project project)
 
 @if (project.getPackageName() != null) {
 package @project.getPackageName()
@@ -11,14 +10,36 @@ package @project.getPackageName()
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
+@if (features.contains("aws-lambda-scheduled-event")) {
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
+}
 import io.micronaut.function.aws.runtime.AbstractMicronautLambdaRuntime
 import java.net.MalformedURLException
 
-class FunctionLambdaRuntime : AbstractMicronautLambdaRuntime<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent, APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>() {
+@if (features.contains("aws-lambda-scheduled-event")) {
+class FunctionLambdaRuntime : AbstractMicronautLambdaRuntime<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent, ScheduledEvent, Void?>()
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+class FunctionLambdaRuntime : AbstractMicronautLambdaRuntime<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent, S3EventNotification, Void?>()
+} else {
+class FunctionLambdaRuntime : AbstractMicronautLambdaRuntime<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent, APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>()
+}
+{
 
+@if (features.contains("aws-lambda-scheduled-event")) {
+    override fun createRequestHandler(vararg args: String?): RequestHandler<ScheduledEvent, Void>? {
+        return FunctionRequestHandler()
+    }
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+    override fun createRequestHandler(vararg args: String?): RequestHandler<S3EventNotification, Void>? {
+        return FunctionRequestHandler()
+    }
+} else {
     override fun createRequestHandler(vararg args: String?): RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>? {
         return FunctionRequestHandler()
     }
+}
 
     companion object {
         @@JvmStatic

--- a/starter-core/src/main/java/io/micronaut/starter/feature/config/Configuration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/config/Configuration.java
@@ -39,6 +39,8 @@ public class Configuration extends LinkedHashMap<String, Object> {
      * A configuration rooted at path, with the given map of configurations
      *
      * @param sourceSet where the configuration is rooted, e.g. main, test
+     * @param fileName Filename
+     * @param templateKey Template Key
      */
     public Configuration(@NonNull String sourceSet, @NonNull String fileName, @NonNull String templateKey) {
         super();

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/AwsLambda.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/AwsLambda.java
@@ -25,6 +25,8 @@ import io.micronaut.starter.feature.DefaultFeature;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.MicronautRuntimeFeature;
+import io.micronaut.starter.feature.aws.AwsApiFeature;
+import io.micronaut.starter.feature.aws.AwsLambdaEventFeature;
 import io.micronaut.starter.feature.awsalexa.AwsAlexa;
 import io.micronaut.starter.feature.awslambdacustomruntime.AwsLambdaCustomRuntime;
 import io.micronaut.starter.feature.function.Cloud;
@@ -107,7 +109,10 @@ public class AwsLambda implements FunctionFeature, DefaultFeature, CloudFeature,
                 } else {
                     addRequestHandler(generatorContext, project);
                     generatorContext.addDependency(Dependency.builder().lookupArtifactId("aws-lambda-java-events").compile());
-                    addTest(generatorContext, project);
+                    if (generatorContext.getFeatures().hasFeature(AwsApiFeature.class) ||
+                            !generatorContext.getFeatures().hasFeature(AwsLambdaEventFeature.class)) {
+                        addTest(generatorContext, project);
+                    }
                 }
                 DocumentationLink link = new DocumentationLink(LINK_TITLE, LINK_URL);
                 generatorContext.addHelpTemplate(new RockerWritable(readmeRockerModel(this, generatorContext, link)));
@@ -151,9 +156,9 @@ public class AwsLambda implements FunctionFeature, DefaultFeature, CloudFeature,
     private void addRequestHandler(GeneratorContext generatorContext, Project project) {
         String awsLambdaRequestHandlerFile = generatorContext.getSourcePath("/{packagePath}/" + REQUEST_HANDLER);
         generatorContext.addTemplate("functionRequestHandler", awsLambdaRequestHandlerFile,
-                awsLambdaFunctionRequestHandlerJava.template(project),
-                awsLambdaFunctionRequestHandlerKotlin.template(project),
-                awsLambdaFunctionRequestHandlerGroovy.template(project));
+                awsLambdaFunctionRequestHandlerJava.template(generatorContext.getFeatures(), project),
+                awsLambdaFunctionRequestHandlerKotlin.template(generatorContext.getFeatures(), project),
+                awsLambdaFunctionRequestHandlerGroovy.template(generatorContext.getFeatures(), project));
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/template/awsLambdaFunctionRequestHandlerGroovy.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/template/awsLambdaFunctionRequestHandlerGroovy.rocker.raw
@@ -1,22 +1,43 @@
 @import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Features;
 
-@args (
-Project project
-)
+@args (Features features, Project project)
 
 @if (project.getPackageName() != null) {
 package @project.getPackageName()
 }
 
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
+
+import io.micronaut.function.aws.MicronautRequestHandler
+@if (features.contains("aws-lambda-scheduled-event")) {
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
+} else {
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.micronaut.function.aws.MicronautRequestHandler
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
+}
+
 import jakarta.inject.Inject
 
+@if (features.contains("aws-lambda-scheduled-event")) {
+class FunctionRequestHandler extends MicronautRequestHandler<ScheduledEvent, Void> {
+    @@Override
+    Void execute(ScheduledEvent input) {
+        null
+    }
+}
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+class FunctionRequestHandler extends MicronautRequestHandler<S3EventNotification, Void> {
+    @@Override
+    public Void execute(S3EventNotification input) {
+        return null;
+    }
+}
+} else {
 class FunctionRequestHandler extends MicronautRequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-
     @@Inject
     ObjectMapper objectMapper
 
@@ -32,4 +53,5 @@ class FunctionRequestHandler extends MicronautRequestHandler<APIGatewayProxyRequ
         }
         response
     }
+}
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/template/awsLambdaFunctionRequestHandlerJava.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/template/awsLambdaFunctionRequestHandlerJava.rocker.raw
@@ -1,23 +1,42 @@
 @import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Features;
 
-@args (
-Project project
-)
+@args (Features features, Project project)
 
 @if (project.getPackageName() != null) {
 package @project.getPackageName();
 }
 
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import io.micronaut.function.aws.MicronautRequestHandler;
+@if (features.contains("aws-lambda-scheduled-event")) {
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
+} else  {
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micronaut.function.aws.MicronautRequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import jakarta.inject.Inject;
 import java.util.Collections;
+}
 
+@if (features.contains("aws-lambda-scheduled-event")) {
+public class FunctionRequestHandler extends MicronautRequestHandler<ScheduledEvent, Void> {
+    @@Override
+    public Void execute(ScheduledEvent input) {
+        return null;
+    }
+}
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+public class FunctionRequestHandler extends MicronautRequestHandler<S3EventNotification, Void> {
+    @@Override
+    public Void execute(S3EventNotification input) {
+        return null;
+    }
+}
+} else {
 public class FunctionRequestHandler extends MicronautRequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-
     @@Inject
     ObjectMapper objectMapper;
 
@@ -33,4 +52,5 @@ public class FunctionRequestHandler extends MicronautRequestHandler<APIGatewayPr
         }
         return response;
     }
+}
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/template/awsLambdaFunctionRequestHandlerKotlin.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/template/awsLambdaFunctionRequestHandlerKotlin.rocker.raw
@@ -1,22 +1,38 @@
 @import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Features;
 
-@args (
-Project project
-)
+@args (Features features, Project project)
 
 @if (project.getPackageName() != null) {
 package @project.getPackageName()
 }
 
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
+import io.micronaut.function.aws.MicronautRequestHandler
+@if (features.contains("aws-lambda-scheduled-event")) {
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
+} else {
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.micronaut.function.aws.MicronautRequestHandler
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import jakarta.inject.Inject
-
+}
+@if (features.contains("aws-lambda-scheduled-event")) {
+class FunctionRequestHandler : MicronautRequestHandler<ScheduledEvent, Void?>() {
+    override fun execute(input: ScheduledEvent): Void? {
+        return null
+    }
+}
+} else if (features.contains("aws-lambda-s3-event-notification")) {
+class FunctionRequestHandler : MicronautRequestHandler<S3EventNotification, Void?>() {
+    override fun execute(input: S3EventNotification): Void? {
+        return null
+    }
+}
+} else {
 class FunctionRequestHandler : MicronautRequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>() {
-
     @@Inject
     lateinit var objectMapper: ObjectMapper
 
@@ -31,5 +47,6 @@ class FunctionRequestHandler : MicronautRequestHandler<APIGatewayProxyRequestEve
         }
         return response
     }
+}
 }
 

--- a/starter-core/src/main/java/io/micronaut/starter/util/ZipUtil.java
+++ b/starter-core/src/main/java/io/micronaut/starter/util/ZipUtil.java
@@ -80,7 +80,9 @@ public class ZipUtil {
      * Does the specified zip bytes contain the specified file.
      * @param bytes The bytes
      * @param filename The file name
-     * @return True if it does
+     * @param contents Contents
+     * @return
+     * True if it does
      */
     public static boolean containsFileWithContents(byte[] bytes, String filename, String contents) {
         Objects.requireNonNull(bytes, "Byte cannot be null");

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AmazonApiGatewaySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AmazonApiGatewaySpec.groovy
@@ -16,6 +16,11 @@ class AmazonApiGatewaySpec extends ApplicationContextSpec implements CommandOutp
         amazonApiGateway.category == Category.CLOUD
     }
 
+    void 'amazon-api-gateway feature is an instance of AwsApiFeature'() {
+        expect:
+        amazonApiGateway instanceof AwsApiFeature
+    }
+
     void "amazon-api-gateway does not support #applicationType application type"(ApplicationType applicationType) {
         expect:
         !amazonApiGateway.supports(applicationType)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AwsLambdaS3EventNotificationSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AwsLambdaS3EventNotificationSpec.groovy
@@ -1,0 +1,35 @@
+package io.micronaut.starter.feature.aws
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.Category
+import spock.lang.Subject
+
+class AwsLambdaS3EventNotificationSpec  extends ApplicationContextSpec {
+
+    @Subject
+    AwsLambdaS3EventNotification awsLambdaS3EventNotification = beanContext.getBean(AwsLambdaS3EventNotification)
+
+    void 'aws-lambda-s3-event-notification feature is in the cloud category'() {
+        expect:
+        awsLambdaS3EventNotification.category == Category.CLOUD
+    }
+
+    void 'aws-lambda-s3-event-notification feature is an instance of AwsLambdaEventFeature'() {
+        expect:
+        awsLambdaS3EventNotification instanceof AwsLambdaEventFeature
+    }
+
+    void "aws-lambda-s3-event-notification does not support #applicationType application type"(ApplicationType applicationType) {
+        expect:
+        !awsLambdaS3EventNotification.supports(applicationType)
+
+        where:
+        applicationType << (ApplicationType.values() - ApplicationType.FUNCTION)
+    }
+
+    void "aws-lambda-s3-event-notification supports function application type"() {
+        expect:
+        awsLambdaS3EventNotification.supports(ApplicationType.FUNCTION)
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/LambdaFunctionUrlSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/LambdaFunctionUrlSpec.groovy
@@ -15,6 +15,10 @@ class LambdaFunctionUrlSpec extends ApplicationContextSpec implements CommandOut
         expect:
         lambdaFunctionUrl.category == Category.CLOUD
     }
+    void 'aws-lambda-function-url feature is an instance of AwsApiFeature'() {
+        expect:
+        lambdaFunctionUrl instanceof AwsApiFeature
+    }
 
     void "aws-lambda-function-url does not support #applicationType application type"(ApplicationType applicationType) {
         expect:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/ScheduledEventSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/ScheduledEventSpec.groovy
@@ -1,0 +1,35 @@
+package io.micronaut.starter.feature.aws
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.Category
+import spock.lang.Subject
+
+class ScheduledEventSpec extends ApplicationContextSpec {
+
+    @Subject
+    AwsLambdaScheduledEvent awsLambdaScheduledEvent = beanContext.getBean(AwsLambdaScheduledEvent)
+
+    void 'aws-lambda-scheduled-event feature is in the cloud category'() {
+        expect:
+        awsLambdaScheduledEvent.category == Category.CLOUD
+    }
+
+    void 'aws-lambda-scheduled-event feature is an instance of AwsLambdaEventFeature'() {
+        expect:
+        awsLambdaScheduledEvent instanceof AwsLambdaEventFeature
+    }
+
+    void "aws-lambda-scheduled-event does not support #applicationType application type"(ApplicationType applicationType) {
+        expect:
+        !awsLambdaScheduledEvent.supports(applicationType)
+
+        where:
+        applicationType << (ApplicationType.values() - ApplicationType.FUNCTION)
+    }
+
+    void "aws-lambda-scheduled-event supports function application type"() {
+        expect:
+        awsLambdaScheduledEvent.supports(ApplicationType.FUNCTION)
+    }
+}

--- a/test-aws/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaS3NotificationEventSpec.groovy
+++ b/test-aws/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaS3NotificationEventSpec.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.starter.core.test.aws
+
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
+import io.micronaut.starter.test.ApplicationTypeCombinations
+import io.micronaut.starter.test.CommandSpec
+import spock.lang.Unroll
+
+class CreateAwsLambdaS3NotificationEventSpec extends CommandSpec {
+
+    @Override
+    String getTempDirectoryPrefix() {
+        "test-aws-lambda-s3-event-notification"
+    }
+
+    @Unroll
+    void 'create-#applicationType with features aws-lambda-s3-event-notification #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
+                                                                                                                             Language lang,
+                                                                                                                             BuildTool build,
+                                                                                                                             TestFramework testFramework) {
+        given:
+        List<String> features = ['aws-lambda-s3-event-notification']
+        generateProject(lang, build, features, applicationType, testFramework)
+
+        when:
+        String output = executeBuild(build, "test")
+
+        then:
+        output.contains("BUILD SUCCESS")
+
+        where:
+        [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.FUNCTION])
+    }
+}

--- a/test-aws/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaScheduledEventSpec.groovy
+++ b/test-aws/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaScheduledEventSpec.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.starter.core.test.aws
+
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
+import io.micronaut.starter.test.ApplicationTypeCombinations
+import io.micronaut.starter.test.CommandSpec
+import spock.lang.Unroll
+
+class CreateAwsLambdaScheduledEventSpec extends CommandSpec {
+
+    @Override
+    String getTempDirectoryPrefix() {
+        "test-aws-lambda-scheduled-event"
+    }
+
+    @Unroll
+    void 'create-#applicationType with features aws-lambda-scheduled-event #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
+                                                                                                                             Language lang,
+                                                                                                                             BuildTool build,
+                                                                                                                             TestFramework testFramework) {
+        given:
+        List<String> features = ['aws-lambda-scheduled-event']
+        generateProject(lang, build, features, applicationType, testFramework)
+
+        when:
+        String output = executeBuild(build, "test")
+
+        then:
+        output.contains("BUILD SUCCESS")
+
+        where:
+        [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.FUNCTION])
+    }
+}

--- a/test-buildtool/src/test/groovy/io/micronaut/starter/core/test/buildTool/MavenPackageSpec.groovy
+++ b/test-buildtool/src/test/groovy/io/micronaut/starter/core/test/buildTool/MavenPackageSpec.groovy
@@ -58,7 +58,7 @@ class MavenPackageSpec extends CommandSpec {
         String output = executeMaven( "package -Dpackaging=docker-native -Pgraalvm", 30)
 
         then:
-        output.contains("Using BASE_IMAGE: ghcr.io/graalvm/native-image:ol8-java11-22.0.0.2")
+        output.contains("Using BASE_IMAGE: ghcr.io/graalvm/native-image:ol8-java11-22.1.0")
 
         where:
         lang << [Language.JAVA, Language.KOTLIN, Language.GROOVY]

--- a/test-lambda.sh
+++ b/test-lambda.sh
@@ -23,8 +23,11 @@ if [ $EXIT_STATUS -ne 0 ]; then
   exit $EXIT_STATUS
 fi
 
-cd ../..
+cd infra
+cdk destroy -f
+cd ../../..
 rm -rf starter-cli/temp
+
 
 ############
 # | BUILD  | TYPE     | RUNTIME | FEATURES
@@ -46,7 +49,9 @@ if [ $EXIT_STATUS -ne 0 ]; then
   exit $EXIT_STATUS
 fi
 
-cd ../..
+cd infra
+cdk destroy -f
+cd ../../..
 rm -rf starter-cli/temp
 
 ############
@@ -69,7 +74,9 @@ if [ $EXIT_STATUS -ne 0 ]; then
   exit $EXIT_STATUS
 fi
 
-cd ../..
+cd infra
+cdk destroy -f
+cd ../../..
 rm -rf starter-cli/temp
 
 ############
@@ -92,7 +99,9 @@ rm -rf starter-cli/temp
 #   exit $EXIT_STATUS
 # fi
 # 
-# cd ../..
+# cd infra
+# cdk destroy -f
+# cd ../../..
 # rm -rf starter-cli/temp
 
 ############
@@ -115,7 +124,9 @@ if [ $EXIT_STATUS -ne 0 ]; then
   exit $EXIT_STATUS
 fi
 
-cd ../..
+cd infra
+cdk destroy -f
+cd ../../..
 rm -rf starter-cli/temp
 
 ############
@@ -138,7 +149,9 @@ if [ $EXIT_STATUS -ne 0 ]; then
   exit $EXIT_STATUS
 fi
 
-cd ../..
+cd infra
+cdk destroy -f
+cd ../../..
 rm -rf starter-cli/temp
 
 ############
@@ -161,7 +174,9 @@ if [ $EXIT_STATUS -ne 0 ]; then
   exit $EXIT_STATUS
 fi
 
-cd ../..
+cd infra
+cdk destroy -f
+cd ../../..
 rm -rf starter-cli/temp
 
 ############
@@ -184,7 +199,9 @@ if [ $EXIT_STATUS -ne 0 ]; then
   exit $EXIT_STATUS
 fi
 
-cd ../..
+cd infra
+cdk destroy -f
+cd ../../..
 rm -rf starter-cli/temp
 
 ############
@@ -207,7 +224,9 @@ rm -rf starter-cli/temp
 #   exit $EXIT_STATUS
 # fi
 # 
-# cd ../..
+# cd infra
+# cdk destroy -f
+# cd ../../..
 # rm -rf starter-cli/temp
 
 ############
@@ -230,7 +249,9 @@ if [ $EXIT_STATUS -ne 0 ]; then
   exit $EXIT_STATUS
 fi
 
-cd ../..
+cd infra
+cdk destroy -f
+cd ../../..
 rm -rf starter-cli/temp
 
 ############
@@ -253,7 +274,9 @@ if [ $EXIT_STATUS -ne 0 ]; then
   exit $EXIT_STATUS
 fi
 
-cd ../..
+cd infra
+cdk destroy -f
+cd ../../..
 rm -rf starter-cli/temp
 
 ############
@@ -276,7 +299,9 @@ rm -rf starter-cli/temp
 #   exit $EXIT_STATUS
 # fi
 # 
-# cd ../..
+# cd infra
+# cdk destroy -f
+# cd ../../..
 # rm -rf starter-cli/temp
 
 exit $EXIT_STATUS


### PR DESCRIPTION
When you work with Lambda. You define the trigger your Lambda Function reacts to. AWS Provides a library (AWS Lambda Events) with some Java POJOs to represent those triggers. 

This PR gives users the ability to generate a Micronaut Functions which is triggered by some of the [AWS Lambda Events](https://mvnrepository.com/artifact/com.amazonaws/aws-lambda-java-events). 

We already have some guides which use some triggers beyond HTTP triggers:

- [Micronaut Lambda Scheduled](https://guides.micronaut.io/latest/micronaut-scheduled.html)
- [S3 Notification Event](https://guides.micronaut.io/latest/micronaut-aws-lambda-s3-event.html)