### PR TITLE
Bug with keys in otel aws

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/opentelemetry/OpenTelemetryXray.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/opentelemetry/OpenTelemetryXray.java
@@ -76,7 +76,7 @@ public class OpenTelemetryXray extends AbstractOpenTelemetry {
             generatorContext.addDependency(OPEN_TELEMETRY_BOM_ALPHA);
             generatorContext.addDependency(OPEN_TELEMETRY_INSTRUMENTATION_AWS_SDK);
         }
-        generatorContext.getConfiguration().put("otel.traces.propagator", "tracecontext, baggage, xray");
+        generatorContext.getConfiguration().addCommaSeparatedValue("otel.traces.propagator", "tracecontext, baggage, xray");
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/opentelemetry/OpenTelemetryXraySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/opentelemetry/OpenTelemetryXraySpec.groovy
@@ -37,7 +37,7 @@ class OpenTelemetryXraySpec extends ApplicationContextSpec implements CommandOut
 
         then:
         ctx.configuration.containsKey('otel.traces.propagator')
-        "tracecontext, baggage, xray" == ctx.configuration.get('otel.traces.propagator')
+        "tracecontext, baggage, xray" == ctx.configuration.otel.traces.propagator
     }
 
     @Unroll


### PR DESCRIPTION
This PR fixes the problem that otel keys are not grouped in `application.yml` file.

Screenshot of an issue:
<img width="1310" alt="Screenshot 2022-08-16 at 12 23 22" src="https://user-images.githubusercontent.com/44323106/185118053-8088ee67-6599-4a6e-ae57-edfb82cabd0b.png">
