### PR TITLE
bug: Fix dependency exclusion for Gradle

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleDependency.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleDependency.java
@@ -111,7 +111,7 @@ public class GradleDependency extends DependencyCoordinate {
             for (DependencyCoordinate exclusion : getExclusions()) {
                 exclusionBuilder
                         .append("      exclude(group").append(mapAccessor).append("\"").append(exclusion.getGroupId())
-                        .append("\", name").append(mapAccessor).append("\"").append(exclusion.getArtifactId()).append("\")\n");
+                        .append("\", module").append(mapAccessor).append("\"").append(exclusion.getArtifactId()).append("\")\n");
             }
             snippet += exclusionBuilder.toString();
             snippet += "    }";

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/DynamoDbSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/DynamoDbSpec.groovy
@@ -46,8 +46,8 @@ class DynamoDbSpec extends ApplicationContextSpec implements CommandOutputFixtur
         then:
         template.contains('implementation("io.micronaut.aws:micronaut-aws-sdk-v2")')
         template.contains("""    implementation("software.amazon.awssdk:dynamodb") {
-                            |      exclude(group$mapNotation "software.amazon.awssdk", name$mapNotation "apache-client")
-                            |      exclude(group$mapNotation "software.amazon.awssdk", name$mapNotation "netty-nio-client")
+                            |      exclude(group$mapNotation "software.amazon.awssdk", module$mapNotation "apache-client")
+                            |      exclude(group$mapNotation "software.amazon.awssdk", module$mapNotation "netty-nio-client")
                             |    }""".stripMargin())
         template.contains('implementation("software.amazon.awssdk:url-connection-client")')
 


### PR DESCRIPTION
We used the wrong notation for exclusions in Gradle.

We had exclude(group: xxx, name: yyy) but it should be module instead of name

ie: exclude(group: xxx, module: yyy)

See https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.html\#sec:excluding-transitive-deps

Bug was introduced here https://github.com/micronaut-projects/micronaut-starter/pull/1319 for 3.5.3, and was found when testing https://github.com/micronaut-projects/micronaut-guides/issues/1010

I've tagged this 3.5.4 (and based it off 3.5.x), but in all likelyhood it will be in 3.6.0