### PR TITLE
Default to AWS Lambda architecture to x86

### DIFF
--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
@@ -217,14 +217,15 @@ public class CreateLambdaBuilderCommand extends BuilderCommand {
         List<Feature> cpuArchitecturesFeatures = features.stream()
                 .filter(CpuArchitecture.class::isInstance)
                 .collect(Collectors.toList());
-        out("Choose your Lambda Architecture. (enter for Java ARM)");
+        String defaultCpuArchitecture = X86.NAME;
+        out("Choose your Lambda Architecture. (enter for " + defaultCpuArchitecture + ")");
         String option = getListOption(
                 cpuArchitecturesFeatures.stream()
                         .map(Feature::getName)
                         .sorted()
                         .collect(Collectors.toList()),
                 o -> o,
-                Arm.NAME,
+                defaultCpuArchitecture,
                 reader);
         return cpuArchitecturesFeatures
                 .stream()

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsApiFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsApiFeature.java
@@ -26,7 +26,6 @@ public interface AwsApiFeature extends AwsLambdaEventFeature, LambdaTrigger {
             .compile()
             .build();
 
-
     @Override
     default String getMicronautDocumentation() {
         return "https://micronaut-projects.github.io/micronaut-aws/latest/guide/index.html#amazonApiGateway";

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
@@ -40,6 +40,7 @@ import io.micronaut.starter.feature.InfrastructureAsCodeFeature;
 import io.micronaut.starter.feature.MultiProjectFeature;
 import io.micronaut.starter.feature.architecture.Arm;
 import io.micronaut.starter.feature.architecture.CpuArchitecture;
+import io.micronaut.starter.feature.architecture.X86;
 import io.micronaut.starter.feature.aws.template.cdkappstack;
 import io.micronaut.starter.feature.aws.template.cdkappstacktest;
 import io.micronaut.starter.feature.aws.template.cdkhelp;
@@ -74,18 +75,25 @@ public class Cdk implements MultiProjectFeature, InfrastructureAsCodeFeature {
     public static final String INFRA_MODULE = "infra";
     public static final String NAME = "aws-cdk";
     private static final String MAIN_CLASS_NAME = "Main";
-    private final Arm arm;
+    private final CpuArchitecture defaultCpuArchitecture;
     private final DependencyContext dependencyContext;
 
     @Deprecated
     public Cdk(CoordinateResolver coordinateResolver) {
-        this(coordinateResolver, new Arm());
+        this(coordinateResolver, new X86());
+    }
+
+    @Deprecated
+    public Cdk(CoordinateResolver coordinateResolver,
+               Arm arm) {
+        this.defaultCpuArchitecture = arm;
+        this.dependencyContext = new DependencyContextImpl(coordinateResolver);
     }
 
     @Inject
     public Cdk(CoordinateResolver coordinateResolver,
-               Arm arm) {
-        this.arm = arm;
+               X86 x86) {
+        this.defaultCpuArchitecture = x86;
         this.dependencyContext = new DependencyContextImpl(coordinateResolver);
     }
 
@@ -131,7 +139,7 @@ public class Cdk implements MultiProjectFeature, InfrastructureAsCodeFeature {
                 cdkappstacktest.template(generatorContext.getProject(), handler)));
 
         CpuArchitecture architecture = generatorContext.getFeatures().getFeature(CpuArchitecture.class)
-                .orElse(arm);
+                .orElse(defaultCpuArchitecture);
         generatorContext.addTemplate("cdk-appstack", new RockerTemplate(INFRA_MODULE, lang.getSrcDir() + "/{packagePath}/AppStack.java",
                 cdkappstack.template(generatorContext.getFeatures(),
                         generatorContext.getProject(),

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/AwsLambda.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/AwsLambda.java
@@ -28,6 +28,7 @@ import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.MicronautRuntimeFeature;
 import io.micronaut.starter.feature.architecture.Arm;
 import io.micronaut.starter.feature.architecture.CpuArchitecture;
+import io.micronaut.starter.feature.architecture.X86;
 import io.micronaut.starter.feature.aws.AwsApiFeature;
 import io.micronaut.starter.feature.aws.AwsLambdaEventFeature;
 import io.micronaut.starter.feature.awsalexa.AwsAlexa;
@@ -67,7 +68,7 @@ public class AwsLambda implements FunctionFeature, DefaultFeature, CloudFeature,
 
     private final ShadePlugin shadePlugin;
     private final AwsLambdaCustomRuntime customRuntime;
-    private final Arm arm;
+    private final CpuArchitecture defaultCpuArchitecture;
 
     @Deprecated
     public AwsLambda(ShadePlugin shadePlugin,
@@ -75,19 +76,28 @@ public class AwsLambda implements FunctionFeature, DefaultFeature, CloudFeature,
         this(shadePlugin, customRuntime, new Arm());
     }
 
-    @Inject
+    @Deprecated
     public AwsLambda(ShadePlugin shadePlugin,
                      AwsLambdaCustomRuntime customRuntime,
                      Arm arm) {
         this.shadePlugin = shadePlugin;
         this.customRuntime = customRuntime;
-        this.arm = arm;
+        this.defaultCpuArchitecture = arm;
+    }
+
+    @Inject
+    public AwsLambda(ShadePlugin shadePlugin,
+                     AwsLambdaCustomRuntime customRuntime,
+                     X86 x86) {
+        this.shadePlugin = shadePlugin;
+        this.customRuntime = customRuntime;
+        this.defaultCpuArchitecture = x86;
     }
 
     @Override
     public void processSelectedFeatures(FeatureContext featureContext) {
         featureContext.addFeatureIfNotPresent(ShadePlugin.class, shadePlugin);
-        featureContext.addFeatureIfNotPresent(CpuArchitecture.class, arm);
+        featureContext.addFeatureIfNotPresent(CpuArchitecture.class, defaultCpuArchitecture);
         if (featureContext.isPresent(GraalVM.class) &&
                 (
                         featureContext.getBuildTool() == BuildTool.MAVEN ||

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/ArmSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/ArmSpec.groovy
@@ -44,14 +44,5 @@ class ArmSpec extends ApplicationContextSpec implements CommandOutputFixture {
         then:
         output."$Cdk.INFRA_MODULE/src/main/java/example/micronaut/AppStack.java".contains($/import software.amazon.awscdk.services.lambda.Architecture/$)
         output."$Cdk.INFRA_MODULE/src/main/java/example/micronaut/AppStack.java".contains($/.architecture(Architecture.ARM_64)/$)
-
-        when:
-        output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),
-                [Cdk.NAME, AwsLambda.FEATURE_NAME_AWS_LAMBDA])
-
-        then:
-        output."$Cdk.INFRA_MODULE/src/main/java/example/micronaut/AppStack.java".contains($/import software.amazon.awscdk.services.lambda.Architecture/$)
-        output."$Cdk.INFRA_MODULE/src/main/java/example/micronaut/AppStack.java".contains($/.architecture(Architecture.ARM_64)/$)
-
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/X86Spec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/X86Spec.groovy
@@ -45,13 +45,12 @@ class X86Spec extends ApplicationContextSpec implements CommandOutputFixture {
         output."$Cdk.INFRA_MODULE/src/main/java/example/micronaut/AppStack.java".contains($/import software.amazon.awscdk.services.lambda.Architecture/$)
         output."$Cdk.INFRA_MODULE/src/main/java/example/micronaut/AppStack.java".contains($/.architecture(Architecture.X86_64)/$)
 
-        when:
+        when: 'x86 is the default'
         output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),
                 [Cdk.NAME, AwsLambda.FEATURE_NAME_AWS_LAMBDA])
 
         then:
         output."$Cdk.INFRA_MODULE/src/main/java/example/micronaut/AppStack.java".contains($/import software.amazon.awscdk.services.lambda.Architecture/$)
-        output."$Cdk.INFRA_MODULE/src/main/java/example/micronaut/AppStack.java".contains($/.architecture(Architecture.ARM_64)/$)
-
+        output."$Cdk.INFRA_MODULE/src/main/java/example/micronaut/AppStack.java".contains($/.architecture(Architecture.X86_64)/$)
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/CdkFeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/CdkFeatureSpec.groovy
@@ -58,6 +58,19 @@ class CdkFeatureSpec extends ApplicationContextSpec implements CommandOutputFixt
         buildTool << [BuildTool.GRADLE, BuildTool.GRADLE_KOTLIN , BuildTool.MAVEN]
     }
 
+    void 'architecture defaults to X86 for  #buildTool'() {
+        when:
+        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool), [Cdk.NAME])
+
+        then:
+        output.'infra/src/main/java/example/micronaut/AppStack.java'.contains('.architecture(Architecture.X86_64)')
+        output.'infra/src/main/java/example/micronaut/AppStack.java'.contains('import software.amazon.awscdk.services.lambda.Architecture;')
+
+        where:
+        buildTool << [BuildTool.GRADLE, BuildTool.GRADLE_KOTLIN , BuildTool.MAVEN]
+    }
+
+
     void 'Function AppStack with Alexa Skills is included for #buildTool'() {
         when:
         def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool), [Cdk.NAME,AwsAlexa.NAME])

--- a/test-lambda-graalvm.sh
+++ b/test-lambda-graalvm.sh
@@ -103,6 +103,33 @@ cdk destroy -f
 cd ../../..
 rm -rf starter-cli/temp
 
+
+############
+# | BUILD  | TYPE | RUNTIME  | FEATURES
+# | GRADLE | APP  | PROVIDED | aws-lambda,aws-cdk,graalvm,amazon-api-gateway-http
+############
+
+./gradlew micronaut-cli:run --args="create-app -b gradle -f \"aws-lambda,aws-cdk,graalvm,amazon-api-gateway-http\" temp" || EXIT_STATUS=$?
+
+if [ $EXIT_STATUS -ne 0 ]; then
+  exit $EXIT_STATUS
+fi
+
+cd starter-cli/temp
+
+./test-lambda.sh  || EXIT_STATUS=$? 
+
+if [ $EXIT_STATUS -ne 0 ]; then
+  echo "❌ FAILED | GRADLE  | APP  | PROVIDED | aws-lambda,aws-cdk,graalvm,amazon-api-gateway-http"
+  exit $EXIT_STATUS
+fi
+
+cd infra
+cdk destroy -f
+cd ../../..
+rm -rf starter-cli/temp
+
+
 ############
 # | BUILD  | TYPE     | RUNTIME  | FEATURES
 # | GRADLE | FUNCTION | PROVIDED | aws-lambda,aws-cdk,graalvm,amazon-api-gateway
@@ -120,6 +147,31 @@ cd starter-cli/temp
 
 if [ $EXIT_STATUS -ne 0 ]; then
   echo "❌ FAILED | GRADLE  | FUNCTION  | PROVIDED | aws-lambda,aws-cdk,graalvm,amazon-api-gateway"
+  exit $EXIT_STATUS
+fi
+
+cd infra
+cdk destroy -f
+cd ../../..
+rm -rf starter-cli/temp
+
+############
+# | BUILD  | TYPE     | RUNTIME  | FEATURES
+# | GRADLE | FUNCTION | PROVIDED | aws-lambda,aws-cdk,graalvm,amazon-api-gateway-http
+############
+
+./gradlew micronaut-cli:run --args="create-function-app -b gradle -f \"aws-lambda,aws-cdk,graalvm,amazon-api-gateway-http\" temp" || EXIT_STATUS=$?
+
+if [ $EXIT_STATUS -ne 0 ]; then
+  exit $EXIT_STATUS
+fi
+
+cd starter-cli/temp
+
+./test-lambda.sh  || EXIT_STATUS=$? 
+
+if [ $EXIT_STATUS -ne 0 ]; then
+  echo "❌ FAILED | GRADLE  | FUNCTION  | PROVIDED | aws-lambda,aws-cdk,graalvm,amazon-api-gateway-http"
   exit $EXIT_STATUS
 fi
 


### PR DESCRIPTION
AWS Lambda SnapStart currently does not support ARM. X86 is a better default.

Moreover, this PR adds more scenarios to the bash script used to test lambda and graalvm. 