### PR TITLE
Fix R2dbc ordering and integration with TestResources

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -175,12 +175,19 @@ MavenBuild mavenBuild
      || features.contains("micronaut-aot")
      || features.isFeaturePresent(TestResources.class)
      || features.isFeaturePresent(SharedTestResourceFeature.class)
-     || (features.isFeaturePresent(DatabaseDriverFeature.class) && (!features.isFeaturePresent(Data.class) || features.isFeaturePresent(HibernateReactiveFeature.class)))) {
+     || (features.isFeaturePresent(DatabaseDriverFeature.class)
+          && (!features.isFeaturePresent(Data.class)
+               || features.isFeaturePresent(HibernateReactiveFeature.class)
+               || features.isFeaturePresent(R2dbc.class)))
+) {
           <configuration>
 @if (features.isFeaturePresent(SharedTestResourceFeature.class)) {
             <shared>true</shared>
 }
-@if (features.isFeaturePresent(TestResources.class) && features.isFeaturePresent(DatabaseDriverFeature.class) && (!features.isFeaturePresent(Data.class) || features.isFeaturePresent(HibernateReactiveFeature.class))) {
+@if (features.isFeaturePresent(TestResources.class) &&
+    features.isFeaturePresent(DatabaseDriverFeature.class) &&
+     (!features.isFeaturePresent(Data.class) || features.isFeaturePresent(HibernateReactiveFeature.class) || features.isFeaturePresent(R2dbc.class))
+){
 @with? (String resourceName = features
     .getFeature(DatabaseDriverFeature.class)
     .flatMap(DatabaseDriverFeature::getDbType)
@@ -191,7 +198,10 @@ MavenBuild mavenBuild
                 <groupId>io.micronaut.testresources</groupId>
                 <artifactId>micronaut-test-resources-@resourceName</artifactId>
               </dependency>
-@if (features.isFeaturePresent(HibernateReactiveFeature.class) && features.isFeaturePresent(DatabaseDriverFeature.class) && !features.isFeaturePresent(MigrationFeature.class)) {
+@if ((features.isFeaturePresent(HibernateReactiveFeature.class) || features.isFeaturePresent(R2dbc.class))
+     && features.isFeaturePresent(DatabaseDriverFeature.class)
+     && !features.isFeaturePresent(MigrationFeature.class)
+) {
 @with? (Dependency driver = features.getFeature(DatabaseDriverFeature.class)
                                                       .flatMap(DatabaseDriverFeatureDependencies::getJavaClientDependency)
                                                       .map(Dependency.Builder::build)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/H2.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/H2.java
@@ -25,6 +25,9 @@ import java.util.Optional;
 @Singleton
 @Primary
 public class H2 extends DatabaseDriverFeature {
+
+    public static final String NAME = "h2";
+
     private static final Dependency.Builder DEPENDENCY_H2 = Dependency.builder()
             .groupId("com.h2database")
             .artifactId("h2")
@@ -38,7 +41,7 @@ public class H2 extends DatabaseDriverFeature {
     @Override
     @NonNull
     public String getName() {
-        return "h2";
+        return NAME;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/DataR2dbc.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/DataR2dbc.java
@@ -58,6 +58,11 @@ public class DataR2dbc implements R2dbcFeature, DataFeature, TransactionalNotSup
     }
 
     @Override
+    public int getOrder() {
+        return r2dbc.getOrder() - 1;
+    }
+
+    @Override
     public void apply(GeneratorContext generatorContext) {
         generatorContext.addDependency(DEPENDENCY_MICRONAUT_DATA_PROCESSOR);
         generatorContext.addDependency(DEPENDENCY_MICRONAUT_DATA_R2DBC);

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbc.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbc.java
@@ -25,12 +25,15 @@ import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.database.DatabaseDriverFeature;
 
+import io.micronaut.starter.feature.testresources.TestResources;
 import jakarta.inject.Singleton;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 @Singleton
 public class R2dbc implements R2dbcFeature {
+
+    public static final String NAME = "r2dbc";
 
     private static final Dependency DEPENDENCY_MICRONAUT_R2DBC_CORE = MicronautDependencyUtils.r2dbcDependency()
             .artifactId("micronaut-r2dbc-core")
@@ -51,7 +54,7 @@ public class R2dbc implements R2dbcFeature {
     @NonNull
     @Override
     public String getName() {
-        return "r2dbc";
+        return NAME;
     }
 
     @Override
@@ -96,13 +99,16 @@ public class R2dbc implements R2dbcFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.getFeature(DatabaseDriverFeature.class).ifPresent(dbFeature -> {
+        DatabaseDriverFeature dbFeature = generatorContext.getRequiredFeature(DatabaseDriverFeature.class);
+        if (!generatorContext.isFeaturePresent(TestResources.class)) {
             Map<String, Object> rdbcConfig = new LinkedHashMap<>();
             rdbcConfig.put(getUrlKey(), dbFeature.getR2dbcUrl());
             rdbcConfig.put(USERNAME_KEY, dbFeature.getDefaultUser());
             rdbcConfig.put(PASSWORD_KEY, dbFeature.getDefaultPassword());
             generatorContext.getConfiguration().putAll(rdbcConfig);
-        });
+        } else {
+            dbFeature.getDbType().ifPresent(type -> generatorContext.getConfiguration().put("r2dbc.datasources.default.db-type", type.toString()));
+        }
         if (!generatorContext.isFeaturePresent(DataR2dbc.class)) {
             generatorContext.addDependency(DEPENDENCY_MICRONAUT_R2DBC_CORE);
         }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbc.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbc.java
@@ -107,7 +107,7 @@ public class R2dbc implements R2dbcFeature {
             rdbcConfig.put(PASSWORD_KEY, dbFeature.getDefaultPassword());
             generatorContext.getConfiguration().putAll(rdbcConfig);
         } else {
-            dbFeature.getDbType().ifPresent(type -> generatorContext.getConfiguration().put("r2dbc.datasources.default.db-type", type.toString()));
+            dbFeature.getDbType().ifPresent(type -> generatorContext.getConfiguration().addNested("r2dbc.datasources.default.db-type", type.toString()));
         }
         if (!generatorContext.isFeaturePresent(DataR2dbc.class)) {
             generatorContext.addDependency(DEPENDENCY_MICRONAUT_R2DBC_CORE);

--- a/starter-core/src/main/java/io/micronaut/starter/feature/testresources/TestResources.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/testresources/TestResources.java
@@ -27,6 +27,7 @@ import io.micronaut.starter.feature.build.gradle.MicronautTestResourcesGradlePlu
 import io.micronaut.starter.feature.database.DatabaseDriverFeature;
 import io.micronaut.starter.feature.database.DatabaseDriverFeatureDependencies;
 import io.micronaut.starter.feature.database.HibernateReactiveFeature;
+import io.micronaut.starter.feature.database.r2dbc.R2dbc;
 import io.micronaut.starter.feature.migration.MigrationFeature;
 import jakarta.inject.Singleton;
 
@@ -67,7 +68,7 @@ public class TestResources implements Feature {
     public void apply(GeneratorContext generatorContext) {
         if (generatorContext.getBuildTool().isGradle()) {
             generatorContext.addBuildPlugin(MicronautTestResourcesGradlePlugin.builder().build());
-            if (generatorContext.isFeaturePresent(HibernateReactiveFeature.class)
+            if (isReactive(generatorContext)
                     && generatorContext.isFeaturePresent(DatabaseDriverFeature.class)
                     && !generatorContext.isFeaturePresent(MigrationFeature.class)) {
                 generatorContext.getFeature(DatabaseDriverFeature.class)
@@ -79,6 +80,10 @@ public class TestResources implements Feature {
             BuildProperties buildProperties = generatorContext.getBuildProperties();
             buildProperties.put(MICRONAUT_TEST_RESOURCES_ENABLED, StringUtils.TRUE);
         }
+    }
+
+    private boolean isReactive(GeneratorContext generatorContext) {
+        return generatorContext.isFeaturePresent(HibernateReactiveFeature.class) || generatorContext.isFeaturePresent(R2dbc.class);
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/DataR2dbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/DataR2dbcSpec.groovy
@@ -6,6 +6,13 @@ import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Features
+import io.micronaut.starter.feature.database.DatabaseDriverFeature
+import io.micronaut.starter.feature.database.H2
+import io.micronaut.starter.feature.database.MariaDB
+import io.micronaut.starter.feature.database.MySQL
+import io.micronaut.starter.feature.database.Oracle
+import io.micronaut.starter.feature.database.PostgreSQL
+import io.micronaut.starter.feature.database.SQLServer
 import io.micronaut.starter.feature.database.jdbc.JdbcFeature
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
@@ -68,6 +75,40 @@ class DataR2dbcSpec extends ApplicationContextSpec implements CommandOutputFixtu
         template.contains("runtimeOnly(\"io.r2dbc:r2dbc-h2\")")
         !template.contains("""runtimeOnly("com.h2database:h2")""")
         !template.contains("implementation(\"io.micronaut.sql:micronaut-jdbc-hikari\")")
+    }
+
+    void "test dependencies are present for gradle with #featureClassName"(Class<DatabaseDriverFeature> db) {
+        when:
+        def feature = beanContext.getBean(db)
+
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features([DataR2dbc.NAME, feature.name])
+                .render()
+
+        def jdbcDriver = renderDependency(feature.javaClientDependency.get().build())
+        def r2dbcDriver = renderDependency(feature.r2DbcDependency.get().build())
+
+        then: 'test-resources is applied for all but H2'
+        template.contains('id("io.micronaut.test-resources") version') == isNotH2
+
+        and: 'the processor and correct version of micronaut-data-r2dbc is applied'
+        template.contains('annotationProcessor("io.micronaut.data:micronaut-data-processor")')
+        template.contains('implementation("io.micronaut.data:micronaut-data-r2dbc")')
+        !template.contains('implementation("io.micronaut.r2dbc:micronaut-r2dbc-core")')
+
+        and: 'the r2dbc driver is applied'
+        template.contains($/runtimeOnly("$r2dbcDriver")/$)
+
+        and: 'for test resources, the JDBC driver is applied to the test-resources service unless it is H2'
+        template.contains($/testResourcesService("$jdbcDriver")/$) == isNotH2
+
+        and: 'the jdbc driver is not applied'
+        !template.contains($/runtimeOnly("$jdbcDriver")/$)
+
+        where:
+        db << [H2, PostgreSQL, MySQL, MariaDB, Oracle, SQLServer]
+        featureClassName = db.simpleName
+        isNotH2 = db != H2
     }
 
     void "test migration dependencies are present for gradle"() {
@@ -159,34 +200,29 @@ class DataR2dbcSpec extends ApplicationContextSpec implements CommandOutputFixtu
     }
 
     @Unroll
-    void "test config #driver and #dialect adn build #buildTool"(BuildTool buildTool) {
+    void "test config #driver and build #buildTool"(BuildTool buildTool, Class<DatabaseDriverFeature> featureClass) {
         given:
         Options options = new Options(null, null, buildTool)
-        GeneratorContext ctx = buildGeneratorContext([DataR2dbc.NAME, driver], options)
+        GeneratorContext ctx = buildGeneratorContext([DataR2dbc.NAME, featureClass.NAME], options)
+        def feature = ctx.getRequiredFeature(featureClass)
+        def dialect = feature.dataDialect
 
-        expect:
-        ctx.configuration.containsKey("r2dbc.datasources.default.url")
+        expect: 'the URL is only applied for H2, as otherwise test-resources will provide it'
+        ctx.configuration.containsKey("r2dbc.datasources.default.url") == isH2
+
+        and: 'dialect should always be set'
         ctx.configuration.get("r2dbc.datasources.default.dialect") == dialect
 
+        and: 'db-type should be set for non-h2 databases'
+        if (isH2) {
+            assert ctx.configuration.get("r2dbc.datasources.default.db-type") == null
+        } else {
+            assert ctx.configuration.get("r2dbc.datasources.default.db-type") == feature.dbType.get().toString()
+        }
+
         where:
-        buildTool               | driver      | dialect
-        BuildTool.MAVEN         | "h2"        | "H2"
-        BuildTool.GRADLE_KOTLIN | "h2"        | "H2"
-        BuildTool.GRADLE        | "h2"        | "H2"
-        BuildTool.MAVEN         | "postgres"  | "POSTGRES"
-        BuildTool.GRADLE_KOTLIN | "postgres"  | "POSTGRES"
-        BuildTool.GRADLE        | "postgres"  | "POSTGRES"
-        BuildTool.MAVEN         | "mysql"     | "MYSQL"
-        BuildTool.GRADLE_KOTLIN | "mysql"     | "MYSQL"
-        BuildTool.GRADLE        | "mysql"     | "MYSQL"
-        BuildTool.MAVEN         | "mariadb"   | "MYSQL"
-        BuildTool.GRADLE_KOTLIN | "mariadb"   | "MYSQL"
-        BuildTool.GRADLE        | "mariadb"   | "MYSQL"
-        BuildTool.MAVEN         | "sqlserver" | "SQL_SERVER"
-        BuildTool.GRADLE_KOTLIN | "sqlserver" | "SQL_SERVER"
-        BuildTool.GRADLE        | "sqlserver" | "SQL_SERVER"
-        BuildTool.MAVEN         | "oracle"    | "ORACLE"
-        BuildTool.MAVEN         | "oracle"    | "ORACLE"
-        BuildTool.GRADLE        | "oracle"    | "ORACLE"
+        [buildTool, featureClass] << [BuildTool.values(), [H2, PostgreSQL, MySQL, MariaDB, Oracle, SQLServer]].combinations()
+        driver = featureClass.simpleName
+        isH2 = featureClass == H2
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/DataR2dbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/DataR2dbcSpec.groovy
@@ -19,7 +19,6 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Options
 import spock.lang.Shared
-import spock.lang.Unroll
 
 class DataR2dbcSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
@@ -305,7 +304,6 @@ class DataR2dbcSpec extends ApplicationContextSpec implements CommandOutputFixtu
         featureClassName = db.simpleName
     }
 
-    @Unroll
     void "test config #driver and build #buildTool"(BuildTool buildTool, Class<DatabaseDriverFeature> featureClass) {
         given:
         Options options = new Options(null, null, buildTool)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/DataR2dbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/DataR2dbcSpec.groovy
@@ -14,6 +14,7 @@ import io.micronaut.starter.feature.database.Oracle
 import io.micronaut.starter.feature.database.PostgreSQL
 import io.micronaut.starter.feature.database.SQLServer
 import io.micronaut.starter.feature.database.jdbc.JdbcFeature
+import io.micronaut.starter.feature.migration.Flyway
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Options
@@ -127,7 +128,7 @@ class DataR2dbcSpec extends ApplicationContextSpec implements CommandOutputFixtu
         !template.contains("implementation(\"io.micronaut.sql:micronaut-jdbc-hikari\")")
     }
 
-    void "test dependencies are present for maven"() {
+    void "test dependencies are present for maven and H2"() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .features(["data-r2dbc"])
@@ -160,8 +161,59 @@ class DataR2dbcSpec extends ApplicationContextSpec implements CommandOutputFixtu
         noExceptionThrown()
         semanticVersionOptional.isPresent()
     }
-    
-    void "test migration dependencies are present for maven"() {
+
+    void "test dependencies are present for maven and #featureClassName"(Class<DatabaseDriverFeature> db) {
+        when:
+        def feature = beanContext.getBean(db)
+
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features([DataR2dbc.NAME, db.NAME])
+                .render()
+        def project = new XmlParser().parseText(template)
+        def micronautPlugin = project.build.plugins.plugin.find { it.artifactId.text() == 'micronaut-maven-plugin' }
+        def testResourcesModuleName = feature.dbType.get().r2dbcTestResourcesModuleName
+        def jdbcDriverDependency = feature.javaClientDependency.get().build()
+        def r2dbcDriverDependency = feature.r2DbcDependency.get().build()
+
+        then:
+        with(project.build.plugins.plugin.find { it.artifactId.text() == "maven-compiler-plugin" }) {
+            def artifacts = configuration.annotationProcessorPaths.path.collect { "${it.groupId.text()}:${it.artifactId.text()}".toString() }
+            artifacts.contains("io.micronaut.data:micronaut-data-processor")
+        }
+        with(project.dependencies.dependency.find { it.artifactId.text() == "micronaut-data-r2dbc" }) {
+            scope.text() == 'compile'
+            groupId.text() == 'io.micronaut.data'
+        }
+        !project.dependencies.dependency.find { it.artifactId.text() == "micronaut-r2dbc-core" }
+        with(project.dependencies.dependency.find { it.artifactId.text() == r2dbcDriverDependency.artifactId }) {
+            scope.text() == 'runtime'
+            groupId.text() == r2dbcDriverDependency.groupId
+        }
+        !project.dependencies.dependency.find { it.artifactId.text() == "h2" }
+
+        jdbcFeature.name == 'jdbc-hikari'
+        !project.dependencies.dependency.find { it.artifactId.text() == "micronaut-jdbc-hikari" }
+
+        with(micronautPlugin.configuration.testResourcesDependencies.dependency.find { it.groupId.text() == "io.micronaut.testresources" }) {
+            it.artifactId.text() == "micronaut-test-resources-$testResourcesModuleName"
+        }
+        with(micronautPlugin.configuration.testResourcesDependencies.dependency.find { it.groupId.text() == jdbcDriverDependency.groupId }) {
+            it.artifactId.text() == jdbcDriverDependency.artifactId
+        }
+
+        when:
+        Optional<SemanticVersion> semanticVersionOptional = parsePropertySemanticVersion(template, "micronaut.data.version")
+
+        then:
+        noExceptionThrown()
+        semanticVersionOptional.isPresent()
+
+        where:
+        db << [PostgreSQL, MySQL, MariaDB, Oracle, SQLServer]
+        featureClassName = db.simpleName
+    }
+
+    void "test migration dependencies are present for maven and H2"() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .features(["data-r2dbc", "flyway"])
@@ -197,6 +249,60 @@ class DataR2dbcSpec extends ApplicationContextSpec implements CommandOutputFixtu
         then:
         noExceptionThrown()
         semanticVersionOptional.isPresent()
+    }
+
+    void "test migration dependencies are present for maven and #featureClassName"(Class<DatabaseDriverFeature> db) {
+        when:
+        def feature = beanContext.getBean(db)
+
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .features([DataR2dbc.NAME, Flyway.NAME, db.NAME])
+                .render()
+        def project = new XmlParser().parseText(template)
+        def micronautPlugin = project.build.plugins.plugin.find { it.artifactId.text() == 'micronaut-maven-plugin' }
+        def testResourcesModuleName = feature.dbType.get().r2dbcTestResourcesModuleName
+        def jdbcDriverDependency = feature.javaClientDependency.get().build()
+        def r2dbcDriverDependency = feature.r2DbcDependency.get().build()
+
+        then:
+        with(project.build.plugins.plugin.find { it.artifactId.text() == "maven-compiler-plugin" }) {
+            def artifacts = configuration.annotationProcessorPaths.path.collect { "${it.groupId.text()}:${it.artifactId.text()}".toString() }
+            artifacts.contains("io.micronaut.data:micronaut-data-processor")
+        }
+        with(project.dependencies.dependency.find { it.artifactId.text() == "micronaut-data-r2dbc" }) {
+            scope.text() == 'compile'
+            groupId.text() == 'io.micronaut.data'
+        }
+        !project.dependencies.dependency.find { it.artifactId.text() == "micronaut-r2dbc-core" }
+        with(project.dependencies.dependency.find { it.artifactId.text() == r2dbcDriverDependency.artifactId }) {
+            scope.text() == 'runtime'
+            groupId.text() == r2dbcDriverDependency.groupId
+        }
+        with(project.dependencies.dependency.find { it.artifactId.text() == jdbcDriverDependency.artifactId }) {
+            scope.text() == 'runtime'
+            groupId.text() == jdbcDriverDependency.groupId
+        }
+
+        with(micronautPlugin.configuration.testResourcesDependencies.dependency.find { it.groupId.text() == "io.micronaut.testresources" }) {
+            it.artifactId.text() == "micronaut-test-resources-$testResourcesModuleName"
+        }
+
+        and: 'We do not add the jdbc driver to the test resources dependencies as its already a dependency'
+        !micronautPlugin.configuration.testResourcesDependencies.dependency.find { it.groupId.text() == jdbcDriverDependency.groupId }
+
+        jdbcFeature.name == 'jdbc-hikari'
+        !project.dependencies.dependency.find { it.artifactId.text() == "micronaut-jdbc-hikari" }
+
+        when:
+        Optional<SemanticVersion> semanticVersionOptional = parsePropertySemanticVersion(template, "micronaut.data.version")
+
+        then:
+        noExceptionThrown()
+        semanticVersionOptional.isPresent()
+
+        where:
+        db << [PostgreSQL, MySQL, MariaDB, Oracle, SQLServer]
+        featureClassName = db.simpleName
     }
 
     @Unroll

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/R2dbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/R2dbcSpec.groovy
@@ -3,6 +3,12 @@ package io.micronaut.starter.feature.database.r2dbc
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.feature.database.DatabaseDriverFeature
+import io.micronaut.starter.feature.database.H2
+import io.micronaut.starter.feature.database.MariaDB
+import io.micronaut.starter.feature.database.MySQL
+import io.micronaut.starter.feature.database.Oracle
+import io.micronaut.starter.feature.database.PostgreSQL
+import io.micronaut.starter.feature.database.SQLServer
 import io.micronaut.starter.feature.database.jdbc.JdbcFeature
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
@@ -24,6 +30,40 @@ class R2dbcSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
         where:
         driver << (beanContext.getBeansOfType(DatabaseDriverFeature)*.name) - "oracle-cloud-atp"
+    }
+
+    void "test dependencies are present for gradle with #featureClassName"(Class<DatabaseDriverFeature> db) {
+        when:
+        def feature = beanContext.getBean(db)
+
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features([R2dbc.NAME, feature.name])
+                .render()
+
+        def jdbcDriver = renderDependency(feature.javaClientDependency.get().build())
+        def r2dbcDriver = renderDependency(feature.r2DbcDependency.get().build())
+
+        then: 'test-resources is applied for all but H2'
+        template.contains('id("io.micronaut.test-resources") version') == isNotH2
+
+        and: 'the data processor is not applied'
+        !template.contains('annotationProcessor("io.micronaut.data:micronaut-data-processor")')
+        !template.contains('implementation("io.micronaut.data:micronaut-data-r2dbc")')
+        template.contains('implementation("io.micronaut.r2dbc:micronaut-r2dbc-core")')
+
+        and: 'the r2dbc driver is applied'
+        template.contains($/runtimeOnly("$r2dbcDriver")/$)
+
+        and: 'for test resources, the JDBC driver is applied to the test-resources service unless it is H2'
+        template.contains($/testResourcesService("$jdbcDriver")/$) == isNotH2
+
+        and: 'the jdbc driver is not applied'
+        !template.contains($/runtimeOnly("$jdbcDriver")/$)
+
+        where:
+        db << [H2, PostgreSQL, MySQL, MariaDB, Oracle, SQLServer]
+        featureClassName = db.simpleName
+        isNotH2 = db != H2
     }
 
     @Unroll

--- a/starter-core/src/test/groovy/io/micronaut/starter/fixture/CommandOutputFixture.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/fixture/CommandOutputFixture.groovy
@@ -6,6 +6,7 @@ import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.application.OperatingSystem
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.application.generator.ProjectGenerator
+import io.micronaut.starter.build.dependencies.Dependency
 import io.micronaut.starter.io.ConsoleOutput
 import io.micronaut.starter.io.MapOutputHandler
 import io.micronaut.starter.io.OutputHandler
@@ -58,5 +59,9 @@ trait CommandOutputFixture {
                 handler,
                 generatorContext)
         handler.getProject()
+    }
+
+    String renderDependency(Dependency dependency) {
+        return "${dependency.groupId}:${dependency.artifactId}${dependency.version == null ? '' : ":${dependency.version}"}"
     }
 }

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/DataR2dbcSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/DataR2dbcSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.starter.core.test.feature.database
 
+import io.micronaut.starter.feature.database.MySQL
 import io.micronaut.starter.feature.database.r2dbc.DataR2dbc
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
@@ -15,7 +16,7 @@ class DataR2dbcSpec extends CommandSpec {
 
     void "test maven data-r2dbc with #language"(Language language) {
         when:
-        generateProject(language, BuildTool.MAVEN, [DataR2dbc.NAME])
+        generateProject(language, BuildTool.MAVEN, [DataR2dbc.NAME, MySQL.NAME])
         String output = executeMaven("compile test")
 
         then:
@@ -27,7 +28,7 @@ class DataR2dbcSpec extends CommandSpec {
 
     void "test gradle data-r2dbc with #language"(Language language) {
         when:
-        generateProject(language, BuildTool.GRADLE, [DataR2dbc.NAME])
+        generateProject(language, BuildTool.GRADLE, [DataR2dbc.NAME, MySQL.NAME])
         BuildResult result = executeGradle("test")
 
         then:

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/DataR2dbcSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/DataR2dbcSpec.groovy
@@ -1,10 +1,10 @@
 package io.micronaut.starter.core.test.feature.database
 
+import io.micronaut.starter.feature.database.r2dbc.DataR2dbc
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.test.CommandSpec
 import org.gradle.testkit.runner.BuildResult
-import spock.lang.Unroll
 
 class DataR2dbcSpec extends CommandSpec {
 
@@ -13,10 +13,9 @@ class DataR2dbcSpec extends CommandSpec {
         return "dataR2dbc"
     }
 
-    @Unroll
     void "test maven data-r2dbc with #language"(Language language) {
         when:
-        generateProject(language, BuildTool.MAVEN, ["data-r2dbc"])
+        generateProject(language, BuildTool.MAVEN, [DataR2dbc.NAME])
         String output = executeMaven("compile test")
 
         then:
@@ -26,10 +25,9 @@ class DataR2dbcSpec extends CommandSpec {
         language << Language.values()
     }
 
-    @Unroll
     void "test gradle data-r2dbc with #language"(Language language) {
         when:
-        generateProject(language, BuildTool.GRADLE, ["data-r2dbc"])
+        generateProject(language, BuildTool.GRADLE, [DataR2dbc.NAME])
         BuildResult result = executeGradle("test")
 
         then:

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/R2dbcSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/R2dbcSpec.groovy
@@ -1,0 +1,40 @@
+package io.micronaut.starter.core.test.feature.database
+
+import io.micronaut.starter.feature.database.MySQL
+import io.micronaut.starter.feature.database.r2dbc.R2dbc
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.test.CommandSpec
+import org.gradle.testkit.runner.BuildResult
+
+class R2dbcSpec extends CommandSpec {
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "r2dbc"
+    }
+
+    void "test maven r2dbc with #language"(Language language) {
+        when:
+        generateProject(language, BuildTool.MAVEN, [R2dbc.NAME, MySQL.NAME])
+        String output = executeMaven("compile test")
+
+        then:
+        output?.contains("BUILD SUCCESS")
+
+        where:
+        language << Language.values()
+    }
+
+    void "test gradle r2dbc with #language"(Language language) {
+        when:
+        generateProject(language, BuildTool.GRADLE, [R2dbc.NAME, MySQL.NAME])
+        BuildResult result = executeGradle("test")
+
+        then:
+        result?.output?.contains("BUILD SUCCESS")
+
+        where:
+        language << Language.values()
+    }
+}


### PR DESCRIPTION
We had intermittent failures as R2dbc and DataR2dbc had the same ordering so the result was non-repeatable.

This PR applies the correct ordering.

We also did not handle Test Resources properly, we handled it for HibernateReactive, but R2DBC was missed.