### PR TITLE
Update PostgreSQL to handle changing Micronaut Data R2DBC BOM

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/PostgreSQL.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/PostgreSQL.java
@@ -87,7 +87,7 @@ public class PostgreSQL extends DatabaseDriverFeature {
     public void apply(GeneratorContext generatorContext) {
         if (generatorContext.isFeaturePresent(R2dbc.class)) {
             generatorContext.addDependency(Dependency.builder()
-                    .groupId("io.r2dbc")
+                    .groupId("org.postgresql")
                     .artifactId("r2dbc-postgresql")
                     .runtime());
             if (!generatorContext.isFeaturePresent(MigrationFeature.class)) {


### PR DESCRIPTION
Micronaut Data R2DBC version 3.0.0 [changed the group ID](https://github.com/micronaut-projects/micronaut-r2dbc/pull/253/files#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR32) of the r2dbc-postgresql artifact to org.postgresql.

This will fix Micronaut Starter to do the same thing, otherwise, when running a newly downloaded project, you get an error.