### PR TITLE
Add allow-pool-suspension when Crac and Hikari are both selected

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/crac/Crac.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/crac/Crac.java
@@ -22,17 +22,18 @@ import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.build.gradle.GradlePlugin;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.database.jdbc.Hikari;
 import jakarta.inject.Singleton;
 
 @Singleton
 public class Crac implements Feature {
 
-    public static final String FEATURE_NAME_GRAALVM = "crac";
+    public static final String NAME = "crac";
 
     @Override
     @NonNull
     public String getName() {
-        return FEATURE_NAME_GRAALVM;
+        return NAME;
     }
 
     @Override
@@ -79,6 +80,9 @@ public class Crac implements Feature {
                     .id("io.micronaut.crac")
                     .lookupArtifactId("micronaut-crac-plugin")
                     .build());
+        }
+        if (generatorContext.isFeaturePresent(Hikari.class)) {
+            generatorContext.getConfiguration().addNested("datasources.default.allow-pool-suspension", true);
         }
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/jdbc/Hikari.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/jdbc/Hikari.java
@@ -26,13 +26,15 @@ import jakarta.inject.Singleton;
 @Primary
 public class Hikari extends JdbcFeature {
 
+    public static final String NAME = "jdbc-hikari";
+
     public Hikari(DatabaseDriverFeature dbFeature) {
         super(dbFeature);
     }
 
     @Override
     public String getName() {
-        return "jdbc-hikari";
+        return NAME;
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/crac/CracSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/crac/CracSpec.groovy
@@ -4,6 +4,8 @@ import groovy.xml.XmlSlurper
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.application.generator.GeneratorContext
+import io.micronaut.starter.feature.database.jdbc.Hikari
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
@@ -66,5 +68,22 @@ class CracSpec extends ApplicationContextSpec implements CommandOutputFixture {
             scope.text() == 'compile'
             groupId.text() == 'io.micronaut.crac'
         }
+    }
+
+    void "test crac without hikari feature doesn't add configuration"() {
+        when:
+        GeneratorContext ctx = buildGeneratorContext([Crac.NAME])
+
+        then:
+        !ctx.configuration.containsKey("datasources.default.allow-pool-suspension")
+    }
+
+    void "test crac and hikari feature adds configuration"() {
+        when:
+        GeneratorContext ctx = buildGeneratorContext([Crac.NAME, Hikari.NAME])
+
+        then:
+        ctx.configuration.containsKey("datasources.default.allow-pool-suspension")
+        ctx.configuration."datasources.default.allow-pool-suspension" == true
     }
 }


### PR DESCRIPTION
Hikari requires this setting so we can pause it prior to a CRaC checkpoint

This is for 3.8.0 but based off of 3.7.x at the moment until a 3.8.x branch exists

Fixes #1459