### PR TITLE
Fix maven build for Oracle cloud function

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -208,11 +208,11 @@ MavenBuild mavenBuild
 @if (applicationType == ApplicationType.FUNCTION && features.contains("oracle-function")){
             <nativeImageBuildArgs>
               <arg>-H:+StaticExecutableWithDynamicLibC</arg>
-              <arg>-Dfn.handler=${exec.mainClass}::handleRequest</arg>
-              <arg>--initialize-at-build-time=com.example</arg>
+              <arg>-Dfn.handler=${function.entrypoint}</arg>
+              <arg>--initialize-at-build-time=@project.getPackageName()</arg>
             </nativeImageBuildArgs>
             <appArguments>
-              <arg>${exec.mainClass}::handleRequest</arg>
+              <arg>${function.entrypoint}</arg>
             </appArguments>
 }
 @if (features.contains("micronaut-aot")) {
@@ -492,7 +492,7 @@ MavenBuild mavenBuild
           </to>
   @if(applicationType == ApplicationType.FUNCTION && features.contains("oracle-function")){
           <container>
-            <args>${exec.mainClass}::handleRequest</args>
+            <args>${function.entrypoint}</args>
             <mainClass>${exec.mainClass}</mainClass>
           </container>
   }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/oraclefunction/OracleRawFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/oraclefunction/OracleRawFunction.java
@@ -30,6 +30,7 @@ import io.micronaut.starter.feature.function.oraclefunction.template.raw.oracleR
 import io.micronaut.starter.feature.function.oraclefunction.template.raw.oracleRawFunctionKotlinJunit;
 import io.micronaut.starter.feature.function.oraclefunction.template.raw.oracleRawFunctionKotlinKoTest;
 import io.micronaut.starter.feature.logging.SimpleLogging;
+import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.Language;
 import io.micronaut.starter.template.RockerTemplate;
 import jakarta.inject.Singleton;
@@ -37,6 +38,7 @@ import jakarta.inject.Singleton;
 @Singleton
 public class OracleRawFunction extends OracleFunction {
     public static final String FEATURE_NAME_ORACLE_RAW_FUNCTION = "oracle-function";
+
     private final OracleFunction httpFunction;
 
     public OracleRawFunction(SimpleLogging simpleLogging, OracleFunction httpFunction) {
@@ -83,6 +85,14 @@ public class OracleRawFunction extends OracleFunction {
                     generatorContext.addTemplate("function", new RockerTemplate(
                             sourceFile,
                             oracleRawFunctionJava.template(project)));
+            }
+
+            if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
+                generatorContext.getBuildProperties().put(PROPERTY_MICRONAUT_RUNTIME, resolveMicronautRuntime(generatorContext));
+                generatorContext.getBuildProperties().put("jib.docker.tag", "${project.version}");
+                generatorContext.getBuildProperties().put("exec.mainClass", "com.fnproject.fn.runtime.EntryPoint");
+                generatorContext.getBuildProperties().put("jib.docker.image", "[REGION].ocir.io/[TENANCY]/[REPO]/${project.artifactId}");
+                generatorContext.getBuildProperties().put("function.entrypoint", project.getPackageName() + ".Function::handleRequest");
             }
 
             applyTestTemplate(generatorContext, project, "Function");

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/oraclefunction/OracleFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/oraclefunction/OracleFunctionSpec.groovy
@@ -129,6 +129,34 @@ class OracleFunctionSpec extends BeanContextSpec  implements CommandOutputFixtur
         String build = output['pom.xml']
 
         then:
+        build.contains('<micronaut.runtime>oracle_function</micronaut.runtime>')
+        build.contains('<jib.docker.tag>${project.version}</jib.docker.tag>')
+        build.contains('<exec.mainClass>com.fnproject.fn.runtime.EntryPoint</exec.mainClass>')
+        build.contains('<jib.docker.image>[REGION].ocir.io/[TENANCY]/[REPO]/${project.artifactId}</jib.docker.image>')
+        build.contains('<function.entrypoint>example.micronaut.Function::handleRequest</function.entrypoint>')
+        build.contains('''
+          <configuration>
+            <nativeImageBuildArgs>
+              <arg>-H:+StaticExecutableWithDynamicLibC</arg>
+              <arg>-Dfn.handler=${function.entrypoint}</arg>
+              <arg>--initialize-at-build-time=example.micronaut</arg>
+            </nativeImageBuildArgs>
+            <appArguments>
+              <arg>${function.entrypoint}</arg>
+            </appArguments>
+          </configuration>''')
+
+        build.contains('''
+        <configuration>
+          <to>
+            <image>${jib.docker.image}:${jib.docker.tag}</image>
+          </to>
+          <container>
+            <args>${function.entrypoint}</args>
+            <mainClass>${exec.mainClass}</mainClass>
+          </container>
+        </configuration>''')
+
         build.contains('''
     <dependency>
       <groupId>com.fnproject.fn</groupId>


### PR DESCRIPTION
This PR fixes generating the serverless function for oracle cloud:

Changes:

- Added new properties in pom.xml 
- Fixed right values for main class 
- Micronaut runtime is set to oracle_function and now the Micronaut maven plugin can pickup right Dockerfile for building native image container.
- Extended test that verify the change