### PR TITLE
bug: Use correct serialization annotation in default/function

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/AbstractFunctionFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/AbstractFunctionFeature.java
@@ -24,6 +24,7 @@ import io.micronaut.starter.feature.MicronautRuntimeFeature;
 import io.micronaut.starter.feature.function.template.http.httpFunctionGroovyController;
 import io.micronaut.starter.feature.function.template.http.httpFunctionJavaController;
 import io.micronaut.starter.feature.function.template.http.httpFunctionKotlinController;
+import io.micronaut.starter.feature.json.SerializationFeature;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.DefaultTestRockerModelProvider;
 import io.micronaut.starter.options.Language;
@@ -47,16 +48,16 @@ public abstract class AbstractFunctionFeature implements FunctionFeature, Micron
         generatorContext.getBuildProperties().put(PROPERTY_MICRONAUT_RUNTIME, resolveMicronautRuntime(generatorContext));
     }
 
-    protected RockerModel javaControllerTemplate(Project project) {
-        return httpFunctionJavaController.template(project);
+    protected RockerModel javaControllerTemplate(Project project, boolean useSerde) {
+        return httpFunctionJavaController.template(project, useSerde);
     }
 
-    protected RockerModel kotlinControllerTemplate(Project project) {
-        return httpFunctionKotlinController.template(project);
+    protected RockerModel kotlinControllerTemplate(Project project, boolean useSerde) {
+        return httpFunctionKotlinController.template(project, useSerde);
     }
 
-    protected RockerModel groovyControllerTemplate(Project project) {
-        return httpFunctionGroovyController.template(project);
+    protected RockerModel groovyControllerTemplate(Project project, boolean useSerde) {
+        return httpFunctionGroovyController.template(project, useSerde);
     }
 
     protected void applyFunction(GeneratorContext generatorContext, ApplicationType type) {
@@ -73,22 +74,23 @@ public abstract class AbstractFunctionFeature implements FunctionFeature, Micron
             Language language = generatorContext.getLanguage();
             String sourceFile = generatorContext.getSourcePath("/{packagePath}/" + className + "Controller");
 
+            boolean serdeFeaturePresent = generatorContext.isFeaturePresent(SerializationFeature.class);
             switch (language) {
                 case GROOVY:
                     generatorContext.addTemplate("function", new RockerTemplate(
                             sourceFile,
-                            groovyControllerTemplate(project)));
+                            groovyControllerTemplate(project, serdeFeaturePresent)));
                     break;
                 case KOTLIN:
                     generatorContext.addTemplate("function", new RockerTemplate(
                             sourceFile,
-                            kotlinControllerTemplate(project)));
+                            kotlinControllerTemplate(project, serdeFeaturePresent)));
                     break;
                 case JAVA:
                 default:
                     generatorContext.addTemplate("function", new RockerTemplate(
                             sourceFile,
-                            javaControllerTemplate(project)));
+                            javaControllerTemplate(project, serdeFeaturePresent)));
                     break;
             }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GoogleCloudFunctionFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GoogleCloudFunctionFeatureValidator.java
@@ -18,6 +18,7 @@ package io.micronaut.starter.feature.function.gcp;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.graalvm.GraalVM;
+import io.micronaut.starter.feature.json.SerializationFeature;
 import io.micronaut.starter.feature.validation.FeatureValidator;
 import io.micronaut.starter.options.JdkVersion;
 import io.micronaut.starter.options.Options;
