### PR TITLE
fix: CDKSpec failing as micronaut-parent 3.6.1-SNAPSHOT not found

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/Maven.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/Maven.java
@@ -20,6 +20,7 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.maven.MavenBuild;
 import io.micronaut.starter.build.maven.MavenBuildCreator;
+import io.micronaut.starter.build.maven.MavenRepository;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.build.BuildFeature;
 import io.micronaut.starter.feature.build.gitignore;
@@ -30,11 +31,15 @@ import io.micronaut.starter.template.BinaryTemplate;
 import io.micronaut.starter.template.RockerTemplate;
 import io.micronaut.starter.template.Template;
 import io.micronaut.starter.template.URLTemplate;
+import io.micronaut.starter.util.VersionInfo;
 import jakarta.inject.Singleton;
 import io.micronaut.starter.feature.build.maven.templates.multimodule;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
+
+import static io.micronaut.starter.build.Repository.micronautRepositories;
 
 @Singleton
 public class Maven implements BuildFeature {
@@ -76,7 +81,10 @@ public class Maven implements BuildFeature {
 
         Collection<String> moduleNames = generatorContext.getModuleNames();
         if (moduleNames.size() > 1) {
-            generatorContext.addTemplate("multi-module-pom", new RockerTemplate(Template.ROOT, generatorContext.getBuildTool().getBuildFileName(), multimodule.template(generatorContext.getProject(), moduleNames)));
+            List<MavenRepository> mavenRepositories = VersionInfo.getMicronautVersion().endsWith("-SNAPSHOT") ?
+                    MavenRepository.listOf(micronautRepositories()) :
+                    null;
+            generatorContext.addTemplate("multi-module-pom", new RockerTemplate(Template.ROOT, generatorContext.getBuildTool().getBuildFileName(), multimodule.template(mavenRepositories, generatorContext.getProject(), moduleNames)));
         }
 
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/multimodule.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/multimodule.rocker.raw
@@ -1,7 +1,13 @@
 @import io.micronaut.starter.application.Project
 @import io.micronaut.starter.util.VersionInfo
+@import io.micronaut.starter.template.WritableUtils
+@import io.micronaut.starter.template.Writable
+@import io.micronaut.starter.build.maven.MavenRepository
 @import java.util.Collection
-@args (Project project, Collection<String> moduleNames)
+@import java.util.List
+@import java.util.stream.Collectors
+
+@args (List<MavenRepository> maybeRepositories, Project project, Collection<String> moduleNames)
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -11,7 +17,11 @@
         <artifactId>micronaut-parent</artifactId>
         <version>@VersionInfo.getMicronautVersion()</version>
     </parent>
-
+@if (maybeRepositories != null) {
+    <repositories>
+@WritableUtils.renderWritableList(maybeRepositories.stream().map(Writable.class::cast).collect(Collectors.toList()), 8)
+    </repositories>
+}
     <artifactId>@(project.getName())-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
     <groupId>@project.getPackageName()</groupId>


### PR DESCRIPTION
When we run the CDKSpec against a SNAPSHOT, maven fails to compile as micronaut-parent
cannot be found.

This change checks to see if we are running on a snapshot micronaut version, and if we
are, it renders a <repositories> block in the multimodule POM (this already happens in
the app and infra poms)