### PR TITLE
Add Migration datasource if Migration used with HibernateReactive

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DatabaseDriverFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DatabaseDriverFeature.java
@@ -70,9 +70,12 @@ public abstract class DatabaseDriverFeature
     private boolean shouldAddJdbcFeature(FeatureContext featureContext) {
         return !featureContext.isPresent(JdbcFeature.class)
                 && !featureContext.isPresent(R2dbcFeature.class)
-                && !featureContext.isPresent(DataHibernateReactive.class)
-                && !featureContext.isPresent(HibernateReactiveJpa.class)
+                && !hasHibernateReactiveWithoutMigration(featureContext)
                 && jdbcFeature != null;
+    }
+
+    private boolean hasHibernateReactiveWithoutMigration(FeatureContext featureContext) {
+        return featureContext.isPresent(HibernateReactiveFeature.class) && !featureContext.isPresent(MigrationFeature.class);
     }
 
     @Override
@@ -114,6 +117,9 @@ public abstract class DatabaseDriverFeature
         }
         if (generatorContext.getFeatures().hasFeature(DataHibernateReactive.class) || generatorContext.getFeatures().hasFeature(HibernateReactiveJpa.class)) {
             getHibernateReactiveJavaClientDependency().ifPresent(dependencies::add);
+            if (generatorContext.isFeaturePresent(MigrationFeature.class)) {
+                getJavaClientDependency().ifPresent(dependencies::add);
+            }
         } else {
             getJavaClientDependency().ifPresent(dependencies::add);
         }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/HibernateReactiveFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/HibernateReactiveFeature.java
@@ -19,6 +19,8 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.migration.MigrationFeature;
 
+import java.util.Optional;
+
 public abstract class HibernateReactiveFeature extends TestContainersFeature implements JpaFeature {
 
     public static final String JPA_DEFAULT_REACTIVE = "jpa.default.reactive";
@@ -37,9 +39,13 @@ public abstract class HibernateReactiveFeature extends TestContainersFeature imp
                         Hbm2ddlAuto.UPDATE.toString());
 
         generatorContext.getConfiguration().put(JPA_DEFAULT_REACTIVE, true);
