### PR TITLE
Add Oracle Cloud DevOps CI Workflow

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/DefaultPomDependencyVersionResolver.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/DefaultPomDependencyVersionResolver.java
@@ -18,7 +18,6 @@ package io.micronaut.starter.build.dependencies;
 import io.micronaut.core.annotation.NonNull;
 import jakarta.inject.Singleton;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/OCICiWorkflowFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/OCICiWorkflowFeature.java
@@ -19,6 +19,8 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.ci.workflows.CIWorkflowFeature;
 import io.micronaut.starter.feature.ci.workflows.oci.templates.buildSpec;
+import io.micronaut.starter.feature.ci.workflows.oci.templates.buildSpecGraal;
+import io.micronaut.starter.feature.graalvm.GraalVM;
 import io.micronaut.starter.template.RockerTemplate;
 import io.micronaut.starter.template.Template;
 import jakarta.inject.Singleton;
@@ -28,6 +30,7 @@ public class OCICiWorkflowFeature extends CIWorkflowFeature {
 
     public static final String NAME = "oci-devops-build-ci";
     private static final String WORKFLOW_FILENAME = "build_spec.yml";
+    private static final String GRAALVM_VERSION = "22.1.0";
 
     @NonNull
     @Override
@@ -60,11 +63,20 @@ public class OCICiWorkflowFeature extends CIWorkflowFeature {
     }
 
     private Template workflowRockerTemplate(GeneratorContext generatorContext) {
-        return new RockerTemplate(getWorkflowFileName(generatorContext), buildSpec.template(
-                generatorContext.getProject().getName(),
-                generatorContext.getJdkVersion(),
-                generatorContext.getBuildTool()
-        ));
+        if (!generatorContext.getFeatures().hasFeature(GraalVM.class)) {
+            return new RockerTemplate(getWorkflowFileName(generatorContext), buildSpec.template(
+                    generatorContext.getProject().getName(),
+                    generatorContext.getJdkVersion(),
+                    generatorContext.getBuildTool()
+            ));
+        } else {
+            return new RockerTemplate(getWorkflowFileName(generatorContext), buildSpecGraal.template(
+                    generatorContext.getProject().getName(),
+                    generatorContext.getJdkVersion(),
+                    generatorContext.getBuildTool(),
+                    GRAALVM_VERSION
+            ));
+        }
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/OCICiWorkflowFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/OCICiWorkflowFeature.java
@@ -1,0 +1,59 @@
+package io.micronaut.starter.feature.ci.workflows.oci;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.feature.ci.workflows.CIWorkflowFeature;
+import io.micronaut.starter.feature.ci.workflows.oci.templates.buildSpec;
+import io.micronaut.starter.template.RockerTemplate;
+import io.micronaut.starter.template.Template;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class OCICiWorkflowFeature extends CIWorkflowFeature {
+
+    public static final String NAME = "oci-devops-build-ci";
+    private static final String WORKFLOW_FILENAME = "build_spec.yml";
+
+    @NonNull
+    @Override
+    public String getWorkflowFileName(GeneratorContext generatorContext) {
+        return WORKFLOW_FILENAME;
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Oracle Cloud DevOps Build CI Workflow";
+    }
+
+    @Override
+    @NonNull
+    public String getDescription() {
+        return "Adds a Oracle Cloud DevOps Build Workflow to build a Micronaut application";
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        super.apply(generatorContext);
+
+        generatorContext.addTemplate("buildSpec", workflowRockerTemplate(generatorContext));
+    }
+
+    private Template workflowRockerTemplate(GeneratorContext generatorContext) {
+        return new RockerTemplate(getWorkflowFileName(generatorContext), buildSpec.template(
+                generatorContext.getProject().getName(),
+                generatorContext.getJdkVersion(),
+                generatorContext.getBuildTool()
+        ));
+    }
+
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://docs.oracle.com/en-us/iaas/Content/devops/using/build_specs.htm";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/OCICiWorkflowFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/OCICiWorkflowFeature.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.starter.feature.ci.workflows.oci;
 
 import io.micronaut.core.annotation.NonNull;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/OCICiWorkflowFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/OCICiWorkflowFeature.java
@@ -23,6 +23,7 @@ import io.micronaut.starter.feature.ci.workflows.oci.templates.buildSpecGraal;
 import io.micronaut.starter.feature.graalvm.GraalVM;
 import io.micronaut.starter.template.RockerTemplate;
 import io.micronaut.starter.template.Template;
+import io.micronaut.starter.util.VersionInfo;
 import jakarta.inject.Singleton;
 
 @Singleton
@@ -30,7 +31,6 @@ public class OCICiWorkflowFeature extends CIWorkflowFeature {
 
     public static final String NAME = "oci-devops-build-ci";
     private static final String WORKFLOW_FILENAME = "build_spec.yml";
-    private static final String GRAALVM_VERSION = "22.1.0";
 
     @NonNull
     @Override
@@ -74,7 +74,7 @@ public class OCICiWorkflowFeature extends CIWorkflowFeature {
                     generatorContext.getProject().getName(),
                     generatorContext.getJdkVersion(),
                     generatorContext.getBuildTool(),
-                    GRAALVM_VERSION
+                    VersionInfo.getDependencyVersion("graal").getValue()
             ));
         }
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/templates/buildSpec.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/templates/buildSpec.rocker.raw
@@ -1,0 +1,46 @@
+@import io.micronaut.starter.options.JdkVersion
+@import io.micronaut.starter.options.BuildTool
+
+@args (
+String projectName,
+JdkVersion jdkVersion,
+BuildTool buildTool
+)
+
+version: 0.1
+component: build
+timeoutInSeconds: 1000
+shell: bash
+
+steps:
+  - type: Command
+    name: "Setup JDK"
+    timeoutInSeconds: 40
+    command: |
+      @if (jdkVersion.majorVersion() == 8) {
+      PKG_NAME=java-1.8.0-openjdk
+      } else if(jdkVersion.majorVersion() == 11) {
+      PKG_NAME=java-11-openjdk
+      } else if(jdkVersion.majorVersion() == 17) {
+      PKG_NAME=java-17-openjdk
+      }
+      yum -y install $PKG_NAME
+      JAVA_TO_SELECT=$(alternatives --display java | grep "family $PKG_NAME" | cut -d' ' -f1)
+      alternatives --set java $JAVA_TO_SELECT
+  - type: Command
+    name: "Build an application"
+    command: |
+    @if (buildTool.equals(BuildTool.MAVEN)) {
+      ./mvnw verify
+    } else if (buildTool.isGradle()) {
+      ./gradlew build
+    }
+
+outputArtifacts:
+  - name: jar
+    type: BINARY
+    @if (buildTool.equals(BuildTool.MAVEN)) {
+    location: target/@projectName-0.1.jar
+    } else if (buildTool.isGradle()) {
+    location: build/libs/@projectName-0.1-all.jar
+    }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/templates/buildSpec.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/templates/buildSpec.rocker.raw
@@ -35,6 +35,14 @@ steps:
     } else if (buildTool.isGradle()) {
       ./gradlew build
     }
+  - type: Command
+    name: "Build a docker image"
+    command: |
+    @if (buildTool.equals(BuildTool.MAVEN)) {
+      ./mvnw package -Dpackaging=docker
+    } else if (buildTool.isGradle()) {
+      ./gradlew dockerBuild
+    }
 
 outputArtifacts:
   - name: jar
@@ -44,3 +52,6 @@ outputArtifacts:
     } else if (buildTool.isGradle()) {
     location: build/libs/@projectName-0.1-all.jar
     }
