### PR TITLE
Use url-connection-client for dynamodb and graal

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleDependency.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleDependency.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static io.micronaut.core.util.CollectionUtils.isEmpty;
+
 public class GradleDependency extends DependencyCoordinate {
 
     public static final Comparator<GradleDependency> COMPARATOR = (o1, o2) -> {
@@ -102,7 +104,7 @@ public class GradleDependency extends DependencyCoordinate {
         if (isPom() && isKotlinDSL) {
             snippet += ")";
         }
-        if (getExclusions() != null && !getExclusions().isEmpty()) {
+        if (!isEmpty(getExclusions())) {
             snippet += " {\n";
             final String mapAccessor = isKotlinDSL ? " = " : ": ";
             final StringBuilder exclusionBuilder = new StringBuilder();

--- a/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleDependency.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleDependency.java
@@ -22,7 +22,6 @@ import io.micronaut.starter.build.dependencies.Coordinate;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.DependencyContext;
 import io.micronaut.starter.build.dependencies.DependencyCoordinate;
-
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -104,6 +103,7 @@ public class GradleDependency extends DependencyCoordinate {
         if (isPom() && isKotlinDSL) {
             snippet += ")";
         }
+
         if (isNotEmpty(getExclusions())) {
             snippet += " {\n";
             final String mapAccessor = isKotlinDSL ? " = " : ": ";

--- a/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleDependency.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleDependency.java
@@ -102,6 +102,18 @@ public class GradleDependency extends DependencyCoordinate {
         if (isPom() && isKotlinDSL) {
             snippet += ")";
         }
+        if (getExclusions() != null && !getExclusions().isEmpty()) {
+            snippet += " {\n";
+            final String mapAccessor = isKotlinDSL ? " = " : ": ";
+            final StringBuilder exclusionBuilder = new StringBuilder();
+            for (DependencyCoordinate exclusion : getExclusions()) {
+                exclusionBuilder
+                        .append("      exclude(group").append(mapAccessor).append("\"").append(exclusion.getGroupId())
+                        .append("\", name").append(mapAccessor).append("\"").append(exclusion.getArtifactId()).append("\")\n");
+            }
+            snippet += exclusionBuilder.toString();
+            snippet += "    }";
+        }
         return snippet;
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleDependency.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleDependency.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static io.micronaut.core.util.CollectionUtils.isEmpty;
+import static io.micronaut.core.util.CollectionUtils.isNotEmpty;
 
 public class GradleDependency extends DependencyCoordinate {
 
@@ -104,7 +104,7 @@ public class GradleDependency extends DependencyCoordinate {
         if (isPom() && isKotlinDSL) {
             snippet += ")";
         }
-        if (!isEmpty(getExclusions())) {
+        if (isNotEmpty(getExclusions())) {
             snippet += " {\n";
             final String mapAccessor = isKotlinDSL ? " = " : ": ";
             final StringBuilder exclusionBuilder = new StringBuilder();

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsSdkClient.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsSdkClient.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.aws;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.feature.graalvm.GraalVM;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.micronaut.starter.feature.aws.AwsV2Sdk.APACHE_CLIENT_DEPENDENCY;
+import static io.micronaut.starter.feature.aws.AwsV2Sdk.URL_CONNECTION_CLIENT;
+import static io.micronaut.starter.feature.aws.AwsV2Sdk.NETTY_NIO_CLIENT_DEPENDENCY;
+
+public enum AwsSdkClient {
+    APACHE(APACHE_CLIENT_DEPENDENCY),
+    URL_CONNECTION(URL_CONNECTION_CLIENT),
+    NETTY_IO(NETTY_NIO_CLIENT_DEPENDENCY);
+
+    private final Dependency.Builder dependency;
+
+    AwsSdkClient(Dependency.Builder dependency) {
+        this.dependency = dependency;
+    }
+
+    @NonNull
+    public Dependency.Builder getDependency() {
+        return dependency;
+    }
+
+    @NonNull
+    public static List<Dependency> dependencies(@NonNull GeneratorContext generatorContext,
+                                                @NonNull Dependency.Builder awsSdkDependency,
+                                                @NonNull AwsSdkClient clientIfGraalVM) {
+        List<Dependency> result = new ArrayList<>();
+        if (generatorContext.isFeaturePresent(GraalVM.class)) {
+            for (AwsSdkClient v : AwsSdkClient.values()) {
+                if (v != clientIfGraalVM) {
+                    awsSdkDependency.exclude(v.dependency.build());
+                }
+            }
+            result.add(clientIfGraalVM.getDependency().build());
+        }
+        result.add(awsSdkDependency.build());
+        return result;
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsSdkDependenciesUtils.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsSdkDependenciesUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.aws;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.feature.graalvm.GraalVM;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class to decoracte AWS SDK dependencies with extra HTTP Client dependendies and exclusions.
+ */
+public class AwsSdkDependenciesUtils {
+    @NonNull
+    public static List<Dependency> dependencies(@NonNull GeneratorContext generatorContext,
+                                                @NonNull Dependency.Builder awsSdkDependency) {
+        return dependencies(generatorContext, awsSdkDependency, AwsSdkClient.URL_CONNECTION);
+    }
+
+    @NonNull
+    public static List<Dependency> dependencies(@NonNull GeneratorContext generatorContext,
+                                                @NonNull Dependency.Builder awsSdkDependency,
+                                                @NonNull AwsSdkClient clientIfGraalVM) {
+        List<Dependency> result = new ArrayList<>();
+        if (generatorContext.isFeaturePresent(GraalVM.class)) {
+            for (AwsSdkClient v : AwsSdkClient.values()) {
+                if (v != clientIfGraalVM) {
+                    awsSdkDependency.exclude(v.getDependency().build());
+                }
+            }
+            result.add(clientIfGraalVM.getDependency().build());
+        }
+        result.add(awsSdkDependency.build());
+        return result;
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsV2Sdk.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsV2Sdk.java
@@ -31,16 +31,14 @@ public class AwsV2Sdk implements AwsFeature {
             .groupId(GROUP_ID_AWS_SDK_V2)
             .artifactId("url-connection-client")
             .compile();
-    static final Dependency APACHE_CLIENT_DEPENDENCY = Dependency.builder()
+    static final Dependency.Builder APACHE_CLIENT_DEPENDENCY = Dependency.builder()
             .groupId(GROUP_ID_AWS_SDK_V2)
             .artifactId("apache-client")
-            .compile()
-            .build();
-    static final Dependency NETTY_NIO_CLIENT_DEPENDENCY = Dependency.builder()
+            .compile();
+    static final Dependency.Builder NETTY_NIO_CLIENT_DEPENDENCY = Dependency.builder()
             .groupId(GROUP_ID_AWS_SDK_V2)
             .artifactId("netty-nio-client")
-            .compile()
-            .build();
+            .compile();
 
     @Override
     @NonNull

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsV2Sdk.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsV2Sdk.java
@@ -27,6 +27,20 @@ import jakarta.inject.Singleton;
 public class AwsV2Sdk implements AwsFeature {
 
     public static final String ARTIFACT_ID_MICRONAUT_AWS_SDK_V_2 = "micronaut-aws-sdk-v2";
+    static final Dependency.Builder URL_CONNECTION_CLIENT = Dependency.builder()
+            .groupId(GROUP_ID_AWS_SDK_V2)
+            .artifactId("url-connection-client")
+            .compile();
+    static final Dependency APACHE_CLIENT_DEPENDENCY = Dependency.builder()
+            .groupId(GROUP_ID_AWS_SDK_V2)
+            .artifactId("apache-client")
+            .compile()
+            .build();
+    static final Dependency NETTY_NIO_CLIENT_DEPENDENCY = Dependency.builder()
+            .groupId(GROUP_ID_AWS_SDK_V2)
+            .artifactId("netty-nio-client")
+            .compile()
+            .build();
 
     @Override
     @NonNull

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/DynamoDb.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/DynamoDb.java
@@ -35,11 +35,29 @@ import io.micronaut.starter.feature.aws.template.ciawsregionconditionJava;
 import io.micronaut.starter.feature.aws.template.ciawsregionconditionKotlin;
 import io.micronaut.starter.feature.config.ApplicationConfiguration;
 import io.micronaut.starter.feature.config.Configuration;
+import io.micronaut.starter.feature.graalvm.GraalVM;
 import jakarta.inject.Singleton;
 
 @Singleton
 public class DynamoDb implements AwsFeature {
     public static final String ARTIFACTID_DYNAMODB = "dynamodb";
+
+    private static final Dependency.Builder URL_CONNECTION_CLIENT = Dependency.builder()
+            .groupId(GROUP_ID_AWS_SDK_V2)
+            .artifactId("url-connection-client")
+            .compile();
+    private static final Dependency APACHE_CLIENT_DEPENDENCY = Dependency.builder()
+            .groupId(GROUP_ID_AWS_SDK_V2)
+            .artifactId("apache-client")
+            .compile()
+            .build();
+    private static final Dependency NETTY_NIO_CLIENT_DEPENDENCY = Dependency.builder()
+            .groupId(GROUP_ID_AWS_SDK_V2)
+            .artifactId("netty-nio-client")
+            .compile()
+            .build();
+    public static final String NAME = "dynamodb";
+
     private final AwsV2Sdk awsV2Sdk;
 
     public DynamoDb(AwsV2Sdk awsV2Sdk) {
@@ -55,10 +73,16 @@ public class DynamoDb implements AwsFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.addDependency(Dependency.builder()
+        Dependency.Builder dynamoDbDependency = Dependency.builder()
                 .groupId(GROUP_ID_AWS_SDK_V2)
                 .artifactId(ARTIFACTID_DYNAMODB)
-                .compile());
+                .compile();
+
+        if (generatorContext.isFeaturePresent(GraalVM.class)) {
+            dynamoDbDependency.exclude(APACHE_CLIENT_DEPENDENCY).exclude(NETTY_NIO_CLIENT_DEPENDENCY);
+            generatorContext.addDependency(URL_CONNECTION_CLIENT);
+        }
+        generatorContext.addDependency(dynamoDbDependency);
 
         String repositoryFile = generatorContext.getSourcePath("/{packagePath}/DynamoRepository");
         generatorContext.addTemplate("dynamoRepository", repositoryFile,
@@ -91,7 +115,7 @@ public class DynamoDb implements AwsFeature {
     @Override
     @NonNull
     public String getName() {
-        return "dynamodb";
+        return NAME;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/DynamoDb.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/DynamoDb.java
@@ -38,24 +38,14 @@ import io.micronaut.starter.feature.config.Configuration;
 import io.micronaut.starter.feature.graalvm.GraalVM;
 import jakarta.inject.Singleton;
 
+import static io.micronaut.starter.feature.aws.AwsV2Sdk.APACHE_CLIENT_DEPENDENCY;
+import static io.micronaut.starter.feature.aws.AwsV2Sdk.NETTY_NIO_CLIENT_DEPENDENCY;
+import static io.micronaut.starter.feature.aws.AwsV2Sdk.URL_CONNECTION_CLIENT;
+
 @Singleton
 public class DynamoDb implements AwsFeature {
-    public static final String ARTIFACTID_DYNAMODB = "dynamodb";
 
-    private static final Dependency.Builder URL_CONNECTION_CLIENT = Dependency.builder()
-            .groupId(GROUP_ID_AWS_SDK_V2)
-            .artifactId("url-connection-client")
-            .compile();
-    private static final Dependency APACHE_CLIENT_DEPENDENCY = Dependency.builder()
-            .groupId(GROUP_ID_AWS_SDK_V2)
-            .artifactId("apache-client")
-            .compile()
-            .build();
-    private static final Dependency NETTY_NIO_CLIENT_DEPENDENCY = Dependency.builder()
-            .groupId(GROUP_ID_AWS_SDK_V2)
-            .artifactId("netty-nio-client")
-            .compile()
-            .build();
+    public static final String ARTIFACTID_DYNAMODB = "dynamodb";
     public static final String NAME = "dynamodb";
 
     private final AwsV2Sdk awsV2Sdk;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/DynamoDb.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/DynamoDb.java
@@ -35,12 +35,7 @@ import io.micronaut.starter.feature.aws.template.ciawsregionconditionJava;
 import io.micronaut.starter.feature.aws.template.ciawsregionconditionKotlin;
 import io.micronaut.starter.feature.config.ApplicationConfiguration;
 import io.micronaut.starter.feature.config.Configuration;
-import io.micronaut.starter.feature.graalvm.GraalVM;
 import jakarta.inject.Singleton;
-
-import static io.micronaut.starter.feature.aws.AwsV2Sdk.APACHE_CLIENT_DEPENDENCY;
-import static io.micronaut.starter.feature.aws.AwsV2Sdk.NETTY_NIO_CLIENT_DEPENDENCY;
-import static io.micronaut.starter.feature.aws.AwsV2Sdk.URL_CONNECTION_CLIENT;
 
 @Singleton
 public class DynamoDb implements AwsFeature {
@@ -68,11 +63,8 @@ public class DynamoDb implements AwsFeature {
                 .artifactId(ARTIFACTID_DYNAMODB)
                 .compile();
 
-        if (generatorContext.isFeaturePresent(GraalVM.class)) {
-            dynamoDbDependency.exclude(APACHE_CLIENT_DEPENDENCY).exclude(NETTY_NIO_CLIENT_DEPENDENCY);
-            generatorContext.addDependency(URL_CONNECTION_CLIENT);
-        }
-        generatorContext.addDependency(dynamoDbDependency);
+        AwsSdkDependenciesUtils.dependencies(generatorContext, dynamoDbDependency)
+                .forEach(generatorContext::addDependency);
 
         String repositoryFile = generatorContext.getSourcePath("/{packagePath}/DynamoRepository");
         generatorContext.addTemplate("dynamoRepository", repositoryFile,

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/DynamoDbSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/DynamoDbSpec.groovy
@@ -4,6 +4,7 @@ import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Feature
+import io.micronaut.starter.feature.graalvm.GraalVM
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
@@ -12,7 +13,7 @@ class DynamoDbSpec extends ApplicationContextSpec implements CommandOutputFixtur
 
     void 'test readme.md with feature dynamodb contains links to micronaut docs'() {
         when:
-        def output = generate(['dynamodb'])
+        def output = generate([DynamoDb.NAME])
         def readme = output["README.md"]
 
         then:
@@ -20,11 +21,11 @@ class DynamoDbSpec extends ApplicationContextSpec implements CommandOutputFixtur
         readme.contains("[https://aws.amazon.com/dynamodb/](https://aws.amazon.com/dynamodb/)")
     }
 
-    void 'test gradle dynamodb feature for language=#language'(Language language, BuildTool buildTool) {
+    void 'test #buildTool dynamodb feature for language=#language'(Language language, BuildTool buildTool) {
         when:
-        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+        String template = new BuildBuilder(beanContext, buildTool)
                 .language(language)
-                .features(['dynamodb'])
+                .features([DynamoDb.NAME])
                 .render()
 
         then:
@@ -35,11 +36,30 @@ class DynamoDbSpec extends ApplicationContextSpec implements CommandOutputFixtur
         [language, buildTool] << [Language.values().toList(), [BuildTool.GRADLE, BuildTool.GRADLE_KOTLIN]].combinations()
     }
 
+    void 'test #buildTool dynamodb feature for language=#language with GraalVM'(Language language, BuildTool buildTool) {
+        when:
+        String template = new BuildBuilder(beanContext, buildTool)
+                .language(language)
+                .features([DynamoDb.NAME, GraalVM.FEATURE_NAME_GRAALVM])
+                .render()
+        String mapNotation = buildTool == BuildTool.GRADLE ? ':' : ' ='
+        then:
+        template.contains('implementation("io.micronaut.aws:micronaut-aws-sdk-v2")')
+        template.contains("""    implementation("software.amazon.awssdk:dynamodb") {
+                            |      exclude(group$mapNotation "software.amazon.awssdk", name$mapNotation "apache-client")
+                            |      exclude(group$mapNotation "software.amazon.awssdk", name$mapNotation "netty-nio-client")
+                            |    }""".stripMargin())
+        template.contains('implementation("software.amazon.awssdk:url-connection-client")')
+
+        where:
+        [language, buildTool] << [Language.values().toList() - Language.GROOVY, [BuildTool.GRADLE, BuildTool.GRADLE_KOTLIN]].combinations()
+    }
+
     void 'test maven dynamodb feature for language=#language'(Language language) {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .language(language)
-                .features(['dynamodb'])
+                .features([DynamoDb.NAME])
                 .render()
 
         then:
@@ -61,9 +81,53 @@ class DynamoDbSpec extends ApplicationContextSpec implements CommandOutputFixtur
         language << Language.values().toList()
     }
 
+    void 'test maven dynamodb feature for language=#language with GraalVM'(Language language) {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features([DynamoDb.NAME, GraalVM.FEATURE_NAME_GRAALVM])
+                .render()
+
+        then:
+        template.contains("""
+    <dependency>
+      <groupId>io.micronaut.aws</groupId>
+      <artifactId>micronaut-aws-sdk-v2</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    """)
+        template.contains("""
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>dynamodb</artifactId>
+      <scope>compile</scope>
+      <exclusions>
+          <exclusion>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+          </exclusion>
+        </exclusions>
+    </dependency>
+""")
+        template.contains("""
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>url-connection-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    """)
+
+        where:
+        language << Language.values().toList() - Language.GROOVY
+    }
+
     void "dynamodb feature is in the DATABASE category"() {
         given:
-        String feature = 'dynamodb'
+        String feature = DynamoDb.NAME
 
         when:
         Optional<Feature> featureOptional = findFeatureByName(feature)


### PR DESCRIPTION
The apache client doesn't work with native compilation, so if the user selects
dynamodb and graalvm then we switch to the url-connection one, and exclude the other
from the dependencies

This also fixes exclusions for Gradle which were not previously required

Pushed for 3.5.x incase we do a release of that as mentioned in the team meeting