### PR TITLE
Don't perform dependency substitutions if test-resources also applied

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/json/SerializationBsonFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/json/SerializationBsonFeature.java
@@ -20,10 +20,12 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.build.dependencies.Substitution;
+import io.micronaut.starter.feature.testresources.TestResources;
 import io.micronaut.starter.util.VersionInfo;
 import jakarta.inject.Singleton;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 @Singleton
@@ -53,6 +55,11 @@ public class SerializationBsonFeature implements SerializationFeature {
     @Override
     @NonNull
     public List<Substitution> substitutions(@NonNull GeneratorContext generatorContext) {
+        // See https://github.com/micronaut-projects/micronaut-test-resources/issues/103
+        if (generatorContext.isFeaturePresent(TestResources.class)) {
+            return Collections.emptyList();
+        }
+
         String serializationVersion = VersionInfo.getBomVersion(MICRONAUT_SERIALIZATION);
         Dependency replacement = MicronautDependencyUtils.serdeDependency()
                 .artifactId(ARTIFACT_ID_MICRONAUT_SERDE_BSON)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/json/SerializationJacksonFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/json/SerializationJacksonFeature.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.build.dependencies.Substitution;
+import io.micronaut.starter.feature.testresources.TestResources;
 import io.micronaut.starter.util.VersionInfo;
 import jakarta.inject.Singleton;
 import java.util.Collections;
@@ -52,6 +53,11 @@ public class SerializationJacksonFeature implements SerializationFeature {
     @Override
     @NonNull
     public List<Substitution> substitutions(@NonNull GeneratorContext generatorContext) {
+        // See https://github.com/micronaut-projects/micronaut-test-resources/issues/103
+        if (generatorContext.isFeaturePresent(TestResources.class)) {
+            return Collections.emptyList();
+        }
+
         String serializationVersion = VersionInfo.getBomVersion(MICRONAUT_SERIALIZATION);
         return Collections.singletonList(Substitution.builder()
                         .target(DEPENDENCY_MICRONAUT_JACKSON_DATABIND)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/json/SerializationJsonpFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/json/SerializationJsonpFeature.java
@@ -20,11 +20,13 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.build.dependencies.Substitution;
+import io.micronaut.starter.feature.testresources.TestResources;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.util.VersionInfo;
 import jakarta.inject.Singleton;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 @Singleton
@@ -66,6 +68,11 @@ public class SerializationJsonpFeature implements SerializationFeature {
     @Override
     @NonNull
     public List<Substitution> substitutions(@NonNull GeneratorContext generatorContext) {
+        // See https://github.com/micronaut-projects/micronaut-test-resources/issues/103
+        if (generatorContext.isFeaturePresent(TestResources.class)) {
+            return Collections.emptyList();
+        }
+
         String serializationVersion = VersionInfo.getBomVersion(MICRONAUT_SERIALIZATION);
         String dataBindVersion = generatorContext.resolveCoordinate("jakarta.json.bind-api").getVersion();
         return Arrays.asList(Substitution.builder()

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/json/JsonFeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/json/JsonFeatureSpec.groovy
@@ -22,36 +22,40 @@ class JsonFeatureSpec extends ApplicationContextSpec {
         'io.micronaut:micronaut-jackson-databind' | 'jackson-databind'
     }
 
-    @Unroll
-    void "test selected JSON feature for Gradle: #feature"(String module,
-                                                           String feature,
-                                                           String substitutiontarget1,
-                                                           String substitutionreplacement1,
-                                                           String substitutiontarget2,
-                                                           String substitutionreplacement2) {
+    void "test selected JSON feature for Gradle: #feature with test-resources #hasTestResources"(String module,
+                                                                                                 String feature,
+                                                                                                 String substitutiontarget1,
+                                                                                                 String substitutionreplacement1,
+                                                                                                 String substitutiontarget2,
+                                                                                                 String substitutionreplacement2) {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .features([feature])
+                .features([feature] + (hasTestResources ? ['test-resources'] : []))
                 .render()
 
         then:
         template.contains("implementation(\"$module")
         template.contains('annotationProcessor("io.micronaut.serde:micronaut-serde-processor")')
-        template.contains('substitute(module("io.micronaut:micronaut-jackson-databind"))')
-        template.contains("substitute(module(\"$substitutiontarget1")
-        template.contains(".using(module(\"$substitutionreplacement1")
+
+        and: "If we do not have test resources included, we should have the substitution"
+        !hasTestResources == template.contains('substitute(module("io.micronaut:micronaut-jackson-databind"))')
+        !hasTestResources == template.contains("substitute(module(\"$substitutiontarget1")
+        !hasTestResources == template.contains(".using(module(\"$substitutionreplacement1")
         if (substitutiontarget2 != null) {
-            assert template.contains("substitute(module(\"$substitutiontarget2")
+            assert !hasTestResources == template.contains("substitute(module(\"$substitutiontarget2")
         }
         if (substitutionreplacement2 != null) {
-            assert template.contains(".using(module(\"$substitutionreplacement2")
+            assert !hasTestResources == template.contains(".using(module(\"$substitutionreplacement2")
         }
 
         where:
-        module                                       | feature                 | substitutiontarget1                       | substitutionreplacement1                     | substitutiontarget2                   | substitutionreplacement2
-        'io.micronaut.serde:micronaut-serde-jackson' | 'serialization-jackson' | 'io.micronaut:micronaut-jackson-databind' | 'io.micronaut.serde:micronaut-serde-jackson' | null                                  | null
-        'io.micronaut.serde:micronaut-serde-jsonp'   | 'serialization-jsonp'   | 'io.micronaut:micronaut-jackson-databind' | 'jakarta.json.bind:jakarta.json.bind-api'    | 'io.micronaut:micronaut-jackson-core' | 'io.micronaut.serde:micronaut-serde-jsonp'
-        'io.micronaut.serde:micronaut-serde-bson'    | 'serialization-bson'    | 'io.micronaut:micronaut-jackson-databind' | 'io.micronaut.serde:micronaut-serde-bson'    | 'io.micronaut:micronaut-jackson-core' | 'io.micronaut.serde:micronaut-serde-bson'
+        module                                       | feature                 | substitutiontarget1                       | substitutionreplacement1                     | substitutiontarget2                   | substitutionreplacement2                   | hasTestResources
+        'io.micronaut.serde:micronaut-serde-jackson' | 'serialization-jackson' | 'io.micronaut:micronaut-jackson-databind' | 'io.micronaut.serde:micronaut-serde-jackson' | null                                  | null                                       | false
+        'io.micronaut.serde:micronaut-serde-jsonp'   | 'serialization-jsonp'   | 'io.micronaut:micronaut-jackson-databind' | 'jakarta.json.bind:jakarta.json.bind-api'    | 'io.micronaut:micronaut-jackson-core' | 'io.micronaut.serde:micronaut-serde-jsonp' | false
+        'io.micronaut.serde:micronaut-serde-bson'    | 'serialization-bson'    | 'io.micronaut:micronaut-jackson-databind' | 'io.micronaut.serde:micronaut-serde-bson'    | 'io.micronaut:micronaut-jackson-core' | 'io.micronaut.serde:micronaut-serde-bson'  | false
+        'io.micronaut.serde:micronaut-serde-jackson' | 'serialization-jackson' | 'io.micronaut:micronaut-jackson-databind' | 'io.micronaut.serde:micronaut-serde-jackson' | null                                  | null                                       | true
+        'io.micronaut.serde:micronaut-serde-jsonp'   | 'serialization-jsonp'   | 'io.micronaut:micronaut-jackson-databind' | 'jakarta.json.bind:jakarta.json.bind-api'    | 'io.micronaut:micronaut-jackson-core' | 'io.micronaut.serde:micronaut-serde-jsonp' | true
+        'io.micronaut.serde:micronaut-serde-bson'    | 'serialization-bson'    | 'io.micronaut:micronaut-jackson-databind' | 'io.micronaut.serde:micronaut-serde-bson'    | 'io.micronaut:micronaut-jackson-core' | 'io.micronaut.serde:micronaut-serde-bson'  | true
     }
 
     @Unroll


### PR DESCRIPTION
If we do the dependency substitutions, then the test-resources server can not currently start up, and the task hangs waiting for success.

For now, we will stop doing the substitution in Gradle if both features are applied as decided in https://github.com/micronaut-projects/micronaut-test-resources/issues/103