+  - name: build-service-demo
+    type: DOCKER_IMAGE
+    location: @projectName

--- a/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/templates/buildSpecGraal.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/ci/workflows/oci/templates/buildSpecGraal.rocker.raw
@@ -1,0 +1,89 @@
+@import io.micronaut.starter.options.JdkVersion
+@import io.micronaut.starter.options.BuildTool
+
+@args (
+String projectName,
+JdkVersion jdkVersion,
+BuildTool buildTool,
+String graalVmVersion
+)
+
+version: 0.1
+component: build
+timeoutInSeconds: 1000
+shell: bash
+
+inputArtifacts:
+  - name: graalvm
+    type: URL
+    @if (jdkVersion.majorVersion() == 17) {
+    url: https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-@graalVmVersion/graalvm-ce-java17-linux-amd64-@(graalVmVersion).tar.gz
+    } else {
+    url: https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-@graalVmVersion/graalvm-ce-java11-linux-amd64-@(graalVmVersion).tar.gz
+    }
+    location: /workspace/graalvm-ce.tar.gz
+
+steps:
+  - type: Command
+    name: "Setup GraalVM"
+    timeoutInSeconds: 40
+    command: |
+      tar -xzf /workspace/graalvm-ce.tar.gz
+  - type: Command
+    name: "Build an application"
+    command: |
+    @if (jdkVersion.majorVersion() == 17) {
+      JAVA_HOME=$(pwd)/graalvm-ce-java17-@graalVmVersion
+    } else {
+      JAVA_HOME=$(pwd)/graalvm-ce-java11-@graalVmVersion
+    }
+    @if (buildTool.equals(BuildTool.MAVEN)) {
+      ./mvnw verify
+    } else if (buildTool.isGradle()) {
+      ./gradlew build
+    }
+  - type: Command
+    name: "Build a native image"
+    command: |
+    @if (jdkVersion.majorVersion() == 17) {
+      JAVA_HOME=$(pwd)/graalvm-ce-java17-@graalVmVersion
+    } else {
+      JAVA_HOME=$(pwd)/graalvm-ce-java11-@graalVmVersion
+    }
+    @if (buildTool.equals(BuildTool.MAVEN)) {
+      ./mvnw package -Dpackaging=native-image
+    } else if (buildTool.isGradle()) {
+      ./gradlew nativeCompile
+    }
+  - type: Command
+    name: "Build a docker image with native image"
+    command: |
+    @if (jdkVersion.majorVersion() == 17) {
+      JAVA_HOME=$(pwd)/graalvm-ce-java17-@graalVmVersion
+    } else {
+      JAVA_HOME=$(pwd)/graalvm-ce-java11-@graalVmVersion
+    }
+    @if (buildTool.equals(BuildTool.MAVEN)) {
+      ./mvnw package -Dpackaging=docker-native
+    } else if (buildTool.isGradle()) {
+      ./gradlew dockerBuildNative
+    }
+
+outputArtifacts:
+  - name: jar
+    type: BINARY
+    @if (buildTool.equals(BuildTool.MAVEN)) {
+    location: target/@projectName-0.1.jar
+    } else if (buildTool.isGradle()) {
+    location: build/libs/@projectName-0.1-all.jar
+    }
+  - name: build-service-demo
+    type: DOCKER_IMAGE
+    location: @projectName
+  - name: jar
+    type: BINARY
+    @if (buildTool.equals(BuildTool.MAVEN)) {
+    location: target/@projectName
+    } else if (buildTool.isGradle()) {
+    location: build/native/nativeCompile/@projectName
+    }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/ci/workflows/oci/OCIWorkflowCISpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/ci/workflows/oci/OCIWorkflowCISpec.groovy
@@ -1,0 +1,49 @@
+package io.micronaut.starter.feature.ci.workflows.oci
+
+import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
+import spock.lang.Unroll
+
+class OCIWorkflowCISpec extends BeanContextSpec implements CommandOutputFixture {
+
+    @Unroll
+    void 'test oci-devops-build-ci is created for #buildTool and #jdkVersion'(BuildTool buildTool, JdkVersion jdkVersion) {
+        when:
+        def output = generate(ApplicationType.DEFAULT,
+                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, JdkVersion.valueOf(jdkVersion.majorVersion())),
+                [OCICiWorkflowFeature.NAME])
+        def workflow = output["build_spec.yml"]
+
+        then:
+        workflow
+
+        switch (jdkVersion.majorVersion()) {
+            case 8:
+                assert workflow.contains("PKG_NAME=java-1.8.0-openjdk")
+                break
+            case 11:
+                assert workflow.contains("PKG_NAME=java-11-openjdk")
+                break
+            case 17:
+                assert workflow.contains("PKG_NAME=java-17-openjdk")
+                break
+        }
+
+        if (buildTool.isGradle()) {
+            assert workflow.contains("./gradlew build")
+            assert workflow.contains("location: build/libs/foo-0.1-all.jar")
+        } else if (buildTool == BuildTool.MAVEN) {
+            assert workflow.contains("./mvnw verify")
+            assert workflow.contains("location: target/foo-0.1.jar")
+        }
+
+        where:
+        [buildTool, jdkVersion] << [BuildTool.values(), JdkVersion.values()].combinations()
+    }
+}


### PR DESCRIPTION
This PR adds `Oracle Cloud DevOps Build CI Workflow` feature. 

- It adds `build_spec.yml` into the root of the generated project that is required for the Oracle Cloud DevOps Build tool.
- Adds test that verify generated file

Docs that are related: 
- https://docs.oracle.com/en-us/iaas/Content/devops/using/build_specs.htm - file format specification
- https://docs.oracle.com/en-us/iaas/Content/devops/using/devops_iampolicies.htm - how to setup CI