### PR TITLE
Add back commons-io to the testClasspath

### DIFF
--- a/test-features/build.gradle
+++ b/test-features/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     testImplementation 'com.google.auth:google-auth-library-oauth2-http:1.6.0'
     testImplementation "com.oracle.oci.sdk:oci-java-sdk-full:1.34.0"
     testImplementation "ch.qos.logback:logback-classic:1.2.11"
+    testImplementation("commons-io:commons-io:2.11.0")
 }
 
 sourceSets {

--- a/test-features/build.gradle
+++ b/test-features/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     testImplementation 'com.google.auth:google-auth-library-oauth2-http:1.6.0'
     testImplementation "com.oracle.oci.sdk:oci-java-sdk-full:1.34.0"
     testImplementation "ch.qos.logback:logback-classic:1.2.11"
-    testImplementation("commons-io:commons-io:2.11.0")
 }
 
 sourceSets {
@@ -26,4 +25,12 @@ sourceSets {
 rocker {
     javaVersion = '1.8'
     postProcessing = ['io.micronaut.starter.rocker.WhitespaceProcessor']
+}
+configurations.all {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'io.micronaut.oraclecloud') {
+            details.useVersion '2.1.5'
+            details.because 'https://github.com/micronaut-projects/micronaut-oracle-cloud/releases/tag/v2.2.0 removes commons-io'
+        }
+    }
 }


### PR DESCRIPTION
I am not sure why this was previously available, trying to work out what changed to stop it being there

Before this,`./gradlew :test-features:compileTestGroovy` on `3.6.x` works
But `./gradlew :test-features:compileTestGroovy` on `3.7.x` fails as:

```
/Users/tim/Code/GitHub/micronaut-projects/micronaut-starter/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/github/workflows/oci/OracleFunctionsWorkflowSpec.groovy: 43: unable to resolve class org.apache.commons.io.IOUtils
 @ line 43, column 1.
   import org.apache.commons.io.IOUtils
```
