### PR TITLE
Update scans plugin and try to fix dependabot

### DIFF
--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -10,6 +10,10 @@
             <id>central</id>
             <url>https://repo.maven.apache.org/maven2</url>
         </repository>
+        <repository>
+            <id>gradle-plugins</id>
+            <url>https://plugins.gradle.org/m2</url>
+        </repository>
     </repositories>
     <dependencies>
         <dependency>
@@ -46,7 +50,7 @@
         <dependency>
             <groupId>com.gradle</groupId>
             <artifactId>gradle-enterprise-gradle-plugin</artifactId>
-            <version>3.8.1</version>
+            <version>3.10.3</version>
         </dependency>
         <dependency>
             <groupId>io.micronaut.build.internal</groupId>


### PR DESCRIPTION
Looks like dependabot still isn't seeing the gradle scans plugin.

I've updated it to the latest current version in the POM, and added
the plugin repository to the list of repositories to see if that helps