### PR TITLE
Fix TestResources and Serde combination in Maven builds

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/json/SerializationFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/json/SerializationFeature.java
@@ -22,6 +22,7 @@ import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.build.dependencies.Substitution;
 import io.micronaut.starter.feature.Category;
+import io.micronaut.starter.feature.testresources.TestResources;
 import io.micronaut.starter.options.BuildTool;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,17 +63,20 @@ public interface SerializationFeature extends JsonFeature {
         dependencyList.add(serdeProcessor());
         dependencyList.add(serdeModule(generatorContext));
         if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
-            dependencyList.add(micronautRuntimeDependency());
+            dependencyList.add(micronautRuntimeDependency(generatorContext));
         }
         return dependencyList;
     }
 
     @NonNull
-    default Dependency.Builder micronautRuntimeDependency() {
-        return MicronautDependencyUtils.coreDependency()
+    default Dependency.Builder micronautRuntimeDependency(@NonNull GeneratorContext generatorContext) {
+        Dependency.Builder runtime = MicronautDependencyUtils.coreDependency()
                 .artifactId("micronaut-runtime")
-                .compile()
-                .exclude(DEPENDENCY_MICRONAUT_JACKSON_DATABIND);
+                .compile();
+        if (!generatorContext.isFeaturePresent(TestResources.class)) {
+            runtime.exclude(DEPENDENCY_MICRONAUT_JACKSON_DATABIND);
+        }
+        return runtime;
     }
 
     @NonNull

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/json/JsonFeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/json/JsonFeatureSpec.groovy
@@ -74,16 +74,26 @@ class JsonFeatureSpec extends ApplicationContextSpec {
     }
 
     @Unroll
-    void "test selected JSON feature for Maven: #feature"(String artifactId, String feature) {
+    void "test selected JSON feature for Maven: #feature with test-resources #hasTestResources"(String artifactId, String feature) {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .features([feature])
+                .features([feature] + (hasTestResources ? ['test-resources'] : []))
                 .render()
 
         then:
         template.contains("<artifactId>$artifactId</artifactId>")
         template.contains('<artifactId>micronaut-serde-processor</artifactId>')
-        template.contains("""\
+
+        and: "runtime is included and doesn't exclude jackson if test-resources is selected"
+        if (hasTestResources) {
+            assert template.contains("""\
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-runtime</artifactId>
+      <scope>compile</scope>
+    </dependency>""")
+        } else {
+            assert template.contains("""\
     <dependency>
       <groupId>io.micronaut</groupId>
       <artifactId>micronaut-runtime</artifactId>
@@ -95,6 +105,7 @@ class JsonFeatureSpec extends ApplicationContextSpec {
           </exclusion>
         </exclusions>
     </dependency>""")
+        }
         template.contains("""
     <dependency>
       <groupId>io.micronaut.serde</groupId>
@@ -109,9 +120,12 @@ class JsonFeatureSpec extends ApplicationContextSpec {
       <artifactId>jakarta.json.bind-api</artifactId>""")
         }
         where:
-        artifactId                | feature
-        'micronaut-serde-jackson' | 'serialization-jackson'
-        'micronaut-serde-jsonp'   | 'serialization-jsonp'
-        'micronaut-serde-bson'    | 'serialization-bson'
+        artifactId                | feature                 | hasTestResources
+        'micronaut-serde-jackson' | 'serialization-jackson' | false
+        'micronaut-serde-jsonp'   | 'serialization-jsonp'   | false
+        'micronaut-serde-bson'    | 'serialization-bson'    | false
+        'micronaut-serde-jackson' | 'serialization-jackson' | true
+        'micronaut-serde-jsonp'   | 'serialization-jsonp'   | true
+        'micronaut-serde-bson'    | 'serialization-bson'    | true
     }
 }


### PR DESCRIPTION
When running Maven builds with Test Resources, if we exclude the jackson library, then the TestResources client fails with:

```
[ERROR] example.micronaut.BookControllerTest  Time elapsed: 0.329 s  <<< ERROR!
java.lang.NoClassDefFoundError: io/micronaut/jackson/databind/JacksonDatabindMapper
	at io.micronaut.http.client.netty.DefaultHttpClient.createDefaultMediaTypeRegistry(DefaultHttpClient.java:1782)
	at io.micronaut.http.client.netty.DefaultHttpClient.<init>(DefaultHttpClient.java:399)
	at io.micronaut.http.client.netty.NettyHttpClientFactory.createNettyClient(NettyHttpClientFactory.java:132)
	at io.micronaut.http.client.netty.NettyHttpClientFactory.createNettyClient(NettyHttpClientFactory.java:121)
	at io.micronaut.http.client.netty.NettyHttpClientFactory.createClient(NettyHttpClientFactory.java:60)
	at io.micronaut.http.client.HttpClient.create(HttpClient.java:258)
	at io.micronaut.testresources.client.TestResourcesClientFactory.configuredAt(TestResourcesClientFactory.java:55)
	at io.micronaut.testresources.client.TestResourcesClientPropertySourceLoader$ClientTestResourcesResolver.lambda$findClient$1(TestResourcesClientPropertySourceLoader.java:65)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at io.micronaut.testresources.client.TestResourcesClientPropertySourceLoader$ClientTestResourcesResolver.findClient(TestResourcesClientPropertySourceLoader.java:65)
	at io.micronaut.testresources.client.TestResourcesClientPropertySourceLoader$ClientTestResourcesResolver.getPropertyEntries(TestResourcesClientPropertySourceLoader.java:48)
	at io.micronaut.testresources.core.LazyTestResourcesPropertySourceLoader$LazyPropertySource.computeKeys(LazyTestResourcesPropertySourceLoader.java:94)
	at io.micronaut.testresources.core.LazyTestResourcesPropertySourceLoader$LazyPropertySource.iterator(LazyTestResourcesPropertySourceLoader.java:86)
	at io.micronaut.context.env.PropertySourcePropertyResolver.processPropertySource(PropertySourcePropertyResolver.java:528)
	at io.micronaut.context.env.DefaultEnvironment.readPropertySources(DefaultEnvironment.java:434)
	at io.micronaut.context.env.DefaultEnvironment.start(DefaultEnvironment.java:270)
	at io.micronaut.context.DefaultApplicationContext$RuntimeConfiguredEnvironment.start(DefaultApplicationContext.java:769)
	at io.micronaut.context.DefaultApplicationContext$RuntimeConfiguredEnvironment.start(DefaultApplicationContext.java:738)
	at io.micronaut.context.DefaultApplicationContext.startEnvironment(DefaultApplicationContext.java:242)
	at io.micronaut.context.DefaultApplicationContext.start(DefaultApplicationContext.java:193)
	at io.micronaut.test.extensions.AbstractMicronautExtension.startApplicationContext(AbstractMicronautExtension.java:433)
	at io.micronaut.test.extensions.AbstractMicronautExtension.beforeClass(AbstractMicronautExtension.java:314)
	at io.micronaut.test.extensions.junit5.MicronautJunit5Extension.beforeAll(MicronautJunit5Extension.java:84)
```

This applies the same fix as with Gradle here for 3.7.2

https://github.com/micronaut-projects/micronaut-starter/pull/1475