### PR TITLE
Switch to enable classpathInference for test resources

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -184,7 +184,7 @@ MavenBuild mavenBuild
     .flatMap(DatabaseDriverFeature::getDbType)
     .map(dbType -> features.isFeaturePresent(R2dbc.class) ? dbType.getR2dbcTestResourcesModuleName() : features.isFeaturePresent(HibernateReactiveFeature.class) ? dbType.getHibernateReactiveTestResourcesModuleName() : dbType.getJdbcTestResourcesModuleName())
     .orElse(null)) {
-            <classpathInference>false</classpathInference>
+            <classpathInference>true</classpathInference>
             <testResourcesDependencies>
               <dependency>
                 <groupId>io.micronaut.testresources</groupId>

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -184,7 +184,6 @@ MavenBuild mavenBuild
     .flatMap(DatabaseDriverFeature::getDbType)
     .map(dbType -> features.isFeaturePresent(R2dbc.class) ? dbType.getR2dbcTestResourcesModuleName() : features.isFeaturePresent(HibernateReactiveFeature.class) ? dbType.getHibernateReactiveTestResourcesModuleName() : dbType.getJdbcTestResourcesModuleName())
     .orElse(null)) {
-            <classpathInference>true</classpathInference>
             <testResourcesDependencies>
               <dependency>
                 <groupId>io.micronaut.testresources</groupId>

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -17,6 +17,7 @@
 @import io.micronaut.starter.feature.github.workflows.docker.AbstractDockerRegistryWorkflow
 @import io.micronaut.starter.feature.messaging.SharedTestResourceFeature
 @import io.micronaut.starter.feature.migration.MigrationFeature
+@import io.micronaut.starter.feature.testresources.TestResources
 @import io.micronaut.starter.options.JdkVersion
 @import io.micronaut.starter.util.VersionInfo
 
@@ -172,13 +173,14 @@ MavenBuild mavenBuild
      || features.contains("jrebel")
      || features.contains("oracle-function")
      || features.contains("micronaut-aot")
+     || features.isFeaturePresent(TestResources.class)
      || features.isFeaturePresent(SharedTestResourceFeature.class)
      || (features.isFeaturePresent(DatabaseDriverFeature.class) && (!features.isFeaturePresent(Data.class) || features.isFeaturePresent(HibernateReactiveFeature.class)))) {
           <configuration>
 @if (features.isFeaturePresent(SharedTestResourceFeature.class)) {
             <shared>true</shared>
 }
-@if (features.isFeaturePresent(DatabaseDriverFeature.class) && (!features.isFeaturePresent(Data.class) || features.isFeaturePresent(HibernateReactiveFeature.class))) {
+@if (features.isFeaturePresent(TestResources.class) && features.isFeaturePresent(DatabaseDriverFeature.class) && (!features.isFeaturePresent(Data.class) || features.isFeaturePresent(HibernateReactiveFeature.class))) {
 @with? (String resourceName = features
     .getFeature(DatabaseDriverFeature.class)
     .flatMap(DatabaseDriverFeature::getDbType)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataJdbc.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataJdbc.java
@@ -25,6 +25,7 @@ import jakarta.inject.Singleton;
 @Singleton
 public class DataJdbc implements DataFeature {
 
+    public static final String NAME = "data-jdbc";
     private final Data data;
     private final JdbcFeature jdbcFeature;
 
@@ -35,7 +36,7 @@ public class DataJdbc implements DataFeature {
 
     @Override
     public String getName() {
-        return "data-jdbc";
+        return NAME;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataJpa.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataJpa.java
@@ -26,6 +26,7 @@ import jakarta.inject.Singleton;
 @Singleton
 public class DataJpa implements JpaFeature, DataFeature {
 
+    public static final String NAME = "data-jpa";
     private final Data data;
     private final JdbcFeature jdbcFeature;
 
@@ -36,7 +37,7 @@ public class DataJpa implements JpaFeature, DataFeature {
 
     @Override
     public String getName() {
-        return "data-jpa";
+        return NAME;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongo.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongo.java
@@ -27,8 +27,9 @@ import jakarta.inject.Singleton;
 @Singleton
 public class DataMongo extends DataMongoFeature {
 
-    private static final String SYNC_MONGODB_ARTIFACT = "mongodb-driver-sync";
     public static final String NAME = "data-mongodb";
+
+    private static final String SYNC_MONGODB_ARTIFACT = "mongodb-driver-sync";
 
     public DataMongo(Data data, TestContainers testContainers, TestResources testResources) {
         super(data, testContainers, testResources);

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongo.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataMongo.java
@@ -28,6 +28,7 @@ import jakarta.inject.Singleton;
 public class DataMongo extends DataMongoFeature {
 
     private static final String SYNC_MONGODB_ARTIFACT = "mongodb-driver-sync";
+    public static final String NAME = "data-mongodb";
 
     public DataMongo(Data data, TestContainers testContainers, TestResources testResources) {
         super(data, testContainers, testResources);
@@ -36,7 +37,7 @@ public class DataMongo extends DataMongoFeature {
     @NonNull
     @Override
     public String getName() {
-        return "data-mongodb";
+        return NAME;
     }
 
     @NonNull

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/HibernateReactiveFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/HibernateReactiveFeature.java
@@ -19,7 +19,6 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.migration.MigrationFeature;
-import io.micronaut.starter.feature.testresources.DbType;
 import io.micronaut.starter.feature.testresources.EaseTestingFeature;
 import io.micronaut.starter.feature.testresources.TestResources;
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/MongoReactive.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/MongoReactive.java
@@ -24,6 +24,9 @@ import jakarta.inject.Singleton;
 
 @Singleton
 public class MongoReactive extends MongoFeature {
+
+    public static final String NAME = "mongo-reactive";
+
     public MongoReactive(TestContainers testContainers,
                          TestResources testResources) {
         super(testContainers, testResources);
@@ -31,7 +34,7 @@ public class MongoReactive extends MongoFeature {
 
     @Override
     public String getName() {
-        return "mongo-reactive";
+        return NAME;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/MongoSync.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/MongoSync.java
@@ -25,6 +25,8 @@ import jakarta.inject.Singleton;
 @Singleton
 public class MongoSync extends MongoFeature {
 
+    public static final String NAME = "mongo-sync";
+
     public MongoSync(TestContainers testContainers,
                      TestResources testResources) {
         super(testContainers, testResources);
@@ -32,7 +34,7 @@ public class MongoSync extends MongoFeature {
 
     @Override
     public String getName() {
-        return "mongo-sync";
+        return NAME;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/testresources/EaseTestingFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/testresources/EaseTestingFeature.java
@@ -36,7 +36,7 @@ public abstract class EaseTestingFeature implements Feature  {
 
     @Override
     public void processSelectedFeatures(FeatureContext featureContext) {
-        if (!featureContext.isPresent(TestResources.class) && testResources != null) {
+        if (!featureContext.isPresent(TestContainers.class) && testResources != null) {
             featureContext.addFeature(testResources);
         }
     }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/testresources/OptionalTestContainerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/testresources/OptionalTestContainerSpec.groovy
@@ -16,7 +16,9 @@ import io.micronaut.starter.feature.database.SQLServer
 import io.micronaut.starter.feature.database.TestContainers
 import io.micronaut.starter.feature.messaging.mqtt.Mqtt
 import io.micronaut.starter.feature.messaging.rabbitmq.RabbitMQ
+import spock.lang.Requires
 
+@Requires({ jvm.current.isJava11Compatible() })
 class OptionalTestContainerSpec extends ApplicationContextSpec {
 
     private final static TEST_RESOURCE_FEATURES = [

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/testresources/OptionalTestContainerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/testresources/OptionalTestContainerSpec.groovy
@@ -1,0 +1,68 @@
+package io.micronaut.starter.feature.testresources
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.feature.database.DataHibernateReactive
+import io.micronaut.starter.feature.database.DataJdbc
+import io.micronaut.starter.feature.database.DataJpa
+import io.micronaut.starter.feature.database.DataMongo
+import io.micronaut.starter.feature.database.HibernateReactiveJpa
+import io.micronaut.starter.feature.database.MariaDB
+import io.micronaut.starter.feature.database.MongoReactive
+import io.micronaut.starter.feature.database.MongoSync
+import io.micronaut.starter.feature.database.MySQL
+import io.micronaut.starter.feature.database.Oracle
+import io.micronaut.starter.feature.database.PostgreSQL
+import io.micronaut.starter.feature.database.SQLServer
+import io.micronaut.starter.feature.database.TestContainers
+import io.micronaut.starter.feature.messaging.mqtt.Mqtt
+import io.micronaut.starter.feature.messaging.rabbitmq.RabbitMQ
+
+class OptionalTestContainerSpec extends ApplicationContextSpec {
+
+    private final static TEST_RESOURCE_FEATURES = [
+            MySQL.NAME,
+            PostgreSQL.NAME,
+            Oracle.NAME,
+            MariaDB.NAME,
+            SQLServer.NAME,
+            DataMongo.NAME,
+            DataJdbc.NAME,
+            DataJpa.NAME,
+            RabbitMQ.NAME,
+            Mqtt.NAME,
+            MongoSync.NAME,
+            MongoReactive.NAME,
+            HibernateReactiveJpa.NAME,
+            DataHibernateReactive.NAME,
+    ]
+
+    static List<String> extraModules(String name) {
+        name in [DataJpa.NAME, DataJdbc.NAME, HibernateReactiveJpa.NAME, DataHibernateReactive.NAME] ? [MySQL.NAME] : []
+    }
+
+    void "test resources for #features is enabled by default"() {
+        given:
+        def ctx = buildGeneratorContext(features)
+
+        expect:
+        ctx.isFeaturePresent(TestResources)
+        !ctx.isFeaturePresent(TestContainers)
+
+        where:
+        name << TEST_RESOURCE_FEATURES
+        features = [name] + extraModules(name)
+    }
+
+    void "adding features #features removes TestResources"() {
+        given:
+        def ctx = buildGeneratorContext(features)
+
+        expect:
+        !ctx.isFeaturePresent(TestResources)
+        ctx.isFeaturePresent(TestContainers)
+
+        where:
+        name << TEST_RESOURCE_FEATURES
+        features = [name] + extraModules(name) + [TestContainers.NAME]
+    }
+}


### PR DESCRIPTION
It was noticed in #1522 that a plain mysql app didn't work as the TR service didn't have the driver class available.

We decided to enable classpathInference as that works, and that is how the Gradle plugin works also