### PR TITLE
fix: don’t add aws-cdk-lib

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
@@ -157,9 +157,6 @@ public class Cdk implements MultiProjectFeature, InfrastructureAsCodeFeature {
         dependencyContext.addDependency(MicronautDependencyUtils.awsDependency()
                 .artifactId("micronaut-aws-cdk")
                 .compile());
-        dependencyContext.addDependency(Dependency.builder()
-                .lookupArtifactId("aws-cdk-lib")
-                .compile());
         dependencyContext.addDependency(bomDependency().test());
         dependencyContext.addDependency(Dependency.builder()
                 .groupId("org.junit.jupiter")

--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -13,11 +13,6 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>aws-cdk-lib</artifactId>
-            <version>2.24.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
             <version>3.11.0</version>


### PR DESCRIPTION
micronaut-aws-cdk has already a transtive dependency