### PR TITLE
prefix community feature names and titles with contributor name

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,7 +29,7 @@ jobs:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
-        run: ./gradlew check --refresh-dependencies --continue -x test-core:test -x test-cli:test
+        run: ./gradlew check --refresh-dependencies --continue -x test-aws:test -x test-buildtool:test -x test-cli:test -x test-cloud:test -x test-core:test -x test-features:test  
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}

--- a/starter-api/src/test/groovy/io/micronaut/starter/api/FeatureControllerSpec.groovy
+++ b/starter-api/src/test/groovy/io/micronaut/starter/api/FeatureControllerSpec.groovy
@@ -30,14 +30,14 @@ class FeatureControllerSpec extends Specification {
         List<FeatureDTO> communityFeatures = client.features(ApplicationType.DEFAULT, RequestInfo.LOCAL).features.findAll { it.community }
 
         then:
-        communityFeatures.name == [
+        communityFeatures.name.sort() == [
                 'novatec-camunda',
                 'novatec-camunda-external-worker',
                 'agorapulse-gru-http',
                 'agorapulse-micronaut-console',
                 'agorapulse-micronaut-worker',
                 'novatec-zeebe',
-        ]
+        ].sort()
     }
 
     void "test list features - spanish"() {

--- a/starter-api/src/test/groovy/io/micronaut/starter/api/FeatureControllerSpec.groovy
+++ b/starter-api/src/test/groovy/io/micronaut/starter/api/FeatureControllerSpec.groovy
@@ -31,12 +31,12 @@ class FeatureControllerSpec extends Specification {
 
         then:
         communityFeatures.name == [
-                'camunda',
-                'camunda-external-worker',
-                'gru-http',
-                'micronaut-console',
-                'micronaut-worker',
-                'zeebe',
+                'novatec-camunda',
+                'novatec-camunda-external-worker',
+                'agorapulse-gru-http',
+                'agorapulse-micronaut-console',
+                'agorapulse-micronaut-worker',
+                'novatec-zeebe',
         ]
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/CommunityFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/CommunityFeature.java
@@ -13,24 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.feature.agorapulse;
+package io.micronaut.starter.feature;
 
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.starter.feature.CommunityFeature;
 
-public interface AgoraPulseFeature extends CommunityFeature {
+public interface CommunityFeature extends Feature {
+    @NonNull
+    default String getName() {
+        return getCommunityContributor().toLowerCase() + "-" + getCommunityFeatureName();
+    }
 
     @Override
-    default String getThirdPartyDocumentation() {
-        return "https://agorapulse.github.io/agorapulse-oss/#_micronaut_libraries";
+    @NonNull
+    default String getTitle() {
+        return getCommunityContributor() + " " + getCommunityFeatureTitle();
     }
+
+    @NonNull
+    String getCommunityFeatureTitle();
+
+    @NonNull
+    String getCommunityFeatureName();
 
     /**
      * @return Indicates name of the community contributor.
      */
-    @Override
     @NonNull
-    default String getCommunityContributor() {
-        return "Agorapulse";
+    String getCommunityContributor();
+
+    @Override
+    default boolean isCommunity() {
+        return true;
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/console/Console.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/console/Console.java
@@ -47,12 +47,13 @@ public class Console implements AgoraPulseFeature {
 
     @Override
     @NonNull
-    public String getName() {
+    public String getCommunityFeatureName() {
         return "micronaut-console";
     }
 
     @Override
-    public String getTitle() {
+    @NonNull
+    public String getCommunityFeatureTitle() {
         return "Micronaut Console";
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/gru/GruHttp.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/gru/GruHttp.java
@@ -46,12 +46,13 @@ public class GruHttp implements AgoraPulseFeature {
 
     @Override
     @NonNull
-    public String getName() {
+    public String getCommunityFeatureName() {
         return "gru-http";
     }
 
     @Override
-    public String getTitle() {
+    @NonNull
+    public String getCommunityFeatureTitle() {
         return "Gru HTTP - interaction testing";
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/worker/Worker.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/worker/Worker.java
@@ -53,7 +53,6 @@ import jakarta.inject.Singleton;
 
 import java.util.Optional;
 
-
 @Singleton
 public class Worker implements AgoraPulseFeature {
 
@@ -70,12 +69,13 @@ public class Worker implements AgoraPulseFeature {
 
     @Override
     @NonNull
-    public String getName() {
+    public String getCommunityFeatureName() {
         return "micronaut-worker";
     }
 
     @Override
-    public String getTitle() {
+    @NonNull
+    public String getCommunityFeatureTitle() {
         return "Micronaut Worker";
     }
 
@@ -97,7 +97,7 @@ public class Worker implements AgoraPulseFeature {
 
     @Override
     public String getThirdPartyDocumentation() {
-        return "https://agorapulse.github.io/micronaut-worker/";
+        return "https://agorapulse.github.io/agorapulse-micronaut-worker/";
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/camunda/Camunda.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/camunda/Camunda.java
@@ -21,15 +21,13 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.database.DatabaseDriverFeature;
 import io.micronaut.starter.feature.test.AssertJ;
-
 import jakarta.inject.Singleton;
 
 @Singleton
-public class Camunda implements Feature {
+public class Camunda implements NovatecFeature {
 
     private final AssertJ assertJ;
     private final DatabaseDriverFeature defaultDbFeature;
@@ -41,12 +39,13 @@ public class Camunda implements Feature {
 
     @NonNull
     @Override
-    public String getName() {
+    public String getCommunityFeatureName() {
         return "camunda";
     }
 
     @Override
-    public String getTitle() {
+    @NonNull
+    public String getCommunityFeatureTitle() {
         return "Camunda Workflow Engine";
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/camunda/CamundaExternalWorker.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/camunda/CamundaExternalWorker.java
@@ -21,26 +21,21 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.feature.Feature;
 import jakarta.inject.Singleton;
 
 @Singleton
-public class CamundaExternalWorker implements Feature {
+public class CamundaExternalWorker implements NovatecFeature {
 
     @NonNull
     @Override
-    public String getName() {
+    public String getCommunityFeatureName() {
         return "camunda-external-worker";
     }
 
     @Override
-    public String getTitle() {
+    @NonNull
+    public String getCommunityFeatureTitle() {
         return "Camunda Workflow Engine External Worker";
-    }
-
-    @Override
-    public boolean isCommunity() {
-        return true;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/camunda/NovatecFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/camunda/NovatecFeature.java
@@ -13,24 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.feature.agorapulse;
+package io.micronaut.starter.feature.camunda;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.feature.CommunityFeature;
 
-public interface AgoraPulseFeature extends CommunityFeature {
+public interface NovatecFeature extends CommunityFeature {
 
-    @Override
-    default String getThirdPartyDocumentation() {
-        return "https://agorapulse.github.io/agorapulse-oss/#_micronaut_libraries";
-    }
-
-    /**
-     * @return Indicates name of the community contributor.
-     */
     @Override
     @NonNull
     default String getCommunityContributor() {
-        return "Agorapulse";
+        return "Novatec";
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/camunda/Zeebe.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/camunda/Zeebe.java
@@ -21,20 +21,20 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.feature.Feature;
 import jakarta.inject.Singleton;
 
 @Singleton
-public class Zeebe implements Feature {
+public class Zeebe implements NovatecFeature {
 
     @NonNull
     @Override
-    public String getName() {
+    public String getCommunityFeatureName() {
         return "zeebe";
     }
 
     @Override
-    public String getTitle() {
+    @NonNull
+    public String getCommunityFeatureTitle() {
         return "Zeebe Worker";
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/console/ConsoleSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/console/ConsoleSpec.groovy
@@ -15,7 +15,7 @@ class ConsoleSpec extends ApplicationContextSpec {
         List<ApplicationType> supportedApplicationTypes = [ApplicationType.DEFAULT]
 
         when:
-        Optional<Feature> featureOptional = findFeatureByName('micronaut-console')
+        Optional<Feature> featureOptional = findFeatureByName('agorapulse-micronaut-console')
 
         then:
         featureOptional.isPresent()
@@ -41,10 +41,10 @@ class ConsoleSpec extends ApplicationContextSpec {
         }
     }
 
-    @Unroll("#buildTool with feature micronaut-console adds dependency #groupId:#artifactId for #language")
-    void "verify micronaut-console feature dependencies"(Language language, BuildTool buildTool, String groupId, String artifactId) {
+    @Unroll("#buildTool with feature agorapulse-micronaut-console adds dependency #groupId:#artifactId for #language")
+    void "verify agorapulse-micronaut-console feature dependencies"(Language language, BuildTool buildTool, String groupId, String artifactId) {
         given:
-        List<String> features = ['micronaut-console']
+        List<String> features = ['agorapulse-micronaut-console']
         String coordinate = "${groupId}:${artifactId}"
 
         when:
@@ -80,9 +80,9 @@ class ConsoleSpec extends ApplicationContextSpec {
         Language.KOTLIN | BuildTool.MAVEN           | 'org.jetbrains.kotlin'    | 'kotlin-scripting-jsr223'
     }
 
-    void 'verify micronaut-console configuration'() {
+    void 'verify agorapulse-micronaut-console configuration'() {
         when:
-            GeneratorContext commandContext = buildGeneratorContext(['micronaut-console'])
+            GeneratorContext commandContext = buildGeneratorContext(['agorapulse-micronaut-console'])
             int expectedLength = UUID.randomUUID().toString().length()
         then:
             commandContext.configuration.get('console.enabled') == true

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/gru/GruHttpSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/gru/GruHttpSpec.groovy
@@ -13,7 +13,7 @@ class GruHttpSpec extends ApplicationContextSpec {
         List<ApplicationType> supportedApplicationTypes = [ApplicationType.DEFAULT]
 
         when:
-        Optional<Feature> featureOptional = findFeatureByName('gru-http')
+        Optional<Feature> featureOptional = findFeatureByName('agorapulse-gru-http')
 
         then:
         featureOptional.isPresent()
@@ -39,12 +39,12 @@ class GruHttpSpec extends ApplicationContextSpec {
         }
     }
 
-    @Unroll("#buildTool with feature gru-http adds dependency for #buildTool")
-    void "verify gru-http feature dependencies"(BuildTool buildTool) {
+    @Unroll("#buildTool with feature agorapulse-gru-http adds dependency for #buildTool")
+    void "verify agorapulse-gru-http feature dependencies"(BuildTool buildTool) {
         given:
         String groupId = 'com.agorapulse'
         String artifactId = 'gru-micronaut'
-        List<String> features = ['gru-http']
+        List<String> features = ['agorapulse-gru-http']
         String coordinate = "${groupId}:${artifactId}"
 
         when:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/worker/WorkerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/worker/WorkerSpec.groovy
@@ -15,7 +15,7 @@ class WorkerSpec extends ApplicationContextSpec {
         List<ApplicationType> supportedApplicationTypes = [ApplicationType.DEFAULT]
 
         when:
-        Optional<Feature> featureOptional = findFeatureByName('micronaut-worker')
+        Optional<Feature> featureOptional = findFeatureByName('agorapulse-micronaut-worker')
 
         then:
         featureOptional.present
@@ -41,10 +41,10 @@ class WorkerSpec extends ApplicationContextSpec {
         }
     }
 
-    @Unroll("#buildTool with feature micronaut-worker adds dependency #groupId:#artifactId for #language")
-    void "verify micronaut-worker feature dependencies"(Language language, BuildTool buildTool, String groupId, String artifactId) {
+    @Unroll("#buildTool with feature agorapulse-micronaut-worker adds dependency #groupId:#artifactId for #language")
+    void "verify agorapulse-micronaut-worker feature dependencies"(Language language, BuildTool buildTool, String groupId, String artifactId) {
         given:
-        List<String> features = ['micronaut-worker']
+        List<String> features = ['agorapulse-micronaut-worker']
         String coordinate = "${groupId}:${artifactId}"
 
         when:
@@ -62,16 +62,18 @@ class WorkerSpec extends ApplicationContextSpec {
         }
 
         where:
-        language        | buildTool                 | groupId                   | artifactId
-        Language.JAVA   | BuildTool.GRADLE          | 'com.agorapulse'          | 'micronaut-worker'
-        Language.JAVA   | BuildTool.GRADLE_KOTLIN   | 'com.agorapulse'          | 'micronaut-worker'
-        Language.JAVA   | BuildTool.MAVEN           | 'com.agorapulse'          | 'micronaut-worker'
-        Language.GROOVY | BuildTool.GRADLE          | 'com.agorapulse'          | 'micronaut-worker'
-        Language.GROOVY | BuildTool.GRADLE_KOTLIN   | 'com.agorapulse'          | 'micronaut-worker'
-        Language.GROOVY | BuildTool.MAVEN           | 'com.agorapulse'          | 'micronaut-worker'
-        Language.KOTLIN | BuildTool.GRADLE          | 'com.agorapulse'          | 'micronaut-worker'
-        Language.KOTLIN | BuildTool.GRADLE_KOTLIN   | 'com.agorapulse'          | 'micronaut-worker'
-        Language.KOTLIN | BuildTool.MAVEN           | 'com.agorapulse'          | 'micronaut-worker'
+        language        | buildTool
+        Language.JAVA   | BuildTool.GRADLE
+        Language.JAVA   | BuildTool.GRADLE_KOTLIN
+        Language.JAVA   | BuildTool.MAVEN
+        Language.GROOVY | BuildTool.GRADLE
+        Language.GROOVY | BuildTool.GRADLE_KOTLIN
+        Language.GROOVY | BuildTool.MAVEN
+        Language.KOTLIN | BuildTool.GRADLE
+        Language.KOTLIN | BuildTool.GRADLE_KOTLIN
+        Language.KOTLIN | BuildTool.MAVEN
+        groupId = 'com.agorapulse'
+        artifactId = 'micronaut-worker'
     }
 
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/CamundaExternalWorkerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/CamundaExternalWorkerSpec.groovy
@@ -25,9 +25,9 @@ import spock.lang.Unroll
 
 class CamundaExternalWorkerSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
-    void 'test readme.md with feature camunda-external-worker contains links to micronaut docs'() {
+    void 'test readme.md with feature novatec-camunda-external-worker contains links to micronaut docs'() {
         when:
-        def output = generate(['camunda-external-worker'])
+        def output = generate(['novatec-camunda-external-worker'])
         def readme = output["README.md"]
 
         then:
@@ -36,11 +36,11 @@ class CamundaExternalWorkerSpec extends ApplicationContextSpec implements Comman
     }
 
     @Unroll
-    void 'test gradle camunda-external-worker feature for language=#language'() {
+    void 'test gradle novatec-camunda-external-worker feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
                 .language(language)
-                .features(['camunda-external-worker'])
+                .features(['novatec-camunda-external-worker'])
                 .render()
 
         then:
@@ -51,11 +51,11 @@ class CamundaExternalWorkerSpec extends ApplicationContextSpec implements Comman
     }
 
     @Unroll
-    void 'test maven camunda-external-worker feature for language=#language'() {
+    void 'test maven novatec-camunda-external-worker feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .language(language)
-                .features(['camunda-external-worker'])
+                .features(['novatec-camunda-external-worker'])
                 .render()
 
         then:
@@ -68,9 +68,9 @@ class CamundaExternalWorkerSpec extends ApplicationContextSpec implements Comman
         language << Language.values().toList()
     }
 
-    void 'test camunda-external-worker configuration'() {
+    void 'test novatec-camunda-external-worker configuration'() {
         when:
-        GeneratorContext commandContext = buildGeneratorContext(['camunda-external-worker'])
+        GeneratorContext commandContext = buildGeneratorContext(['novatec-camunda-external-worker'])
 
         then:
         commandContext.configuration.get('camunda.external-client.base-url'.toString()) == "http://localhost:8080/engine-rest"

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/CamundaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/CamundaSpec.groovy
@@ -24,9 +24,9 @@ import spock.lang.Unroll
 
 class CamundaSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
-    void 'test readme.md with feature camunda contains links to micronaut docs'() {
+    void 'test readme.md with feature novatec-camunda contains links to micronaut docs'() {
         when:
-        def output = generate(['camunda'])
+        def output = generate(['novatec-camunda'])
         def readme = output["README.md"]
 
         then:
@@ -36,11 +36,11 @@ class CamundaSpec extends ApplicationContextSpec implements CommandOutputFixture
     }
 
     @Unroll
-    void 'test gradle camunda feature for language=#language'() {
+    void 'test gradle novatec-camunda feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
                 .language(language)
-                .features(['camunda'])
+                .features(['novatec-camunda'])
                 .render()
 
         then:
@@ -54,11 +54,11 @@ class CamundaSpec extends ApplicationContextSpec implements CommandOutputFixture
     }
 
     @Unroll
-    void 'test maven camunda feature for language=#language'() {
+    void 'test maven novatec-camunda feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .language(language)
-                .features(['camunda'])
+                .features(['novatec-camunda'])
                 .render()
 
         then:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/ZeebeSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/ZeebeSpec.groovy
@@ -24,9 +24,9 @@ import spock.lang.Unroll
 
 class ZeebeSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
-    void 'test readme.md with feature zeebe contains links to micronaut docs'() {
+    void 'test readme.md with feature novatec-zeebe contains links to micronaut docs'() {
         when:
-        def output = generate(['zeebe'])
+        def output = generate(['novatec-zeebe'])
         def readme = output["README.md"]
 
         then:
@@ -35,11 +35,11 @@ class ZeebeSpec extends ApplicationContextSpec implements CommandOutputFixture {
     }
 
     @Unroll
-    void 'test gradle zeebe feature for language=#language'() {
+    void 'test gradle novatec-zeebe feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
                 .language(language)
-                .features(['zeebe'])
+                .features(['novatec-zeebe'])
                 .render()
 
         then:
@@ -50,11 +50,11 @@ class ZeebeSpec extends ApplicationContextSpec implements CommandOutputFixture {
     }
 
     @Unroll
-    void 'test maven zeebe feature for language=#language'() {
+    void 'test maven novatec-zeebe feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .language(language)
-                .features(['zeebe'])
+                .features(['novatec-zeebe'])
                 .render()
 
         then:

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/console/ConsoleSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/console/ConsoleSpec.groovy
@@ -12,13 +12,13 @@ class ConsoleSpec extends CommandSpec {
 
     @Override
     String getTempDirectoryPrefix() {
-        return "micronaut-console"
+        return "agorapulse-micronaut-console"
     }
 
     @Unroll
-    void "test maven micronaut-console with #language and #testFramework"(Language language, TestFramework testFramework) {
+    void "test maven agorapulse-micronaut-console with #language and #testFramework"(Language language, TestFramework testFramework) {
         when:
-        generateProject(language, BuildTool.MAVEN, ["micronaut-console"], ApplicationType.DEFAULT, testFramework)
+        generateProject(language, BuildTool.MAVEN, ["agorapulse-micronaut-console"], ApplicationType.DEFAULT, testFramework)
         String output = executeMaven("compile test")
 
         then:
@@ -32,9 +32,9 @@ class ConsoleSpec extends CommandSpec {
     }
 
     @Unroll
-    void "test gradle micronaut-console with #language and #testFramework"(BuildTool buildTool, Language language, TestFramework testFramework) {
+    void "test gradle agorapulse-micronaut-console with #language and #testFramework"(BuildTool buildTool, Language language, TestFramework testFramework) {
         when:
-        generateProject(language, buildTool, ["micronaut-console"], ApplicationType.DEFAULT, testFramework)
+        generateProject(language, buildTool, ["agorapulse-micronaut-console"], ApplicationType.DEFAULT, testFramework)
         BuildResult result = executeGradle("test")
 
         then:

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/gru/GruHttpSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/gru/GruHttpSpec.groovy
@@ -12,13 +12,13 @@ class GruHttpSpec extends CommandSpec {
 
     @Override
     String getTempDirectoryPrefix() {
-        return "gru-http"
+        return "agorapulse-gru-http"
     }
 
     @Unroll
-    void "test maven gru-http with #language and #testFramework"(Language language, TestFramework testFramework) {
+    void "test maven agorapulse-gru-http with #language and #testFramework"(Language language, TestFramework testFramework) {
         when:
-        generateProject(language, BuildTool.MAVEN, ["gru-http"], ApplicationType.DEFAULT, testFramework)
+        generateProject(language, BuildTool.MAVEN, ["agorapulse-gru-http"], ApplicationType.DEFAULT, testFramework)
         String output = executeMaven("compile test")
 
         then:
@@ -32,9 +32,9 @@ class GruHttpSpec extends CommandSpec {
     }
 
     @Unroll
-    void "test gradle gru-http with #language and #testFramework"(BuildTool buildTool, Language language, TestFramework testFramework) {
+    void "test gradle agorapulse-gru-http with #language and #testFramework"(BuildTool buildTool, Language language, TestFramework testFramework) {
         when:
-        generateProject(language, buildTool, ["gru-http"], ApplicationType.DEFAULT, testFramework)
+        generateProject(language, buildTool, ["agorapulse-gru-http"], ApplicationType.DEFAULT, testFramework)
         BuildResult result = executeGradle("test")
 
         then:

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/worker/WorkerSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/worker/WorkerSpec.groovy
@@ -12,13 +12,13 @@ class WorkerSpec extends CommandSpec {
 
     @Override
     String getTempDirectoryPrefix() {
-        return "micronaut-worker"
+        return "agorapulse-micronaut-worker"
     }
 
     @Unroll
-    void "test maven micronaut-worker with #language and #testFramework"(Language language, TestFramework testFramework) {
+    void "test maven agorapulse-micronaut-worker with #language and #testFramework"(Language language, TestFramework testFramework) {
         when:
-        generateProject(language, BuildTool.MAVEN, ["micronaut-worker"], ApplicationType.DEFAULT, testFramework)
+        generateProject(language, BuildTool.MAVEN, ["agorapulse-micronaut-worker"], ApplicationType.DEFAULT, testFramework)
         String output = executeMaven("compile test")
 
         then:
@@ -32,9 +32,9 @@ class WorkerSpec extends CommandSpec {
     }
 
     @Unroll
-    void "test gradle micronaut-worker with #language and #testFramework"(BuildTool buildTool, Language language, TestFramework testFramework) {
+    void "test gradle agorapulse-micronaut-worker with #language and #testFramework"(BuildTool buildTool, Language language, TestFramework testFramework) {
         when:
-        generateProject(language, buildTool, ["micronaut-worker"], ApplicationType.DEFAULT, testFramework)
+        generateProject(language, buildTool, ["agorapulse-micronaut-worker"], ApplicationType.DEFAULT, testFramework)
         BuildResult result = executeGradle("test")
 
         then:


### PR DESCRIPTION
To differentiate between features contributed by the core development team and community features. Community features use the company or contributor name as a prefix for the name and title.

cc @tobiasschaefer @musketyr