@@ -34,6 +35,9 @@ public class GoogleCloudFunctionFeatureValidator implements FeatureValidator {
             if (features.stream().anyMatch(f -> f instanceof GraalVM)) {
                 throw new IllegalArgumentException("Google Cloud Function is not supported for GraalVM. " +
                     "Consider Google Cloud Run for deploying GraalVM native images as docker containers.");
+            }
+            if (features.stream().anyMatch(SerializationFeature.class::isInstance)) {
+                throw new IllegalArgumentException("Google Cloud Function does not currently support micronaut-serialization.");
             }
         }
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/template/http/httpFunctionGroovyController.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/template/http/httpFunctionGroovyController.rocker.raw
@@ -1,7 +1,8 @@
 @import io.micronaut.starter.application.Project
 
 @args (
-Project project
+Project project,
+boolean useSerde
 )
 
 @if (project.getPackageName() != null) {
@@ -15,7 +16,11 @@ import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Produces
 import io.micronaut.http.MediaType
+@if (useSerde) {
+import io.micronaut.serde.annotation.Serdeable
+} else {
 import io.micronaut.core.annotation.Introspected
+}
 import groovy.transform.TupleConstructor
 
 @@Controller("/@project.getPropertyName()")
@@ -34,12 +39,20 @@ class @project.getClassName()Controller {
 }
 
 @@TupleConstructor
+@if (useSerde) {
+@@Serdeable
+} else {
 @@Introspected
+}
 class SampleInputMessage{
     String name
 }
 
+@if (useSerde) {
+@@Serdeable
+} else {
 @@Introspected
+}
 class SampleReturnMessage{
     String returnMessage
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/template/http/httpFunctionJavaController.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/template/http/httpFunctionJavaController.rocker.raw
@@ -1,7 +1,8 @@
 @import io.micronaut.starter.application.Project
 
 @args (
-Project project
+Project project,
+boolean useSerde
 )
 
 @if (project.getPackageName() != null) {
@@ -12,7 +13,12 @@ package @project.getPackageName();
 import io.micronaut.http.annotation.*;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.MediaType;
+@if (useSerde) {
+import io.micronaut.serde.annotation.Serdeable;
+} else {
 import io.micronaut.core.annotation.Introspected;
+}
+
 
 @@Controller("/@project.getPropertyName()")
 public class @project.getClassName()Controller {
@@ -31,7 +37,11 @@ public class @project.getClassName()Controller {
     }
 }
 
+@if (useSerde) {
+@@Serdeable
+} else {
 @@Introspected
+}
 class SampleInputMessage{
     private String name;
 
@@ -50,7 +60,11 @@ class SampleInputMessage{
     }
 }
 
+@if (useSerde) {
+@@Serdeable
+} else {
 @@Introspected
+}
 class SampleReturnMessage{
     private String returnMessage;
     public String getReturnMessage() {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/template/http/httpFunctionKotlinController.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/template/http/httpFunctionKotlinController.rocker.raw
@@ -1,7 +1,8 @@
 @import io.micronaut.starter.application.Project
 
 @args (
-Project project
+Project project,
+boolean useSerde
 )
 
 @if (project.getPackageName() != null) {
@@ -15,7 +16,12 @@ import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Produces
 import io.micronaut.http.MediaType
+@if (useSerde) {
+import io.micronaut.serde.annotation.Serdeable
+} else {
 import io.micronaut.core.annotation.Introspected
+}
+
 
 @@Controller("/@project.getPropertyName()")
 class @project.getClassName()Controller {
@@ -32,8 +38,16 @@ class @project.getClassName()Controller {
     }
 }
 
+@if (useSerde) {
+@@Serdeable
+} else {
 @@Introspected
+}
 data class SampleInputMessage(val name: String)
 
+@if (useSerde) {
+@@Serdeable
+} else {
 @@Introspected
+}
 data class SampleReturnMessage(val returnMessage: String)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/gcp/GoogleCloudFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/gcp/GoogleCloudFunctionSpec.groovy
@@ -20,9 +20,9 @@ class GoogleCloudFunctionSpec extends BeanContextSpec  implements CommandOutputF
     void 'test readme.md with feature google-cloud-function contains links to docs'() {
         when:
         def output = generate(
-            ApplicationType.DEFAULT,
-            new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
-            ['google-cloud-function']
+                ApplicationType.DEFAULT,
+                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+                ['google-cloud-function']
         )
         def readme = output["README.md"]
 
@@ -150,9 +150,9 @@ class GoogleCloudFunctionSpec extends BeanContextSpec  implements CommandOutputF
     void 'test Google Cloud does not support JDK < 11'() {
         when:
         generate(
-            ApplicationType.DEFAULT,
-            new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, jdkVersion),
-            ['google-cloud-function']
+                ApplicationType.DEFAULT,
+                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, jdkVersion),
+                ['google-cloud-function']
         )
 
         then:
@@ -161,6 +161,22 @@ class GoogleCloudFunctionSpec extends BeanContextSpec  implements CommandOutputF
 
         where:
         jdkVersion << [JdkVersion.JDK_8]
+    }
+
+    void 'test Google Cloud Function with #serialization is unsupported'() {
+        when:
+        generate(
+                ApplicationType.DEFAULT,
+                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+                ['google-cloud-function',serialization]
+        )
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Google Cloud Function does not currently support micronaut-serialization.'
+
+        where:
+        serialization << ['serialization-jackson', 'serialization-bson', 'serialization-jsonp']
     }
 
     void 'test Google Cloud Function with graalvm is unsupported'() {

--- a/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
+++ b/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
@@ -8,7 +8,6 @@ import io.micronaut.starter.test.ApplicationTypeCombinations
 import io.micronaut.starter.test.CommandSpec
 import spock.lang.Requires
 import spock.lang.Retry
-import spock.lang.Unroll
 import spock.util.environment.Jvm
 
 @Retry // can fail on CI due to port binding race condition, so retry
@@ -20,7 +19,6 @@ class CreateAzureFunctionSpec extends CommandSpec {
         "test-azure-function"
     }
 
-    @Unroll
     void 'create-#applicationType with features azure-function #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                 Language lang,
                                                                                                                 BuildTool build,
@@ -37,5 +35,30 @@ class CreateAzureFunctionSpec extends CommandSpec {
 
         where:
         [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.DEFAULT, ApplicationType.FUNCTION], Language.values() as List<Language>, [BuildTool.GRADLE, BuildTool.MAVEN])
+    }
+
+    void 'default application with features azure-function, #serializationFeature, #lang and #build and test framework: #testFramework'(
+            Language lang,
+            String serializationFeature,
+            BuildTool build,
+            TestFramework testFramework
+    ) {
+        given:
+        List<String> features = ['azure-function'] + serializationFeature
+        generateProject(lang, build, features, ApplicationType.DEFAULT, testFramework)
+
+        when:
+        String output = executeBuild(build, "test")
+
+        then:
+        output.contains("BUILD SUCCESS")
+
+        where:
+        [lang, serializationFeature, build, testFramework] << [
+                Language.values(),
+                ['serialization-jackson', 'serialization-bson', 'serialization-jsonp'],
+                [BuildTool.GRADLE, BuildTool.MAVEN],
+                TestFramework.values()
+        ].combinations()
     }
 }

--- a/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleFunctionSpec.groovy
+++ b/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleFunctionSpec.groovy
@@ -16,7 +16,6 @@ class CreateOracleFunctionSpec extends CommandSpec{
         "test-oraclefunction"
     }
 
-    @Unroll
     void 'create-#applicationType with features oracle-function #lang and #build and test framework: #testFramework'(ApplicationType applicationType,
                                                                                                                            Language lang,
                                                                                                                            BuildTool build,
@@ -33,5 +32,30 @@ class CreateOracleFunctionSpec extends CommandSpec{
 
         where:
         [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.DEFAULT], [Language.GROOVY, Language.JAVA, Language.KOTLIN], [BuildTool.GRADLE])
+    }
+
+    void 'default application with features oracle-function, #serializationFeature, #lang and #build and test framework: #testFramework'(
+            Language lang,
+            String serializationFeature,
+            BuildTool build,
+            TestFramework testFramework
+    ) {
+        given:
+        List<String> features = ['oracle-function'] + serializationFeature
+        generateProject(lang, build, features, ApplicationType.DEFAULT, testFramework)
+
+        when:
+        String output = executeBuild(build, "test")
+
+        then:
+        output.contains("BUILD SUCCESS")
+
+        where:
+        [lang, serializationFeature, build, testFramework] << [
+                Language.values(),
+                ['serialization-jackson', 'serialization-bson', 'serialization-jsonp'],
+                BuildTool.values(),
+                TestFramework.values()
+        ].combinations()
     }
 }


### PR DESCRIPTION
If a Micronaut Serialization feature was selected, DEFAULT FUNCTION applications still used `@Introspected` in the generated Controller.

This PR switches to `@Serdeable` if the feature has been added

Whilst writing the tests for this, I discovered that the GCP module does not support micronaut-serialization

Raised https://github.com/micronaut-projects/micronaut-gcp/issues/724 to look into this, and added a feature constraint to prevent it.

Fixes #1492 1492