### PR TITLE
For `data-jpa` feature don't generate `datasources.default.schema-generate` config values. Use `jpa.default.properties.hibernate.hbm2ddl.auto` config instead.

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DataJpa.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DataJpa.java
@@ -18,10 +18,14 @@ package io.micronaut.starter.feature.database;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.config.ApplicationConfiguration;
+import io.micronaut.starter.feature.config.Configuration;
 import io.micronaut.starter.feature.database.jdbc.JdbcFeature;
-
 import io.micronaut.starter.feature.migration.MigrationFeature;
 import jakarta.inject.Singleton;
+
+import java.util.Collections;
+import java.util.Map;
 
 @Singleton
 public class DataJpa implements JpaFeature, DataFeature {
@@ -66,10 +70,21 @@ public class DataJpa implements JpaFeature, DataFeature {
                 .artifactId("micronaut-data-hibernate-jpa")
                 .compile());
         DatabaseDriverFeature dbFeature = generatorContext.getRequiredFeature(DatabaseDriverFeature.class);
-        generatorContext.getConfiguration().putAll(getDatasourceConfig(dbFeature));
-        generatorContext.getConfiguration().put(JPA_HIBERNATE_PROPERTIES_HBM2DDL,
+        generatorContext.getConfiguration().addNested(getDatasourceConfig(dbFeature));
+        generatorContext.getConfiguration().addNested(JPA_HIBERNATE_PROPERTIES_HBM2DDL,
                 generatorContext.getFeatures().hasFeature(MigrationFeature.class) ? Hbm2ddlAuto.NONE.toString() :
                         Hbm2ddlAuto.UPDATE.toString());
 
+        Configuration testConfig = ApplicationConfiguration.testConfig();
+        generatorContext.addConfiguration(testConfig);
+        testConfig.addNested(JPA_HIBERNATE_PROPERTIES_HBM2DDL,
+                generatorContext.getFeatures().hasFeature(MigrationFeature.class) ? Hbm2ddlAuto.NONE.toString() :
+                        Hbm2ddlAuto.CREATE_DROP.toString());
     }
+
+    @Override
+    public Map<String, Object> getDatasourceConfig(DatabaseDriverFeature driverFeature) {
+        return Collections.singletonMap("datasources.default.dialect", driverFeature.getDataDialect());
+    }
+
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataJpaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataJpaSpec.groovy
@@ -166,7 +166,7 @@ class DataJpaSpec extends ApplicationContextSpec implements CommandOutputFixture
 ''')
     }
 
-    void 'feature data-jdbc contains correct hbm2ddl.auto values'(List<String> features, String prod, String test) {
+    void 'feature data-jpa contains correct hbm2ddl.auto values'(List<String> features, String prod, String test) {
         when:
         def output = generate(features)
         def appConfig = output["src/main/resources/application.yml"]


### PR DESCRIPTION
closes #1523 