-        generatorContext.getConfiguration().put(JPA_DEFAULT_PROPERTIES_HIBERNATE_CONNECTION_URL, dbFeature.getJdbcUrl());
-        generatorContext.getConfiguration().put(JPA_DEFAULT_PROPERTIES_HIBERNATE_CONNECTION_USERNAME, dbFeature.getDefaultUser());
-        generatorContext.getConfiguration().put(JPA_DEFAULT_PROPERTIES_HIBERNATE_CONNECTION_PASSWORD, dbFeature.getDefaultPassword());
+        Optional<MigrationFeature> migrationFeature = generatorContext.getFeatures().getFeature(MigrationFeature.class);
+        generatorContext.getConfiguration().put(JPA_DEFAULT_PROPERTIES_HIBERNATE_CONNECTION_URL,
+                migrationFeature.map(f -> "${datasources.default.url}").orElse(dbFeature.getJdbcUrl()));
+        generatorContext.getConfiguration().put(JPA_DEFAULT_PROPERTIES_HIBERNATE_CONNECTION_USERNAME,
+                migrationFeature.map(f -> "${datasources.default.username}").orElse(dbFeature.getDefaultUser()));
+        generatorContext.getConfiguration().put(JPA_DEFAULT_PROPERTIES_HIBERNATE_CONNECTION_PASSWORD,
+                migrationFeature.map(f -> "${datasources.default.password}").orElse(dbFeature.getDefaultPassword()));
     }
 
     public String getUrlKey() {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/MariaDB.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/MariaDB.java
@@ -25,16 +25,15 @@ import java.util.Optional;
 @Singleton
 public class MariaDB extends MySQLCompatibleFeature {
     public static final String NAME = "mariadb";
+    public static final Dependency.Builder DEPENDENCY_MARIADB_JAVA_CLIENT = Dependency.builder()
+            .groupId("org.mariadb.jdbc")
+            .artifactId("mariadb-java-client")
+            .runtime();
 
     private static final Dependency.Builder DEPENDENCY_R2DBC_MARIADB = Dependency.builder()
             .groupId("org.mariadb")
                     .artifactId("r2dbc-mariadb")
                     .runtime();
-
-    private static final Dependency.Builder DEPENDENCY_MARIADB_JAVA_CLIENT = Dependency.builder()
-            .groupId("org.mariadb.jdbc")
-            .artifactId("mariadb-java-client")
-            .runtime();
 
     public MariaDB(JdbcFeature jdbcFeature, TestContainers testContainers) {
         super(jdbcFeature, testContainers);

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/MySQL.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/MySQL.java
@@ -31,7 +31,7 @@ public class MySQL extends MySQLCompatibleFeature {
                     .artifactId("r2dbc-mysql")
                     .runtime();
 
-    private static final Dependency.Builder DEPENDENCY_MYSQL_CONNECTOR_JAVA = Dependency.builder()
+    public static final Dependency.Builder DEPENDENCY_MYSQL_CONNECTOR_JAVA = Dependency.builder()
             .groupId(NAME)
             .artifactId("mysql-connector-java")
             .runtime();

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/Oracle.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/Oracle.java
@@ -29,6 +29,10 @@ public class Oracle extends DatabaseDriverFeature {
 
     public static final String NAME = "oracle";
     public static final String VERTX_ORACLE_CLIENT = "vertx-oracle-client";
+    public static final Dependency.Builder DEPENDENCY_OJDBC8 = Dependency.builder()
+            .groupId("com.oracle.database.jdbc")
+            .artifactId("ojdbc8")
+            .runtime();
 
     private static final Dependency.Builder DEPENDENCY_ORACLE_R2DBC = Dependency.builder()
             .groupId("com.oracle.database.r2dbc")
@@ -39,11 +43,6 @@ public class Oracle extends DatabaseDriverFeature {
             .groupId(IO_VERTX_DEPENDENCY_GROUP)
             .artifactId(VERTX_ORACLE_CLIENT)
             .compile();
-
-    private static final Dependency.Builder DEPENDENCY_OJDBC8 = Dependency.builder()
-            .groupId("com.oracle.database.jdbc")
-                .artifactId("ojdbc8")
-                .runtime();
 
     public Oracle(JdbcFeature jdbcFeature, TestContainers testContainers) {
         super(jdbcFeature, testContainers);

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/PostgreSQL.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/PostgreSQL.java
@@ -30,15 +30,15 @@ public class PostgreSQL extends DatabaseDriverFeature {
     public static final String NAME = "postgres";
 
     public static final String VERTX_PG_CLIENT = "vertx-pg-client";
+    public static final Dependency.Builder DEPENDENCY_POSTGRESQL = Dependency.builder()
+            .groupId("org.postgresql")
+            .artifactId("postgresql")
+            .runtime();
+
     private static final Dependency.Builder DEPENDENCY_R2DBC_POSTGRESQL = Dependency.builder()
             .groupId("org.postgresql")
             .artifactId("r2dbc-postgresql")
             .runtime();
-
-    private static final Dependency.Builder DEPENDENCY_POSTGRESQL = Dependency.builder()
-            .groupId("org.postgresql")
-                    .artifactId("postgresql")
-                    .runtime();
 
     private static final Dependency.Builder DEPENDENCY_VERTX_PG_CLIENT = Dependency.builder()
             .groupId(IO_VERTX_DEPENDENCY_GROUP)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/SQLServer.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/SQLServer.java
@@ -30,16 +30,15 @@ public class SQLServer extends DatabaseDriverFeature {
     public static final String NAME = "sqlserver";
 
     public static final String VERTX_MSSQL_CLIENT = "vertx-mssql-client";
+    public static final Dependency.Builder DEPENDENCY_MSSQL_JDBC = Dependency.builder()
+            .groupId("com.microsoft.sqlserver")
+            .artifactId("mssql-jdbc")
+            .runtime();
 
     private static final Dependency.Builder DEPENDENCY_VERTX_MSSQL_CLIENT = Dependency.builder()
             .groupId(IO_VERTX_DEPENDENCY_GROUP)
             .artifactId(VERTX_MSSQL_CLIENT)
             .compile();
-
-    private static final Dependency.Builder DEPENDENCY_MSSQL_JDBC = Dependency.builder()
-            .groupId("com.microsoft.sqlserver")
-            .artifactId("mssql-jdbc")
-            .runtime();
 
     private static final Dependency.Builder DEPENDENCY_MSSQL_R2DBC = Dependency.builder()
             .groupId("io.r2dbc")

--- a/starter-core/src/main/java/io/micronaut/starter/feature/migration/Flyway.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/migration/Flyway.java
@@ -25,9 +25,11 @@ import jakarta.inject.Singleton;
 @Singleton
 public class Flyway implements MigrationFeature {
 
+    public static final String NAME = "flyway";
+
     @Override
     public String getName() {
-        return "flyway";
+        return NAME;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/migration/Liquibase.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/migration/Liquibase.java
@@ -22,9 +22,11 @@ import jakarta.inject.Singleton;
 @Singleton
 public class Liquibase implements MigrationFeature {
 
+    public static final String NAME = "liquibase";
+
     @Override
     public String getName() {
-        return "liquibase";
+        return NAME;
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/BaseHibernateReactiveSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/BaseHibernateReactiveSpec.groovy
@@ -1,0 +1,87 @@
+package io.micronaut.starter.feature.database
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.build.dependencies.Dependency
+
+abstract class BaseHibernateReactiveSpec extends ApplicationContextSpec {
+
+    boolean containsDataProcessor(String template) {
+        template.contains('''\
+            <path>
+              <groupId>io.micronaut.data</groupId>
+              <artifactId>micronaut-data-processor</artifactId>
+              <version>${micronaut.data.version}</version>
+            </path>
+''')
+    }
+
+    boolean containsDataHibernateJpa(String template) {
+        template.contains('''\
+    <dependency>
+      <groupId>io.micronaut.data</groupId>
+      <artifactId>micronaut-data-hibernate-jpa</artifactId>
+      <scope>compile</scope>
+    </dependency>
+''')
+    }
+
+    boolean containsDataHibernateReactive(String template) {
+        template.contains('''\
+    <dependency>
+      <groupId>io.micronaut.data</groupId>
+      <artifactId>micronaut-data-hibernate-reactive</artifactId>
+      <scope>compile</scope>
+    </dependency>
+''')
+    }
+
+    boolean containsJdbcDriver(String template, Dependency migrationDriver) {
+        template.contains("""\
+    <dependency>
+      <groupId>$migrationDriver.groupId</groupId>
+      <artifactId>$migrationDriver.artifactId</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+""")
+    }
+
+    boolean containsMigrationLibrary(String template, String migration) {
+        template.contains("""\
+    <dependency>
+      <groupId>io.micronaut.$migration</groupId>
+      <artifactId>micronaut-$migration</artifactId>
+      <scope>compile</scope>
+    </dependency>
+""")
+    }
+
+    boolean containsVertXDriver(String template, String client) {
+        template.contains("""\
+    <dependency>
+      <groupId>$HibernateReactiveFeature.IO_VERTX_DEPENDENCY_GROUP</groupId>
+      <artifactId>$client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+""")
+    }
+
+    boolean contansSqlHibernateReactive(String template) {
+        template.contains('''\
+    <dependency>
+      <groupId>io.micronaut.sql</groupId>
+      <artifactId>micronaut-hibernate-reactive</artifactId>
+      <scope>compile</scope>
+    </dependency>
+''')
+    }
+
+    boolean containsHikariDependency(String template) {
+        template.contains('''\
+    <dependency>
+      <groupId>io.micronaut.sql</groupId>
+      <artifactId>micronaut-jdbc-hikari</artifactId>
+      <scope>compile</scope>
+    </dependency>
+''')
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataHibernateReactiveSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataHibernateReactiveSpec.groovy
@@ -1,10 +1,11 @@
 package io.micronaut.starter.feature.database
 
 import io.micronaut.core.version.SemanticVersion
-import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
+import io.micronaut.starter.feature.migration.Flyway
+import io.micronaut.starter.feature.migration.Liquibase
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
@@ -12,7 +13,7 @@ import spock.lang.Issue
 import spock.lang.Requires
 
 @Requires({ jvm.current.isJava11Compatible() })
-class DataHibernateReactiveSpec extends ApplicationContextSpec {
+class DataHibernateReactiveSpec extends BaseHibernateReactiveSpec {
 
     void "test data jpa reactive requires db"() {
         when:
@@ -37,6 +38,21 @@ class DataHibernateReactiveSpec extends ApplicationContextSpec {
 
         where:
         db << [MySQL.NAME, MariaDB.NAME, PostgreSQL.NAME, Oracle.NAME, SQLServer.NAME]
+    }
+
+    void "test data jpa reactive features with #migration for #db"(String db, String migration) {
+        when:
+        Features features = getFeatures([DataHibernateReactive.NAME, db, migration])
+
+        then:
+        features.contains("data")
+        features.contains(db)
+        features.contains(migration)
+        features.contains("jdbc-hikari")
+        features.contains(DataHibernateReactive.NAME)
+
+        where:
+        [db, migration] << [[MySQL.NAME, MariaDB.NAME, PostgreSQL.NAME, Oracle.NAME, SQLServer.NAME], [Liquibase.NAME, Flyway.NAME]].combinations()
     }
 
     void "data hibernate reactive requires java 11"() {
@@ -95,6 +111,40 @@ class DataHibernateReactiveSpec extends ApplicationContextSpec {
         SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT              | 'mssqlserver'
     }
 
+    void "test dependencies are present for gradle with #db (#client) and #migration"() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .jdkVersion(JdkVersion.JDK_11)
+                .features([DataHibernateReactive.NAME, db, migration])
+                .render()
+
+        then:
+        template.contains('annotationProcessor("io.micronaut.data:micronaut-data-processor")')
+        template.contains('implementation("io.micronaut.data:micronaut-data-hibernate-reactive")')
+        !template.contains('implementation("io.micronaut.sql:micronaut-hibernate-reactive")')
+        template.contains('implementation("io.micronaut.sql:micronaut-jdbc-hikari")')
+        template.contains($/implementation("io.micronaut.$migration:micronaut-$migration")/$)
+        template.contains($/runtimeOnly("$migrationDriver.groupId:$migrationDriver.artifactId")/$)
+        template.contains('runtimeOnly("org.flywaydb:flyway-mysql")') == (migration == Flyway.NAME && db in [MySQL.NAME, MariaDB.NAME])
+        template.contains($/implementation("$HibernateReactiveFeature.IO_VERTX_DEPENDENCY_GROUP:$client")/$)
+
+        template.contains('testImplementation("org.testcontainers:testcontainers")')
+        template.contains($/testImplementation("org.testcontainers:$container")/$)
+
+        where:
+        db              | client                                    | container     | migration      | migrationDriver
+        MySQL.NAME      | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | 'mysql'       | Liquibase.NAME | MySQL.DEPENDENCY_MYSQL_CONNECTOR_JAVA.build()
+        MariaDB.NAME    | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | 'mariadb'     | Liquibase.NAME | MariaDB.DEPENDENCY_MARIADB_JAVA_CLIENT.build()
+        PostgreSQL.NAME | PostgreSQL.VERTX_PG_CLIENT                | 'postgresql'  | Liquibase.NAME | PostgreSQL.DEPENDENCY_POSTGRESQL.build()
+        Oracle.NAME     | Oracle.VERTX_ORACLE_CLIENT                | 'oracle-xe'   | Liquibase.NAME | Oracle.DEPENDENCY_OJDBC8.build()
+        SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT              | 'mssqlserver' | Liquibase.NAME | SQLServer.DEPENDENCY_MSSQL_JDBC.build()
+        MySQL.NAME      | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | 'mysql'       | Flyway.NAME    | MySQL.DEPENDENCY_MYSQL_CONNECTOR_JAVA.build()
+        MariaDB.NAME    | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | 'mariadb'     | Flyway.NAME    | MariaDB.DEPENDENCY_MARIADB_JAVA_CLIENT.build()
+        PostgreSQL.NAME | PostgreSQL.VERTX_PG_CLIENT                | 'postgresql'  | Flyway.NAME    | PostgreSQL.DEPENDENCY_POSTGRESQL.build()
+        Oracle.NAME     | Oracle.VERTX_ORACLE_CLIENT                | 'oracle-xe'   | Flyway.NAME    | Oracle.DEPENDENCY_OJDBC8.build()
+        SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT              | 'mssqlserver' | Flyway.NAME    | SQLServer.DEPENDENCY_MSSQL_JDBC.build()
+    }
+
     void "test kotlin jpa plugin is present for gradle kotlin project"() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
@@ -115,42 +165,12 @@ class DataHibernateReactiveSpec extends ApplicationContextSpec {
                 .render()
 
         then:
-        //src/main
-        template.contains('''\
-            <path>
-              <groupId>io.micronaut.data</groupId>
-              <artifactId>micronaut-data-processor</artifactId>
-              <version>${micronaut.data.version}</version>
-            </path>
-''')
-        !template.contains('''\
-    <dependency>
-      <groupId>io.micronaut.data</groupId>
-      <artifactId>micronaut-data-hibernate-jpa</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''')
-        template.contains('''\
-    <dependency>
-      <groupId>io.micronaut.data</groupId>
-      <artifactId>micronaut-data-hibernate-reactive</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''')
-        !template.contains('''\
-    <dependency>
-      <groupId>io.micronaut.sql</groupId>
-      <artifactId>micronaut-jdbc-hikari</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''')
-        template.contains("""\
-    <dependency>
-      <groupId>$HibernateReactiveFeature.IO_VERTX_DEPENDENCY_GROUP</groupId>
-      <artifactId>$client</artifactId>
-      <scope>compile</scope>
-    </dependency>
-""")
+        containsDataProcessor(template)
+        !containsDataHibernateJpa(template)
+        containsDataHibernateReactive(template)
+        !containsHikariDependency(template)
+        containsVertXDriver(template, client)
+        !containsJdbcDriver(template, migrationDriver)
 
         when:
         Optional<SemanticVersion> semanticVersionOptional = parsePropertySemanticVersion(template, "micronaut.data.version")
@@ -160,12 +180,49 @@ class DataHibernateReactiveSpec extends ApplicationContextSpec {
         semanticVersionOptional.isPresent()
 
         where:
-        db              | client
-        MySQL.NAME      | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT
-        MariaDB.NAME    | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT
-        PostgreSQL.NAME | PostgreSQL.VERTX_PG_CLIENT
-        Oracle.NAME     | Oracle.VERTX_ORACLE_CLIENT
-        SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT
+        db              | client                                    | migrationDriver
+        MySQL.NAME      | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | MySQL.DEPENDENCY_MYSQL_CONNECTOR_JAVA.build()
+        MariaDB.NAME    | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | MariaDB.DEPENDENCY_MARIADB_JAVA_CLIENT.build()
+        PostgreSQL.NAME | PostgreSQL.VERTX_PG_CLIENT                | PostgreSQL.DEPENDENCY_POSTGRESQL.build()
+        Oracle.NAME     | Oracle.VERTX_ORACLE_CLIENT                | Oracle.DEPENDENCY_OJDBC8.build()
+        SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT              | SQLServer.DEPENDENCY_MSSQL_JDBC.build()
+    }
+
+    void "test dependencies are present for maven with #db (#client) and #migration"() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features([DataHibernateReactive.NAME, db, migration])
+                .jdkVersion(JdkVersion.JDK_11)
+                .render()
+
+        then:
+        containsDataProcessor(template)
+        !containsDataHibernateJpa(template)
+        containsDataHibernateReactive(template)
+        containsHikariDependency(template)
+        containsVertXDriver(template, client)
+        containsMigrationLibrary(template, migration)
+        containsJdbcDriver(template, migrationDriver)
+
+        when:
+        Optional<SemanticVersion> semanticVersionOptional = parsePropertySemanticVersion(template, "micronaut.data.version")
+
+        then:
+        noExceptionThrown()
+        semanticVersionOptional.isPresent()
+
+        where:
+        db              | client                                    | migration      | migrationDriver
+        MySQL.NAME      | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | Liquibase.NAME | MySQL.DEPENDENCY_MYSQL_CONNECTOR_JAVA.build()
+        MariaDB.NAME    | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | Liquibase.NAME | MariaDB.DEPENDENCY_MARIADB_JAVA_CLIENT.build()
+        PostgreSQL.NAME | PostgreSQL.VERTX_PG_CLIENT                | Liquibase.NAME | PostgreSQL.DEPENDENCY_POSTGRESQL.build()
+        Oracle.NAME     | Oracle.VERTX_ORACLE_CLIENT                | Liquibase.NAME | Oracle.DEPENDENCY_OJDBC8.build()
+        SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT              | Liquibase.NAME | SQLServer.DEPENDENCY_MSSQL_JDBC.build()
+        MySQL.NAME      | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | Flyway.NAME    | MySQL.DEPENDENCY_MYSQL_CONNECTOR_JAVA.build()
+        MariaDB.NAME    | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | Flyway.NAME    | MariaDB.DEPENDENCY_MARIADB_JAVA_CLIENT.build()
+        PostgreSQL.NAME | PostgreSQL.VERTX_PG_CLIENT                | Flyway.NAME    | PostgreSQL.DEPENDENCY_POSTGRESQL.build()
+        Oracle.NAME     | Oracle.VERTX_ORACLE_CLIENT                | Flyway.NAME    | Oracle.DEPENDENCY_OJDBC8.build()
+        SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT              | Flyway.NAME    | SQLServer.DEPENDENCY_MSSQL_JDBC.build()
     }
 
     void "test kotlin jpa plugin is present for maven kotlin project"() {
@@ -210,6 +267,37 @@ class DataHibernateReactiveSpec extends ApplicationContextSpec {
         PostgreSQL.NAME | 'postgresql'
         Oracle.NAME     | 'oracle'
         SQLServer.NAME  | 'sqlserver'
+    }
+
+    void "test config for #db with #migration"() {
+        when:
+        GeneratorContext ctx = buildGeneratorContext([DataHibernateReactive.NAME, db, migration])
+
+        then:
+        ctx.configuration.containsKey("datasources.default.url")
+        ctx.configuration.containsKey("datasources.default.username")
+        ctx.configuration.containsKey("datasources.default.password")
+        !ctx.configuration.containsKey("datasources.default.dialect")
+        ctx.configuration."jpa.default.reactive" == true
+        with(ctx.configuration."jpa.default.properties.hibernate.connection.url") {
+            it.startsWith("jdbc:")
+            it.contains(jdbcContains)
+        }
+        ctx.configuration.containsKey("jpa.default.properties.hibernate.connection.username")
+        ctx.configuration.containsKey("jpa.default.properties.hibernate.connection.password")
+
+        where:
+        db              | jdbcContains | migration
+        MySQL.NAME      | 'mysql'      | Flyway.NAME
+        MariaDB.NAME    | 'mariadb'    | Flyway.NAME
+        PostgreSQL.NAME | 'postgresql' | Flyway.NAME
+        Oracle.NAME     | 'oracle'     | Flyway.NAME
+        SQLServer.NAME  | 'sqlserver'  | Flyway.NAME
+        MySQL.NAME      | 'mysql'      | Liquibase.NAME
+        MariaDB.NAME    | 'mariadb'    | Liquibase.NAME
+        PostgreSQL.NAME | 'postgresql' | Liquibase.NAME
+        Oracle.NAME     | 'oracle'     | Liquibase.NAME
+        SQLServer.NAME  | 'sqlserver'  | Liquibase.NAME
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-starter/issues/686")

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataHibernateReactiveSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataHibernateReactiveSpec.groovy
@@ -275,16 +275,14 @@ class DataHibernateReactiveSpec extends BaseHibernateReactiveSpec {
 
         then:
         ctx.configuration.containsKey("datasources.default.url")
+        ctx.configuration."datasources.default.url" ==~ "jdbc:$jdbcContains:.*"
         ctx.configuration.containsKey("datasources.default.username")
         ctx.configuration.containsKey("datasources.default.password")
         !ctx.configuration.containsKey("datasources.default.dialect")
         ctx.configuration."jpa.default.reactive" == true
-        with(ctx.configuration."jpa.default.properties.hibernate.connection.url") {
-            it.startsWith("jdbc:")
-            it.contains(jdbcContains)
-        }
-        ctx.configuration.containsKey("jpa.default.properties.hibernate.connection.username")
-        ctx.configuration.containsKey("jpa.default.properties.hibernate.connection.password")
+        ctx.configuration."jpa.default.properties.hibernate.connection.url" == '${datasources.default.url}'
+        ctx.configuration."jpa.default.properties.hibernate.connection.username" == '${datasources.default.username}'
+        ctx.configuration."jpa.default.properties.hibernate.connection.password" == '${datasources.default.password}'
 
         where:
         db              | jdbcContains | migration

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateReactiveJpaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateReactiveJpaSpec.groovy
@@ -1,17 +1,18 @@
 package io.micronaut.starter.feature.database
 
 import io.micronaut.core.version.SemanticVersion
-import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
+import io.micronaut.starter.feature.migration.Flyway
+import io.micronaut.starter.feature.migration.Liquibase
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import spock.lang.Requires
 
 @Requires({ jvm.current.isJava11Compatible() })
-class HibernateReactiveJpaSpec extends ApplicationContextSpec {
+class HibernateReactiveJpaSpec extends BaseHibernateReactiveSpec {
 
     void "test hibernate reactive jpa requires db"() {
         when:
@@ -37,6 +38,22 @@ class HibernateReactiveJpaSpec extends ApplicationContextSpec {
 
         where:
         db << [MySQL.NAME, MariaDB.NAME, PostgreSQL.NAME, Oracle.NAME, SQLServer.NAME]
+    }
+
+    void "test hibernate reactive jpa features for #db with #migration"(String db, String migration) {
+        when:
+        Features features = getFeatures([HibernateReactiveJpa.NAME, db, migration])
+
+        then:
+        !features.contains("data")
+        features.contains(db)
+        features.contains("reactor")
+        features.contains("jdbc-hikari")
+        features.contains(migration)
+        features.contains(HibernateReactiveJpa.NAME)
+
+        where:
+        [db, migration] << [[MySQL.NAME, MariaDB.NAME, PostgreSQL.NAME, Oracle.NAME, SQLServer.NAME], [Liquibase.NAME, Flyway.NAME]].combinations()
     }
 
     void "data hibernate reactive requires java 11"() {
@@ -95,6 +112,39 @@ class HibernateReactiveJpaSpec extends ApplicationContextSpec {
         SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT              | 'mssqlserver'
     }
 
+    void "test dependencies are present for gradle with #db (#client) and #migration"() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features([HibernateReactiveJpa.NAME, db, migration])
+                .jdkVersion(JdkVersion.JDK_11)
+                .render()
+
+        then:
+        !template.contains('annotationProcessor("io.micronaut.data:micronaut-data-processor")')
+        !template.contains('implementation("io.micronaut.data:micronaut-data-hibernate-reactive")')
+        template.contains('implementation("io.micronaut.sql:micronaut-hibernate-reactive")')
+        template.contains('implementation("io.micronaut.sql:micronaut-jdbc-hikari")')
+        template.contains($/implementation("$HibernateReactiveFeature.IO_VERTX_DEPENDENCY_GROUP:$client")/$)
+        template.contains($/runtimeOnly("$migrationDriver.groupId:$migrationDriver.artifactId")/$)
+        template.contains('runtimeOnly("org.flywaydb:flyway-mysql")') == (migration == Flyway.NAME && db in [MySQL.NAME, MariaDB.NAME])
+
+        template.contains('testImplementation("org.testcontainers:testcontainers")')
+        template.contains($/testImplementation("org.testcontainers:$container")/$)
+
+        where:
+        db              | client                                    | container     | migration      | migrationDriver
+        MySQL.NAME      | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | 'mysql'       | Liquibase.NAME | MySQL.DEPENDENCY_MYSQL_CONNECTOR_JAVA.build()
+        MariaDB.NAME    | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | 'mariadb'     | Liquibase.NAME | MariaDB.DEPENDENCY_MARIADB_JAVA_CLIENT.build()
+        PostgreSQL.NAME | PostgreSQL.VERTX_PG_CLIENT                | 'postgresql'  | Liquibase.NAME | PostgreSQL.DEPENDENCY_POSTGRESQL.build()
+        Oracle.NAME     | Oracle.VERTX_ORACLE_CLIENT                | 'oracle-xe'   | Liquibase.NAME | Oracle.DEPENDENCY_OJDBC8.build()
+        SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT              | 'mssqlserver' | Liquibase.NAME | SQLServer.DEPENDENCY_MSSQL_JDBC.build()
+        MySQL.NAME      | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | 'mysql'       | Flyway.NAME    | MySQL.DEPENDENCY_MYSQL_CONNECTOR_JAVA.build()
+        MariaDB.NAME    | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | 'mariadb'     | Flyway.NAME    | MariaDB.DEPENDENCY_MARIADB_JAVA_CLIENT.build()
+        PostgreSQL.NAME | PostgreSQL.VERTX_PG_CLIENT                | 'postgresql'  | Flyway.NAME    | PostgreSQL.DEPENDENCY_POSTGRESQL.build()
+        Oracle.NAME     | Oracle.VERTX_ORACLE_CLIENT                | 'oracle-xe'   | Flyway.NAME    | Oracle.DEPENDENCY_OJDBC8.build()
+        SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT              | 'mssqlserver' | Flyway.NAME    | SQLServer.DEPENDENCY_MSSQL_JDBC.build()
+    }
+
     void "test kotlin jpa plugin is present for gradle kotlin project"() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
@@ -116,48 +166,13 @@ class HibernateReactiveJpaSpec extends ApplicationContextSpec {
 
         then:
         //src/main
-        !template.contains('''\
-            <path>
-              <groupId>io.micronaut.data</groupId>
-              <artifactId>micronaut-data-processor</artifactId>
-              <version>${micronaut.data.version}</version>
-            </path>
-''')
-        !template.contains('''\
-    <dependency>
-      <groupId>io.micronaut.data</groupId>
-      <artifactId>micronaut-data-hibernate-jpa</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''')
-        !template.contains('''\
-    <dependency>
-      <groupId>io.micronaut.data</groupId>
-      <artifactId>micronaut-data-hibernate-reactive</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''')
-        template.contains('''\
-    <dependency>
-      <groupId>io.micronaut.sql</groupId>
-      <artifactId>micronaut-hibernate-reactive</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''')
-        !template.contains('''\
-    <dependency>
-      <groupId>io.micronaut.sql</groupId>
-      <artifactId>micronaut-jdbc-hikari</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''')
-        template.contains("""\
-    <dependency>
-      <groupId>$HibernateReactiveFeature.IO_VERTX_DEPENDENCY_GROUP</groupId>
-      <artifactId>$client</artifactId>
-      <scope>compile</scope>
-    </dependency>
-""")
+        !containsDataProcessor(template)
+        !containsDataHibernateJpa(template)
+        !containsDataHibernateReactive(template)
+        contansSqlHibernateReactive(template)
+        !containsHikariDependency(template)
+        containsVertXDriver(template, client)
+        !containsJdbcDriver(template, migrationDriver)
 
         when:
         Optional<SemanticVersion> semanticVersionOptional = parsePropertySemanticVersion(template, "micronaut.data.version")
@@ -167,12 +182,51 @@ class HibernateReactiveJpaSpec extends ApplicationContextSpec {
         !semanticVersionOptional.isPresent()
 
         where:
-        db              | client
-        MySQL.NAME      | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT
-        MariaDB.NAME    | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT
-        PostgreSQL.NAME | PostgreSQL.VERTX_PG_CLIENT
-        Oracle.NAME     | Oracle.VERTX_ORACLE_CLIENT
-        SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT
+        db              | client                                    | migrationDriver
+        MySQL.NAME      | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | MySQL.DEPENDENCY_MYSQL_CONNECTOR_JAVA.build()
+        MariaDB.NAME    | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | MariaDB.DEPENDENCY_MARIADB_JAVA_CLIENT.build()
+        PostgreSQL.NAME | PostgreSQL.VERTX_PG_CLIENT                | PostgreSQL.DEPENDENCY_POSTGRESQL.build()
+        Oracle.NAME     | Oracle.VERTX_ORACLE_CLIENT                | Oracle.DEPENDENCY_OJDBC8.build()
+        SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT              | SQLServer.DEPENDENCY_MSSQL_JDBC.build()
+    }
+
+    void "test dependencies are present for maven with #db (#client) and #migration"() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features([HibernateReactiveJpa.NAME, db, migration])
+                .jdkVersion(JdkVersion.JDK_11)
+                .render()
+
+        then:
+        //src/main
+        !containsDataProcessor(template)
+        !containsDataHibernateJpa(template)
+        !containsDataHibernateReactive(template)
+        contansSqlHibernateReactive(template)
+        containsHikariDependency(template)
+        containsVertXDriver(template, client)
+        containsMigrationLibrary(template, migration)
+        containsJdbcDriver(template, migrationDriver)
+
+        when:
+        Optional<SemanticVersion> semanticVersionOptional = parsePropertySemanticVersion(template, "micronaut.data.version")
+
+        then:
+        noExceptionThrown()
+        !semanticVersionOptional.isPresent()
+
+        where:
+        db              | client                                    | migration      | migrationDriver
+        MySQL.NAME      | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | Liquibase.NAME | MySQL.DEPENDENCY_MYSQL_CONNECTOR_JAVA.build()
+        MariaDB.NAME    | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | Liquibase.NAME | MariaDB.DEPENDENCY_MARIADB_JAVA_CLIENT.build()
+        PostgreSQL.NAME | PostgreSQL.VERTX_PG_CLIENT                | Liquibase.NAME | PostgreSQL.DEPENDENCY_POSTGRESQL.build()
+        Oracle.NAME     | Oracle.VERTX_ORACLE_CLIENT                | Liquibase.NAME | Oracle.DEPENDENCY_OJDBC8.build()
+        SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT              | Liquibase.NAME | SQLServer.DEPENDENCY_MSSQL_JDBC.build()
+        MySQL.NAME      | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | Flyway.NAME    | MySQL.DEPENDENCY_MYSQL_CONNECTOR_JAVA.build()
+        MariaDB.NAME    | MySQLCompatibleFeature.VERTX_MYSQL_CLIENT | Flyway.NAME    | MariaDB.DEPENDENCY_MARIADB_JAVA_CLIENT.build()
+        PostgreSQL.NAME | PostgreSQL.VERTX_PG_CLIENT                | Flyway.NAME    | PostgreSQL.DEPENDENCY_POSTGRESQL.build()
+        Oracle.NAME     | Oracle.VERTX_ORACLE_CLIENT                | Flyway.NAME    | Oracle.DEPENDENCY_OJDBC8.build()
+        SQLServer.NAME  | SQLServer.VERTX_MSSQL_CLIENT              | Flyway.NAME    | SQLServer.DEPENDENCY_MSSQL_JDBC.build()
     }
 
     void "test kotlin jpa plugin is present for maven kotlin project"() {
@@ -217,5 +271,36 @@ class HibernateReactiveJpaSpec extends ApplicationContextSpec {
         PostgreSQL.NAME | 'postgresql'
         Oracle.NAME     | 'oracle'
         SQLServer.NAME  | 'sqlserver'
+    }
+
+    void "test config for #db with #migration"() {
+        when:
+        GeneratorContext ctx = buildGeneratorContext([HibernateReactiveJpa.NAME, db, migration])
+
+        then:
+        ctx.configuration.containsKey("datasources.default.url")
+        ctx.configuration.containsKey("datasources.default.username")
+        ctx.configuration.containsKey("datasources.default.password")
+        !ctx.configuration.containsKey("datasources.default.dialect")
+        ctx.configuration."jpa.default.reactive" == true
+        with(ctx.configuration."jpa.default.properties.hibernate.connection.url") {
+            it.startsWith("jdbc:")
+            it.contains(jdbcContains)
+        }
+        ctx.configuration.containsKey("jpa.default.properties.hibernate.connection.username")
+        ctx.configuration.containsKey("jpa.default.properties.hibernate.connection.password")
+
+        where:
+        db              | jdbcContains | migration
+        MySQL.NAME      | 'mysql'      | Flyway.NAME
+        MariaDB.NAME    | 'mariadb'    | Flyway.NAME
+        PostgreSQL.NAME | 'postgresql' | Flyway.NAME
+        Oracle.NAME     | 'oracle'     | Flyway.NAME
+        SQLServer.NAME  | 'sqlserver'  | Flyway.NAME
+        MySQL.NAME      | 'mysql'      | Liquibase.NAME
+        MariaDB.NAME    | 'mariadb'    | Liquibase.NAME
+        PostgreSQL.NAME | 'postgresql' | Liquibase.NAME
+        Oracle.NAME     | 'oracle'     | Liquibase.NAME
+        SQLServer.NAME  | 'sqlserver'  | Liquibase.NAME
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateReactiveJpaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateReactiveJpaSpec.groovy
@@ -279,16 +279,14 @@ class HibernateReactiveJpaSpec extends BaseHibernateReactiveSpec {
 
         then:
         ctx.configuration.containsKey("datasources.default.url")
+        ctx.configuration."datasources.default.url" ==~ "jdbc:$jdbcContains:.*"
         ctx.configuration.containsKey("datasources.default.username")
         ctx.configuration.containsKey("datasources.default.password")
         !ctx.configuration.containsKey("datasources.default.dialect")
         ctx.configuration."jpa.default.reactive" == true
-        with(ctx.configuration."jpa.default.properties.hibernate.connection.url") {
-            it.startsWith("jdbc:")
-            it.contains(jdbcContains)
-        }
-        ctx.configuration.containsKey("jpa.default.properties.hibernate.connection.username")
-        ctx.configuration.containsKey("jpa.default.properties.hibernate.connection.password")
+        ctx.configuration."jpa.default.properties.hibernate.connection.url" == '${datasources.default.url}'
+        ctx.configuration."jpa.default.properties.hibernate.connection.username" == '${datasources.default.username}'
+        ctx.configuration."jpa.default.properties.hibernate.connection.password" == '${datasources.default.password}'
 
         where:
         db              | jdbcContains | migration


### PR DESCRIPTION
If we use Hibernate Reactive AND a MigrationFeature, we need to specify a datasource and include the
drivers for the chosen database for the migration to be performed