### PR TITLE
Remove aws-java-sdk-core as a test dependency

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/LocalStack.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/LocalStack.java
@@ -87,9 +87,5 @@ public class LocalStack implements Feature {
                 .groupId(TESTCONTAINERS_GROUP_ID)
                 .artifactId("localstack")
                 .test());
-        generatorContext.addDependency(Dependency.builder()
-                .groupId("com.amazonaws")
-                .artifactId("aws-java-sdk-core")
-                .test());
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/LocalStack.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/LocalStack.java
@@ -23,6 +23,7 @@ import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.database.TestContainers;
+import io.micronaut.starter.feature.messaging.jms.SQS;
 import jakarta.inject.Singleton;
 
 import static io.micronaut.starter.feature.database.TestContainers.TESTCONTAINERS_GROUP_ID;
@@ -87,5 +88,12 @@ public class LocalStack implements Feature {
                 .groupId(TESTCONTAINERS_GROUP_ID)
                 .artifactId("localstack")
                 .test());
+        // SQS pulls this in transitively so this is not required
+        if (!generatorContext.isFeaturePresent(SQS.class)) {
+            generatorContext.addDependency(Dependency.builder()
+                    .groupId("com.amazonaws")
+                    .artifactId("aws-java-sdk-core")
+                    .test());
+        }
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/LocalStackSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/LocalStackSpec.groovy
@@ -44,7 +44,6 @@ class LocalStackSpec extends ApplicationContextSpec implements CommandOutputFixt
         then:
         template.contains('testImplementation("org.testcontainers:testcontainers")')
         template.contains('testImplementation("org.testcontainers:localstack")')
-        template.contains('testImplementation("com.amazonaws:aws-java-sdk-core")')
 
         where:
         language << Language.values().toList()
@@ -71,13 +70,6 @@ class LocalStackSpec extends ApplicationContextSpec implements CommandOutputFixt
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>localstack</artifactId>
-      <scope>test</scope>
-    </dependency>
-""")
-        template.contains("""
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
       <scope>test</scope>
     </dependency>
 """)


### PR DESCRIPTION
When we add aws-java-sdk-core as a test dependency, Maven removes it from the compile time transitive dependencies.

This causes the jms-aws-sqs maven guide to fail as it cannot find com.amazonaws.regions.Regions at compile time.

As the dependency comes in transitively, we can remove it from the locastack feature, as it should be coming in transitively from whichever micronaut aws library the user is using