### PR TITLE
extract getRepositories methods

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleBuildCreator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleBuildCreator.java
@@ -40,9 +40,17 @@ public class GradleBuildCreator {
                 .map(GradlePlugin.class::cast)
                 .sorted(OrderUtil.COMPARATOR)
                 .collect(Collectors.toList());
-        return new GradleBuild(gradleDsl, GradleDependency.listOf(generatorContext), gradlePlugins,
-                GradleRepository.listOf(generatorContext.getBuildTool().getGradleDsl().orElse(GradleDsl.GROOVY),
-                        repositories));
+        return new GradleBuild(gradleDsl,
+                GradleDependency.listOf(generatorContext),
+                gradlePlugins,
+                getRepositories(generatorContext, repositories));
+    }
+
+    @NonNull
+    protected List<GradleRepository> getRepositories(@NonNull GeneratorContext generatorContext,
+                                                     List<Repository> repositories) {
+        return GradleRepository.listOf(generatorContext.getBuildTool().getGradleDsl()
+                .orElse(GradleDsl.GROOVY), repositories);
     }
 
 }

--- a/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
@@ -108,9 +108,14 @@ public class MavenBuildCreator {
                 dependencies,
                 buildProperties.getProperties(),
                 plugins,
-                MavenRepository.listOf(micronautRepositories()),
+                getRepositories(),
                 combineAttribute,
                 testCombineAttribute,
                 generatorContext.getProfiles());
+    }
+
+    @NonNull
+    protected List<MavenRepository> getRepositories() {
+        return MavenRepository.listOf(micronautRepositories());
     }
 }


### PR DESCRIPTION
This allows to easily override `getRepositories` method to add extra repositories. e.g. `mavenLocal`