### PR TITLE
Update Camunda projects to versions built with Micronaut 3.5.x

### DIFF
--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -58,24 +58,24 @@
             <version>1.1.0</version>
         </dependency>
         <dependency>
-            <groupId>org.camunda.assert</groupId>
+            <groupId>org.camunda.bpm</groupId>
             <artifactId>camunda-bpm-assert</artifactId>
             <version>7.17.0</version>
         </dependency>
         <dependency>
             <groupId>info.novatec</groupId>
             <artifactId>micronaut-camunda-bpm-feature</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>info.novatec</groupId>
             <artifactId>micronaut-camunda-external-client-feature</artifactId>
-            <version>2.6.0</version>
+            <version>2.7.1</version>
         </dependency>
         <dependency>
             <groupId>info.novatec</groupId>
             <artifactId>micronaut-zeebe-client-feature</artifactId>
-            <version>1.7.0</version>
+            <version>1.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/CamundaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/CamundaSpec.groovy
@@ -46,7 +46,7 @@ class CamundaSpec extends ApplicationContextSpec implements CommandOutputFixture
         then:
         template.count('implementation("info.novatec:micronaut-camunda-bpm-feature:') == 1
         template.count('testImplementation("org.assertj:assertj-core")') == 1
-        template.count('testImplementation("org.camunda.assert:camunda-bpm-assert') == 1
+        template.count('testImplementation("org.camunda.bpm:camunda-bpm-assert') == 1
         template.count('runtimeOnly("com.h2database:h2")') == 1
 
         where:
@@ -69,7 +69,7 @@ class CamundaSpec extends ApplicationContextSpec implements CommandOutputFixture
  ''') == 1
         template.count('''\
     <dependency>
-      <groupId>org.camunda.assert</groupId>
+      <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-bpm-assert</artifactId>
  ''') == 1
         template.count('''\


### PR DESCRIPTION
I'm the lead developer of the Micronaut Camunda Integration Projects (https://github.com/orgs/camunda-community-hub/repositories?q=micronaut).

This PR only effects newly created projects because the camunda modules are not in the BOM. So this new version upgrade only affects new users creating applications with Micronaut Launch.

Please merge this PR. It updates all features to versions built with Micronaut 3.5.2

FYI: @sdelamo 