### PR TITLE
Add kotlin-maven-noarg dependency to maven plugin if JPA plugin used

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -401,6 +401,13 @@ MavenBuild mavenBuild
             <artifactId>kotlin-maven-allopen</artifactId>
             <version>${kotlinVersion}</version>
           </dependency>
+@if (features.isFeaturePresent(JpaFeature.class)) {
+          <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-maven-noarg</artifactId>
+            <version>${kotlinVersion}</version>
+          </dependency>
+}
         </dependencies>
       </plugin>
       <plugin>


### PR DESCRIPTION
Updating the guide for data reactive hibernate to include a Kotlin example, we found that the
JPA plugin was not getting applied (with the error 'Plugin not found: jpa')

https://github.com/micronaut-projects/micronaut-guides/pull/1048

The fix for this is to include the kotlin-maven-noarg dependency in the dependencies
of kotlin-maven-plugin

Fixes #1362