### PR TITLE
Update Camunda projects to versions built with Micronaut 3.6.x

### DIFF
--- a/starter-core/src/main/resources/pom.xml
+++ b/starter-core/src/main/resources/pom.xml
@@ -80,17 +80,17 @@
         <dependency>
             <groupId>info.novatec</groupId>
             <artifactId>micronaut-camunda-bpm-feature</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>info.novatec</groupId>
             <artifactId>micronaut-camunda-external-client-feature</artifactId>
-            <version>2.7.1</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>info.novatec</groupId>
             <artifactId>micronaut-zeebe-client-feature</artifactId>
-            <version>1.8.0</version>
+            <version>1.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
I'm the lead developer of the Micronaut Camunda Integration Projects (https://github.com/orgs/camunda-community-hub/repositories?q=micronaut).

I recently created the PR #1380 which got merged into 3.7.x. Would it be possible to merge this PR as well into 3.6.x so that projects created with Micronaut Launch 3.6.x will have the correct Camunda projects releases.

This PR only effects newly created projects because the camunda modules are not in the BOM. So this new version upgrade only affects new users creating applications with Micronaut Launch.

Please merge this PR. It updates all features to versions built with Micronaut 3.6.x

FYI: @sdelamo