### PR TITLE
Enable eager initialization of singletons with CRaC

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/RequireEagerSingletonInitializationFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/RequireEagerSingletonInitializationFeature.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature;
+
+public interface RequireEagerSingletonInitializationFeature extends Feature {
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/crac/Crac.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/crac/Crac.java
@@ -21,12 +21,12 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.build.gradle.GradlePlugin;
 import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.RequireEagerSingletonInitializationFeature;
 import io.micronaut.starter.feature.database.jdbc.Hikari;
 import jakarta.inject.Singleton;
 
 @Singleton
-public class Crac implements Feature {
+public class Crac implements RequireEagerSingletonInitializationFeature {
 
     public static final String NAME = "crac";
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/ApplicationRenderingContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/ApplicationRenderingContext.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.lang;
+
+import com.fizzed.rocker.RockerOutput;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+public abstract class ApplicationRenderingContext {
+
+    private final String defaultEnvironment;
+    private final boolean eagerSingletons;
+
+    protected ApplicationRenderingContext(String defaultEnvironment, boolean eagerSingletons) {
+        this.defaultEnvironment = defaultEnvironment;
+        this.eagerSingletons = eagerSingletons;
+    }
+
+    public boolean isRequired() {
+        return defaultEnvironment != null || eagerSingletons;
+    }
+
+    @Nullable
+    public RockerOutput getContextConfigurer() {
+        return isRequired() ? getRendered() : null;
+    }
+
+    @NonNull
+    protected abstract RockerOutput getRendered();
+
+    public boolean isEagerSingletons() {
+        return eagerSingletons;
+    }
+
+    public String getDefaultEnvironment() {
+        return defaultEnvironment;
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplication.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.feature.RequireEagerSingletonInitializationFeature;
 import io.micronaut.starter.feature.database.TransactionalNotSupported;
 import io.micronaut.starter.feature.test.template.groovyJunit;
 import io.micronaut.starter.feature.test.template.koTest;
@@ -68,7 +69,7 @@ public class GroovyApplication implements GroovyApplicationFeature {
 
     protected RockerModel application(GeneratorContext generatorContext) {
         String defaultEnvironment = generatorContext.hasConfigurationEnvironment(Environment.DEVELOPMENT) ? Environment.DEVELOPMENT : null;
-        return application.template(generatorContext.getProject(), generatorContext.getFeatures(), defaultEnvironment);
+        return application.template(generatorContext.getProject(), generatorContext.getFeatures(), defaultEnvironment, generatorContext.getFeatures().isFeaturePresent(RequireEagerSingletonInitializationFeature.class));
     }
 
     protected void addApplication(GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplication.java
@@ -30,7 +30,6 @@ import io.micronaut.starter.options.DefaultTestRockerModelProvider;
 import io.micronaut.starter.options.TestFramework;
 import io.micronaut.starter.options.TestRockerModelProvider;
 import io.micronaut.starter.template.RockerTemplate;
-
 import jakarta.inject.Singleton;
 
 @Singleton
@@ -68,8 +67,17 @@ public class GroovyApplication implements GroovyApplicationFeature {
     }
 
     protected RockerModel application(GeneratorContext generatorContext) {
-        String defaultEnvironment = generatorContext.hasConfigurationEnvironment(Environment.DEVELOPMENT) ? Environment.DEVELOPMENT : null;
-        return application.template(generatorContext.getProject(), generatorContext.getFeatures(), defaultEnvironment, generatorContext.getFeatures().isFeaturePresent(RequireEagerSingletonInitializationFeature.class));
+        String defaultEnvironment = getDefaultEnvironment(generatorContext);
+        boolean eagerInitSingleton = generatorContext.getFeatures().isFeaturePresent(RequireEagerSingletonInitializationFeature.class);
+        return application.template(
+                generatorContext.getProject(),
+                generatorContext.getFeatures(),
+                new GroovyApplicationRenderingContext(defaultEnvironment, eagerInitSingleton)
+        );
+    }
+
+    private static String getDefaultEnvironment(GeneratorContext generatorContext) {
+        return generatorContext.hasConfigurationEnvironment(Environment.DEVELOPMENT) ? Environment.DEVELOPMENT : null;
     }
 
     protected void addApplication(GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplicationRenderingContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplicationRenderingContext.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.lang.groovy;
+
+import com.fizzed.rocker.RockerOutput;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.feature.lang.ApplicationRenderingContext;
+
+public class GroovyApplicationRenderingContext extends ApplicationRenderingContext {
+
+    public GroovyApplicationRenderingContext(String defaultEnvironment, boolean eagerSingletons) {
+        super(defaultEnvironment, eagerSingletons);
+    }
+
+    @NonNull
+    @Override
+    protected RockerOutput getRendered() {
+        return contextConfigurer.template(getDefaultEnvironment(), isEagerSingletons()).render();
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/application.rocker.raw
@@ -1,5 +1,6 @@
 @import io.micronaut.starter.application.Project
 @import io.micronaut.starter.feature.Features
+@import io.micronaut.starter.feature.crac.Crac
 
 @args (Project project, Features features, String defaultEnvironment)
 
@@ -34,11 +35,19 @@ class Application {
     static class DefaultEnvironmentConfigurer implements ApplicationContextConfigurer {
         @@Override
         public void configure(@@NonNull ApplicationContextBuilder builder) {
-            builder.defaultEnvironments("@(defaultEnvironment)");
+            builder.defaultEnvironments("@(defaultEnvironment)")
+@if (features.contains(Crac.NAME)) {
+            builder.eagerInitSingletons(true)
+}
         }
     }
 }
     static void main(String[] args) {
-        Micronaut.run(Application, args)
+        Micronaut.build(args)
+            .mainClass(Application.class)
+@if (features.contains(Crac.NAME)) {
+            .eagerInitSingletons(true)
+}
+            .start()
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/application.rocker.raw
@@ -1,8 +1,7 @@
 @import io.micronaut.starter.application.Project
 @import io.micronaut.starter.feature.Features
-@import io.micronaut.starter.feature.crac.Crac
 
-@args (Project project, Features features, String defaultEnvironment)
+@args (Project project, Features features, String defaultEnvironment, boolean eagerInitSingleton)
 
 package @project.getPackageName()
 
@@ -36,7 +35,7 @@ class Application {
         @@Override
         public void configure(@@NonNull ApplicationContextBuilder builder) {
             builder.defaultEnvironments("@(defaultEnvironment)")
-@if (features.contains(Crac.NAME)) {
+@if (eagerInitSingleton) {
             builder.eagerInitSingletons(true)
 }
         }
@@ -45,7 +44,7 @@ class Application {
     static void main(String[] args) {
         Micronaut.build(args)
             .mainClass(Application.class)
-@if (features.contains(Crac.NAME)) {
+@if (eagerInitSingleton) {
             .eagerInitSingletons(true)
 }
             .start()

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/application.rocker.raw
@@ -1,11 +1,12 @@
 @import io.micronaut.starter.application.Project
 @import io.micronaut.starter.feature.Features
+@import io.micronaut.starter.feature.lang.ApplicationRenderingContext
 
-@args (Project project, Features features, String defaultEnvironment, boolean eagerInitSingleton)
+@args (Project project, Features features, ApplicationRenderingContext context)
 
 package @project.getPackageName()
 
-@if (defaultEnvironment != null) {
+@if (context.isRequired()) {
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.context.ApplicationContextBuilder
 import io.micronaut.context.ApplicationContextConfigurer
@@ -29,24 +30,9 @@ import io.swagger.v3.oas.annotations.info.*
 }
 @@CompileStatic
 class Application {
-@if (defaultEnvironment != null) {
-    @@ContextConfigurer
-    static class DefaultEnvironmentConfigurer implements ApplicationContextConfigurer {
-        @@Override
-        public void configure(@@NonNull ApplicationContextBuilder builder) {
-            builder.defaultEnvironments("@(defaultEnvironment)")
-@if (eagerInitSingleton) {
-            builder.eagerInitSingletons(true)
-}
-        }
-    }
-}
+
+@with? (maybeContextConfig = context.getContextConfigurer()) { @maybeContextConfig }
     static void main(String[] args) {
-        Micronaut.build(args)
-            .mainClass(Application.class)
-@if (eagerInitSingleton) {
-            .eagerInitSingletons(true)
-}
-            .start()
+        Micronaut.run(Application, args)
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/contextConfigurer.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/contextConfigurer.rocker.raw
@@ -1,7 +1,7 @@
 @args (String defaultEnvironment, boolean eagerInitSingleton)
 
     @@ContextConfigurer
-    static class CustomApplicationContextConfigurer implements ApplicationContextConfigurer {
+    static class Configurer implements ApplicationContextConfigurer {
         @@Override
         public void configure(@@NonNull ApplicationContextBuilder builder) {
 @if (defaultEnvironment != null) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/contextConfigurer.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/groovy/contextConfigurer.rocker.raw
@@ -1,0 +1,14 @@
+@args (String defaultEnvironment, boolean eagerInitSingleton)
+
+    @@ContextConfigurer
+    static class CustomApplicationContextConfigurer implements ApplicationContextConfigurer {
+        @@Override
+        public void configure(@@NonNull ApplicationContextBuilder builder) {
+@if (defaultEnvironment != null) {
+            builder.defaultEnvironments("@(defaultEnvironment)")
+}
+@if (eagerInitSingleton) {
+            builder.eagerInitSingletons(true)
+}
+        }
+    }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplication.java
@@ -72,8 +72,17 @@ public class JavaApplication implements JavaApplicationFeature  {
     }
 
     protected RockerModel application(GeneratorContext generatorContext) {
-        String defaultEnvironment = generatorContext.hasConfigurationEnvironment(Environment.DEVELOPMENT) ? Environment.DEVELOPMENT : null;
-        return application.template(generatorContext.getProject(), generatorContext.getFeatures(), defaultEnvironment, generatorContext.getFeatures().isFeaturePresent(RequireEagerSingletonInitializationFeature.class));
+        String defaultEnvironment = getDefaultEnvironment(generatorContext);
+        boolean eagerInitSingleton = generatorContext.getFeatures().isFeaturePresent(RequireEagerSingletonInitializationFeature.class);
+        return application.template(
+                generatorContext.getProject(),
+                generatorContext.getFeatures(),
+                new JavaApplicationRenderingContext(defaultEnvironment, eagerInitSingleton)
+        );
+    }
+
+    private static String getDefaultEnvironment(GeneratorContext generatorContext) {
+        return generatorContext.hasConfigurationEnvironment(Environment.DEVELOPMENT) ? Environment.DEVELOPMENT : null;
     }
 
     protected void addApplicationTest(GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplication.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.feature.RequireEagerSingletonInitializationFeature;
 import io.micronaut.starter.feature.database.TransactionalNotSupported;
 import io.micronaut.starter.feature.test.template.javaJunit;
 import io.micronaut.starter.feature.test.template.koTest;
@@ -72,7 +73,7 @@ public class JavaApplication implements JavaApplicationFeature  {
 
     protected RockerModel application(GeneratorContext generatorContext) {
         String defaultEnvironment = generatorContext.hasConfigurationEnvironment(Environment.DEVELOPMENT) ? Environment.DEVELOPMENT : null;
-        return application.template(generatorContext.getProject(), generatorContext.getFeatures(), defaultEnvironment);
+        return application.template(generatorContext.getProject(), generatorContext.getFeatures(), defaultEnvironment, generatorContext.getFeatures().isFeaturePresent(RequireEagerSingletonInitializationFeature.class));
     }
 
     protected void addApplicationTest(GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplicationRenderingContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplicationRenderingContext.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.lang.java;
+
+import com.fizzed.rocker.RockerOutput;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.feature.lang.ApplicationRenderingContext;
+
+public class JavaApplicationRenderingContext extends ApplicationRenderingContext {
+
+    public JavaApplicationRenderingContext(String defaultEnvironment, boolean eagerSingletons) {
+        super(defaultEnvironment, eagerSingletons);
+    }
+
+    @NonNull
+    @Override
+    protected RockerOutput getRendered() {
+        return contextConfigurer.template(getDefaultEnvironment(), isEagerSingletons()).render();
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/application.rocker.raw
@@ -2,13 +2,14 @@
 @import io.micronaut.starter.feature.Feature
 @import io.micronaut.starter.feature.Features
 @import io.micronaut.starter.feature.dekorate.AbstractDekoratePlatformFeature
+@import io.micronaut.starter.feature.lang.ApplicationRenderingContext
 @import java.util.stream.Collectors
 
-@args (Project project, Features features, String defaultEnvironment, boolean eagerInitSingleton)
+@args (Project project, Features features, ApplicationRenderingContext context)
 
 package @project.getPackageName();
 
-@if (defaultEnvironment != null) {
+@if (context.isRequired()) {
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.ApplicationContextConfigurer;
@@ -80,24 +81,9 @@ import io.dekorate.halkyon.annotation.HalkyonComponent;
 @@HalkyonComponent(name = "@project.getName()")
 }
 public class Application {
-@if (defaultEnvironment != null) {
-    @@ContextConfigurer
-    public static class DefaultEnvironmentConfigurer implements ApplicationContextConfigurer {
-        @@Override
-        public void configure(@@NonNull ApplicationContextBuilder builder) {
-            builder.defaultEnvironments("@(defaultEnvironment)");
-@if (eagerInitSingleton) {
-            builder.eagerInitSingletons(true);
-}
-        }
-    }
-}
+
+@with? (maybeContextConfig = context.getContextConfigurer()) { @maybeContextConfig }
     public static void main(String[] args) {
-        Micronaut.build(args)
-            .mainClass(Application.class)
-@if (eagerInitSingleton) {
-            .eagerInitSingletons(true)
-}
-            .start();
+        Micronaut.run(Application.class, args);
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/application.rocker.raw
@@ -3,9 +3,8 @@
 @import io.micronaut.starter.feature.Features
 @import io.micronaut.starter.feature.dekorate.AbstractDekoratePlatformFeature
 @import java.util.stream.Collectors
-@import io.micronaut.starter.feature.crac.Crac
 
-@args (Project project, Features features, String defaultEnvironment)
+@args (Project project, Features features, String defaultEnvironment, boolean eagerInitSingleton)
 
 package @project.getPackageName();
 
@@ -87,7 +86,7 @@ public class Application {
         @@Override
         public void configure(@@NonNull ApplicationContextBuilder builder) {
             builder.defaultEnvironments("@(defaultEnvironment)");
-@if (features.contains(Crac.NAME)) {
+@if (eagerInitSingleton) {
             builder.eagerInitSingletons(true);
 }
         }
@@ -96,7 +95,7 @@ public class Application {
     public static void main(String[] args) {
         Micronaut.build(args)
             .mainClass(Application.class)
-@if (features.contains(Crac.NAME)) {
+@if (eagerInitSingleton) {
             .eagerInitSingletons(true)
 }
             .start();

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/application.rocker.raw
@@ -3,6 +3,7 @@
 @import io.micronaut.starter.feature.Features
 @import io.micronaut.starter.feature.dekorate.AbstractDekoratePlatformFeature
 @import java.util.stream.Collectors
+@import io.micronaut.starter.feature.crac.Crac
 
 @args (Project project, Features features, String defaultEnvironment)
 
@@ -86,10 +87,18 @@ public class Application {
         @@Override
         public void configure(@@NonNull ApplicationContextBuilder builder) {
             builder.defaultEnvironments("@(defaultEnvironment)");
+@if (features.contains(Crac.NAME)) {
+            builder.eagerInitSingletons(true);
+}
         }
     }
 }
     public static void main(String[] args) {
-        Micronaut.run(Application.class, args);
+        Micronaut.build(args)
+            .mainClass(Application.class)
+@if (features.contains(Crac.NAME)) {
+            .eagerInitSingletons(true)
+}
+            .start();
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/contextConfigurer.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/contextConfigurer.rocker.raw
@@ -1,0 +1,14 @@
+@args (String defaultEnvironment, boolean eagerInitSingleton)
+
+    @@ContextConfigurer
+    public static class CustomApplicationContextConfigurer implements ApplicationContextConfigurer {
+        @@Override
+        public void configure(@@NonNull ApplicationContextBuilder builder) {
+@if (defaultEnvironment != null) {
+            builder.defaultEnvironments("@(defaultEnvironment)");
+}
+@if (eagerInitSingleton) {
+            builder.eagerInitSingletons(true);
+}
+        }
+    }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/contextConfigurer.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/contextConfigurer.rocker.raw
@@ -1,7 +1,7 @@
 @args (String defaultEnvironment, boolean eagerInitSingleton)
 
     @@ContextConfigurer
-    public static class CustomApplicationContextConfigurer implements ApplicationContextConfigurer {
+    public static class Configurer implements ApplicationContextConfigurer {
         @@Override
         public void configure(@@NonNull ApplicationContextBuilder builder) {
 @if (defaultEnvironment != null) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplication.java
@@ -22,6 +22,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.feature.RequireEagerSingletonInitializationFeature;
 import io.micronaut.starter.feature.database.TransactionalNotSupported;
 import io.micronaut.starter.feature.test.template.koTest;
 import io.micronaut.starter.feature.test.template.kotlinJunit;
@@ -73,7 +74,7 @@ public class KotlinApplication implements KotlinApplicationFeature {
 
     protected RockerModel application(GeneratorContext generatorContext) {
         String defaultEnvironment = generatorContext.hasConfigurationEnvironment(Environment.DEVELOPMENT) ? Environment.DEVELOPMENT : null;
-        return application.template(generatorContext.getProject(), generatorContext.getFeatures(), defaultEnvironment);
+        return application.template(generatorContext.getProject(), generatorContext.getFeatures(), defaultEnvironment, generatorContext.getFeatures().isFeaturePresent(RequireEagerSingletonInitializationFeature.class));
     }
 
     protected void addApplicationTest(GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplication.java
@@ -73,8 +73,17 @@ public class KotlinApplication implements KotlinApplicationFeature {
     }
 
     protected RockerModel application(GeneratorContext generatorContext) {
-        String defaultEnvironment = generatorContext.hasConfigurationEnvironment(Environment.DEVELOPMENT) ? Environment.DEVELOPMENT : null;
-        return application.template(generatorContext.getProject(), generatorContext.getFeatures(), defaultEnvironment, generatorContext.getFeatures().isFeaturePresent(RequireEagerSingletonInitializationFeature.class));
+        String defaultEnvironment = getDefaultEnvironment(generatorContext);
+        boolean eagerInitSingleton = generatorContext.getFeatures().isFeaturePresent(RequireEagerSingletonInitializationFeature.class);
+        return application.template(
+                generatorContext.getProject(),
+                generatorContext.getFeatures(),
+                new KotlinApplicationRenderingContext(defaultEnvironment, eagerInitSingleton)
+        );
+    }
+
+    private static String getDefaultEnvironment(GeneratorContext generatorContext) {
+        return generatorContext.hasConfigurationEnvironment(Environment.DEVELOPMENT) ? Environment.DEVELOPMENT : null;
     }
 
     protected void addApplicationTest(GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplicationRenderingContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplicationRenderingContext.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.lang.kotlin;
+
+import com.fizzed.rocker.RockerOutput;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.feature.lang.ApplicationRenderingContext;
+
+public class KotlinApplicationRenderingContext extends ApplicationRenderingContext {
+
+    public KotlinApplicationRenderingContext(String defaultEnvironment, boolean eagerSingletons) {
+        super(defaultEnvironment, eagerSingletons);
+    }
+
+    @NonNull
+    @Override
+    protected RockerOutput getRendered() {
+        return contextConfigurer.template(getDefaultEnvironment(), isEagerSingletons()).render();
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/application.rocker.raw
@@ -2,19 +2,20 @@
 @import io.micronaut.starter.feature.Feature
 @import io.micronaut.starter.feature.Features
 @import io.micronaut.starter.feature.dekorate.AbstractDekoratePlatformFeature
+@import io.micronaut.starter.feature.lang.ApplicationRenderingContext
 @import java.util.stream.Collectors
 
-@args (Project project, Features features, String defaultEnvironment, boolean eagerInitSingleton)
+@args (Project project, Features features, ApplicationRenderingContext context)
 
 package @project.getPackageName()
 
-@if (defaultEnvironment != null) {
+@if (context.isRequired()) {
 import io.micronaut.context.ApplicationContextBuilder
 import io.micronaut.context.ApplicationContextConfigurer
 import io.micronaut.context.annotation.ContextConfigurer
 }
 
-import io.micronaut.runtime.Micronaut
+import io.micronaut.runtime.Micronaut.run
 @if(features.getFeatures().stream().anyMatch(f -> f instanceof AbstractDekoratePlatformFeature)) {
 @if (features.contains("dekorate-kubernetes")) {
 import io.dekorate.kubernetes.annotation.KubernetesApplication
@@ -85,25 +86,8 @@ object Dekorate {
 }
 }
 
-
-@if (defaultEnvironment != null) {
-
-@@ContextConfigurer
-class DefaultEnvironmentConfigurer: ApplicationContextConfigurer {
-    override fun configure(builder: ApplicationContextBuilder) {
-        builder.defaultEnvironments("@(defaultEnvironment)");
-@if (eagerInitSingleton) {
-        builder.eagerInitSingletons(true);
-}
-	}
-}
-
-}
+@with? (maybeContextConfig = context.getContextConfigurer()) { @maybeContextConfig }
 fun main(args: Array<String>) {
-    Micronaut.build(*args)
-@if (eagerInitSingleton) {
-        .eagerInitSingletons(true)
-}
-        .start()
+	run(*args)
 }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/application.rocker.raw
@@ -3,6 +3,7 @@
 @import io.micronaut.starter.feature.Features
 @import io.micronaut.starter.feature.dekorate.AbstractDekoratePlatformFeature
 @import java.util.stream.Collectors
+@import io.micronaut.starter.feature.crac.Crac
 
 @args (Project project, Features features, String defaultEnvironment)
 
@@ -14,7 +15,7 @@ import io.micronaut.context.ApplicationContextConfigurer
 import io.micronaut.context.annotation.ContextConfigurer
 }
 
-import io.micronaut.runtime.Micronaut.*
+import io.micronaut.runtime.Micronaut
 @if(features.getFeatures().stream().anyMatch(f -> f instanceof AbstractDekoratePlatformFeature)) {
 @if (features.contains("dekorate-kubernetes")) {
 import io.dekorate.kubernetes.annotation.KubernetesApplication
@@ -92,11 +93,18 @@ object Dekorate {
 class DefaultEnvironmentConfigurer: ApplicationContextConfigurer {
 	override fun configure(builder: ApplicationContextBuilder) {
 		builder.defaultEnvironments("@(defaultEnvironment)");
+@if (features.contains(Crac.NAME)) {
+        builder.eagerInitSingletons(true);
+}
 	}
 }
 
 }
 fun main(args: Array<String>) {
-	run(*args)
+    Micronaut.build(*args)
+@if (features.contains(Crac.NAME)) {
+        .eagerInitSingletons(true)
+}
+        .start()
 }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/application.rocker.raw
@@ -90,8 +90,8 @@ object Dekorate {
 
 @@ContextConfigurer
 class DefaultEnvironmentConfigurer: ApplicationContextConfigurer {
-	override fun configure(builder: ApplicationContextBuilder) {
-		builder.defaultEnvironments("@(defaultEnvironment)");
+    override fun configure(builder: ApplicationContextBuilder) {
+        builder.defaultEnvironments("@(defaultEnvironment)");
 @if (eagerInitSingleton) {
         builder.eagerInitSingletons(true);
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/application.rocker.raw
@@ -3,9 +3,8 @@
 @import io.micronaut.starter.feature.Features
 @import io.micronaut.starter.feature.dekorate.AbstractDekoratePlatformFeature
 @import java.util.stream.Collectors
-@import io.micronaut.starter.feature.crac.Crac
 
-@args (Project project, Features features, String defaultEnvironment)
+@args (Project project, Features features, String defaultEnvironment, boolean eagerInitSingleton)
 
 package @project.getPackageName()
 
@@ -93,7 +92,7 @@ object Dekorate {
 class DefaultEnvironmentConfigurer: ApplicationContextConfigurer {
 	override fun configure(builder: ApplicationContextBuilder) {
 		builder.defaultEnvironments("@(defaultEnvironment)");
-@if (features.contains(Crac.NAME)) {
+@if (eagerInitSingleton) {
         builder.eagerInitSingletons(true);
 }
 	}
@@ -102,7 +101,7 @@ class DefaultEnvironmentConfigurer: ApplicationContextConfigurer {
 }
 fun main(args: Array<String>) {
     Micronaut.build(*args)
-@if (features.contains(Crac.NAME)) {
+@if (eagerInitSingleton) {
         .eagerInitSingletons(true)
 }
         .start()

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/contextConfigurer.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/contextConfigurer.rocker.raw
@@ -1,7 +1,7 @@
 @args (String defaultEnvironment, boolean eagerInitSingleton)
 
 @@ContextConfigurer
-class CustomApplicationContextConfigurer: ApplicationContextConfigurer {
+class Configurer: ApplicationContextConfigurer {
     override fun configure(builder: ApplicationContextBuilder) {
 @if (defaultEnvironment != null) {
         builder.defaultEnvironments("@(defaultEnvironment)");

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/contextConfigurer.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/contextConfigurer.rocker.raw
@@ -1,0 +1,13 @@
+@args (String defaultEnvironment, boolean eagerInitSingleton)
+
+@@ContextConfigurer
+class CustomApplicationContextConfigurer: ApplicationContextConfigurer {
+    override fun configure(builder: ApplicationContextBuilder) {
+@if (defaultEnvironment != null) {
+        builder.defaultEnvironments("@(defaultEnvironment)");
+}
+@if (eagerInitSingleton) {
+        builder.eagerInitSingletons(true);
+}
+	}
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/crac/CracSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/crac/CracSpec.groovy
@@ -9,6 +9,7 @@ import io.micronaut.starter.feature.database.jdbc.Hikari
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
 import spock.lang.Shared
 
 class CracSpec extends ApplicationContextSpec implements CommandOutputFixture {
@@ -18,12 +19,24 @@ class CracSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature crac contains links to micronaut docs'() {
         when:
-        def output = generate(['crac'])
+        def output = generate([Crac.NAME])
         def readme = output["README.md"]
 
         then:
         readme.contains("[Micronaut Support for CRaC (Coordinated Restore at Checkpoint) documentation](https://micronaut-projects.github.io/micronaut-crac/latest/guide)")
         readme.contains("[https://wiki.openjdk.org/display/CRaC](https://wiki.openjdk.org/display/CRaC)")
+    }
+
+    void "test singletons are eager for #language"(Language language) {
+        when:
+        def output = generate(ApplicationType.DEFAULT, new Options(language), [Crac.NAME])
+        def application = output[language.getSourcePath("/example/micronaut/Application")]
+
+        then:
+        application.contains(".eagerInitSingletons(true)")
+
+        where:
+        language << Language.values()
     }
 
     void "feature crac #desc for #applicationType"(ApplicationType applicationType) {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/lang/JavaApplicationSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/lang/JavaApplicationSpec.groovy
@@ -72,7 +72,7 @@ import io.micronaut.runtime.Micronaut;
 public class Application {
 
     @ContextConfigurer
-    public static class CustomApplicationContextConfigurer implements ApplicationContextConfigurer {
+    public static class Configurer implements ApplicationContextConfigurer {
         @Override
         public void configure(@NonNull ApplicationContextBuilder builder) {
             builder.defaultEnvironments("env");
@@ -103,7 +103,7 @@ import io.micronaut.runtime.Micronaut;
 public class Application {
 
     @ContextConfigurer
-    public static class CustomApplicationContextConfigurer implements ApplicationContextConfigurer {
+    public static class Configurer implements ApplicationContextConfigurer {
         @Override
         public void configure(@NonNull ApplicationContextBuilder builder) {
             builder.defaultEnvironments("env");
@@ -135,7 +135,7 @@ import io.micronaut.runtime.Micronaut;
 public class Application {
 
     @ContextConfigurer
-    public static class CustomApplicationContextConfigurer implements ApplicationContextConfigurer {
+    public static class Configurer implements ApplicationContextConfigurer {
         @Override
         public void configure(@NonNull ApplicationContextBuilder builder) {
             builder.eagerInitSingletons(true);

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/lang/JavaApplicationSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/lang/JavaApplicationSpec.groovy
@@ -34,7 +34,7 @@ class JavaApplicationSpec extends BeanContextSpec implements CommandOutputFixtur
     }
 
     void "test java application"() {
-        String applicationJava = application.template(buildProject(), getFeatures([]), null)
+        String applicationJava = application.template(buildProject(), getFeatures([]), null, false)
         .render()
         .toString()
 
@@ -54,8 +54,30 @@ public class Application {
 """.trim())
     }
 
+    void "test java application with eagerInit"() {
+        String applicationJava = application.template(buildProject(), getFeatures([]), null, true)
+                .render()
+                .toString()
+
+        expect:
+        applicationJava.contains("""
+package example.micronaut;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+    public static void main(String[] args) {
+        Micronaut.build(args)
+            .mainClass(Application.class)
+            .eagerInitSingletons(true)
+            .start();
+    }
+}
+""".trim())
+    }
+
     void "test java application with openapi"() {
-        String applicationJava = application.template(buildProject(), getFeatures(["openapi"]), null)
+        String applicationJava = application.template(buildProject(), getFeatures(["openapi"]), null, false)
                 .render()
                 .toString()
 
@@ -84,7 +106,7 @@ public class Application {
     }
 
     void "test java application with dekorate-kubernetes"() {
-        String applicationJava = application.template(buildProject(), getFeatures(["dekorate-kubernetes"]), null)
+        String applicationJava = application.template(buildProject(), getFeatures(["dekorate-kubernetes"]), null, false)
                 .render()
                 .toString()
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/lang/JavaApplicationSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/lang/JavaApplicationSpec.groovy
@@ -46,7 +46,9 @@ import io.micronaut.runtime.Micronaut;
 
 public class Application {
     public static void main(String[] args) {
-        Micronaut.run(Application.class, args);
+        Micronaut.build(args)
+            .mainClass(Application.class)
+            .start();
     }
 }
 """.trim())
@@ -73,7 +75,9 @@ import io.swagger.v3.oas.annotations.info.*;
 )
 public class Application {
     public static void main(String[] args) {
-        Micronaut.run(Application.class, args);
+        Micronaut.build(args)
+            .mainClass(Application.class)
+            .start();
     }
 }
 """.trim())
@@ -103,7 +107,9 @@ import io.dekorate.kubernetes.annotation.Probe;
 )
 public class Application {
     public static void main(String[] args) {
-        Micronaut.run(Application.class, args);
+        Micronaut.build(args)
+            .mainClass(Application.class)
+            .start();
     }
 }
 """.trim())

--- a/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateBeanSpec.groovy
+++ b/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateBeanSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.starter.cli.test
 
 import io.micronaut.starter.cli.CodeGenConfig
 import io.micronaut.starter.cli.command.project.bean.CreateBeanCommand
+import io.micronaut.starter.feature.crac.Crac
 import io.micronaut.starter.io.ConsoleOutput
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateCracAppSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateCracAppSpec.groovy
@@ -1,0 +1,32 @@
+package io.micronaut.starter.core.test.create
+
+import io.micronaut.starter.feature.crac.Crac
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.test.CommandSpec
+import io.micronaut.starter.test.LanguageBuildCombinations
+import spock.lang.Retry
+import spock.lang.Unroll
+
+@Retry // sometimes CI gets connection failure/reset resolving dependencies from Maven central
+class CreateCracAppSpec extends CommandSpec {
+
+    void 'test basic create-app for #lang and #buildTool with CRaC'(Language lang, BuildTool buildTool) {
+        given:
+        generateProject(lang, buildTool, [Crac.NAME])
+
+        when:
+        String output = executeBuild(buildTool, "test")
+
+        then:
+        output.contains("BUILD SUCCESS")
+
+        where:
+        [lang, buildTool] << LanguageBuildCombinations.combinations()
+    }
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "test-crac-app"
+    }
+}


### PR DESCRIPTION
This PR sets the eager initialization of singletons option if the CRaC feature is selected

https://docs.micronaut.io/latest/guide/#eagerInit

To allow this, we had to switch from `Micronaut.run` to `Micronaut.build` in the Application main class.

Fixes #1513