### PR TITLE
Several r2dbc fixes for starter

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/H2.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/H2.java
@@ -31,7 +31,8 @@ public class H2 extends DatabaseDriverFeature {
     private static final Dependency.Builder DEPENDENCY_H2 = Dependency.builder()
             .groupId("com.h2database")
             .artifactId("h2")
-            .runtime();
+            .runtime()
+            .template();
 
     private static final Dependency.Builder DEPENDENCY_R2DBC_H2 = Dependency.builder()
             .groupId("io.r2dbc")

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
@@ -68,6 +68,10 @@ public class TestContainers implements Feature {
                     testConfig.put(driverConfiguration.getUrlKey(), url);
                 });
                 generatorContext.addDependency(testContainerTestDependency("r2dbc"));
+                // TestContainers requires the database module, a jdbc driver AND the r2dbc module: see https://www.testcontainers.org/modules/databases/r2dbc/
+                driverFeature.getJavaClientDependency().ifPresent(d -> generatorContext.addDependency(d.testRuntime()));
+                artifactIdForDriverFeature(driverFeature).ifPresent(dependencyArtifactId ->
+                        generatorContext.addDependency(testContainerTestDependency(dependencyArtifactId)));
             });
             generatorContext.getFeature(DatabaseDriverConfigurationFeature.class).ifPresent(driverConfiguration -> {
                 String driver = "org.testcontainers.jdbc.ContainerDatabaseDriver";

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
@@ -125,7 +125,7 @@ public class TestContainers implements Feature {
     }
 
     @NonNull
-    private static Optional<String> artifactIdForDriverFeature(@NonNull DatabaseDriverFeature driverFeature) {
+    public static Optional<String> artifactIdForDriverFeature(@NonNull DatabaseDriverFeature driverFeature) {
         if (driverFeature instanceof MySQL) {
             return Optional.of("mysql");
         } else if (driverFeature instanceof PostgreSQL) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbc.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import io.micronaut.starter.feature.database.jdbc.Hikari;
 import io.micronaut.starter.feature.database.jdbc.JdbcFeature;
 import io.micronaut.starter.feature.migration.MigrationFeature;
 import io.micronaut.starter.feature.testresources.TestResources;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import java.util.LinkedHashMap;
@@ -52,6 +53,12 @@ public class R2dbc implements R2dbcFeature {
     private final DatabaseDriverFeature defaultDbFeature;
     private final Hikari hikari;
 
+    @Deprecated
+    public R2dbc(DatabaseDriverFeature defaultDbFeature) {
+        this(defaultDbFeature, new Hikari(defaultDbFeature));
+    }
+
+    @Inject
     public R2dbc(DatabaseDriverFeature defaultDbFeature, Hikari hikari) {
         this.defaultDbFeature = defaultDbFeature;
         this.hikari = hikari;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbc.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbc.java
@@ -25,8 +25,12 @@ import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.database.DatabaseDriverFeature;
 
+import io.micronaut.starter.feature.database.jdbc.Hikari;
+import io.micronaut.starter.feature.database.jdbc.JdbcFeature;
+import io.micronaut.starter.feature.migration.MigrationFeature;
 import io.micronaut.starter.feature.testresources.TestResources;
 import jakarta.inject.Singleton;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -46,9 +50,11 @@ public class R2dbc implements R2dbcFeature {
     private static final String PASSWORD_KEY = PREFIX + "password";
 
     private final DatabaseDriverFeature defaultDbFeature;
+    private final Hikari hikari;
 
-    public R2dbc(DatabaseDriverFeature defaultDbFeature) {
+    public R2dbc(DatabaseDriverFeature defaultDbFeature, Hikari hikari) {
         this.defaultDbFeature = defaultDbFeature;
+        this.hikari = hikari;
     }
 
     @NonNull
@@ -72,6 +78,9 @@ public class R2dbc implements R2dbcFeature {
     public void processSelectedFeatures(FeatureContext featureContext) {
         if (!featureContext.isPresent(DatabaseDriverFeature.class)) {
             featureContext.addFeature(defaultDbFeature);
+        }
+        if (featureContext.isPresent(MigrationFeature.class) && !featureContext.isPresent(JdbcFeature.class)) {
+            featureContext.addFeature(hikari);
         }
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbcFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbcFeatureValidator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.database.r2dbc;
+
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.database.TestContainers;
+import io.micronaut.starter.feature.migration.MigrationFeature;
+import io.micronaut.starter.feature.validation.FeatureValidator;
+import io.micronaut.starter.options.Options;
+import jakarta.inject.Singleton;
+
+import java.util.Set;
+
+@Singleton
+public class R2dbcFeatureValidator implements FeatureValidator {
+
+    @Override
+    public void validatePreProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+    }
+
+    @Override
+    public void validatePostProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+        if (containsR2dbcFeature(features) && hasMigrationFeature(features) && hasTestContainersFeature(features)) {
+            throw new IllegalArgumentException("Testcontainers is not supported with R2DBC and Migration. Please remove the TestContainers feature to use Test Resources instead.");
+        }
+    }
+
+    private static boolean hasTestContainersFeature(Set<Feature> features) {
+        return features.stream().anyMatch(TestContainers.class::isInstance);
+    }
+
+    private static boolean hasMigrationFeature(Set<Feature> features) {
+        return features.stream().anyMatch(f -> MigrationFeature.class.isAssignableFrom(f.getClass()));
+    }
+
+    private static boolean containsR2dbcFeature(Set<Feature> features) {
+        return features.stream().anyMatch(f -> R2dbcFeature.class.isAssignableFrom(f.getClass()));
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbcFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbcFeatureValidator.java
@@ -34,20 +34,18 @@ public class R2dbcFeatureValidator implements FeatureValidator {
 
     @Override
     public void validatePostProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
-        if (containsR2dbcFeature(features) && hasMigrationFeature(features) && hasTestContainersFeature(features)) {
+        if (hasSubclassOf(features, R2dbcFeature.class) &&
+                hasSubclassOf(features, MigrationFeature.class) &&
+                hasInstance(features, TestContainers.class)) {
             throw new IllegalArgumentException("Testcontainers is not supported with R2DBC and Migration. Please remove the TestContainers feature to use Test Resources instead.");
         }
     }
 
-    private static boolean hasTestContainersFeature(Set<Feature> features) {
-        return features.stream().anyMatch(TestContainers.class::isInstance);
+    private static boolean hasInstance(Set<Feature> features, Class<? extends Feature> featureClass) {
+        return features.stream().anyMatch(featureClass::isInstance);
     }
 
-    private static boolean hasMigrationFeature(Set<Feature> features) {
-        return features.stream().anyMatch(f -> MigrationFeature.class.isAssignableFrom(f.getClass()));
-    }
-
-    private static boolean containsR2dbcFeature(Set<Feature> features) {
-        return features.stream().anyMatch(f -> R2dbcFeature.class.isAssignableFrom(f.getClass()));
+    private static boolean hasSubclassOf(Set<Feature> features, Class<? extends Feature> featureClass) {
+        return features.stream().anyMatch(f -> featureClass.isAssignableFrom(f.getClass()));
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifier.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifier.groovy
@@ -52,7 +52,7 @@ class GradleBuildTestVerifier implements BuildTestVerifier {
 
     @Override
     boolean hasTestResourceDependency(String groupId, String artifactId) {
-        hasDependency(groupId, artifactId, "testResourcesService")
+        hasDependency(groupId, artifactId, Scope.TEST_RESOURCES_SERVICE)
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/R2dbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/R2dbcSpec.groovy
@@ -11,12 +11,26 @@ import io.micronaut.starter.feature.database.MySQL
 import io.micronaut.starter.feature.database.Oracle
 import io.micronaut.starter.feature.database.PostgreSQL
 import io.micronaut.starter.feature.database.SQLServer
+import io.micronaut.starter.feature.database.TestContainers
 import io.micronaut.starter.feature.database.jdbc.JdbcFeature
+import io.micronaut.starter.feature.migration.Flyway
+import io.micronaut.starter.feature.migration.Liquibase
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Options
 
 class R2dbcSpec extends ApplicationContextSpec implements CommandOutputFixture {
+
+    void "check validator with TestContainers and #migrator"() {
+        when:
+        generate([R2dbc.NAME, migrator, TestContainers.NAME])
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        migrator << [Flyway.NAME, Liquibase.NAME]
+    }
 
     void "test dependencies are present for gradle with #featureClassName"(Class<DatabaseDriverFeature> db) {
         when:

--- a/starter-core/src/test/groovy/io/micronaut/starter/fixture/CommandOutputFixture.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/fixture/CommandOutputFixture.groovy
@@ -6,7 +6,6 @@ import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.application.OperatingSystem
 import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.application.generator.ProjectGenerator
-import io.micronaut.starter.build.dependencies.Dependency
 import io.micronaut.starter.io.ConsoleOutput
 import io.micronaut.starter.io.MapOutputHandler
 import io.micronaut.starter.io.OutputHandler
@@ -59,9 +58,5 @@ trait CommandOutputFixture {
                 handler,
                 generatorContext)
         handler.getProject()
-    }
-
-    String renderDependency(Dependency dependency) {
-        return "${dependency.groupId}:${dependency.artifactId}${dependency.version == null ? '' : ":${dependency.version}"}"
     }
 }

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/DataR2dbcSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/DataR2dbcSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.starter.core.test.feature.database
 
 import io.micronaut.starter.feature.database.MySQL
+import io.micronaut.starter.feature.database.TestContainers
 import io.micronaut.starter.feature.database.r2dbc.DataR2dbc
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
@@ -26,6 +27,15 @@ class DataR2dbcSpec extends CommandSpec {
         language << Language.values()
     }
 
+    void "test maven data-r2dbc with TestContainers"() {
+        when:
+        generateProject(Language.JAVA, BuildTool.MAVEN, [DataR2dbc.NAME, MySQL.NAME, TestContainers.NAME])
+        String output = executeMaven("compile test")
+
+        then:
+        output?.contains("BUILD SUCCESS")
+    }
+
     void "test gradle data-r2dbc with #language"(Language language) {
         when:
         generateProject(language, BuildTool.GRADLE, [DataR2dbc.NAME, MySQL.NAME])
@@ -36,5 +46,14 @@ class DataR2dbcSpec extends CommandSpec {
 
         where:
         language << Language.values()
+    }
+
+    void "test gradle data-r2dbc with TestContainers"() {
+        when:
+        generateProject(Language.JAVA, BuildTool.GRADLE, [DataR2dbc.NAME, MySQL.NAME])
+        BuildResult result = executeGradle("test")
+
+        then:
+        result?.output?.contains("BUILD SUCCESS")
     }
 }

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/R2dbcSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/R2dbcSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.starter.core.test.feature.database
 
 import io.micronaut.starter.feature.database.MySQL
+import io.micronaut.starter.feature.database.TestContainers
 import io.micronaut.starter.feature.database.r2dbc.R2dbc
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
@@ -26,6 +27,15 @@ class R2dbcSpec extends CommandSpec {
         language << Language.values()
     }
 
+    void "test maven data-r2dbc with TestContainers"() {
+        when:
+        generateProject(Language.JAVA, BuildTool.MAVEN, [R2dbc.NAME, MySQL.NAME, TestContainers.NAME])
+        String output = executeMaven("compile test")
+
+        then:
+        output?.contains("BUILD SUCCESS")
+    }
+
     void "test gradle r2dbc with #language"(Language language) {
         when:
         generateProject(language, BuildTool.GRADLE, [R2dbc.NAME, MySQL.NAME])
@@ -36,5 +46,14 @@ class R2dbcSpec extends CommandSpec {
 
         where:
         language << Language.values()
+    }
+
+    void "test gradle data-r2dbc with TestContainers"() {
+        when:
+        generateProject(Language.JAVA, BuildTool.GRADLE, [R2dbc.NAME, MySQL.NAME])
+        BuildResult result = executeGradle("test")
+
+        then:
+        result?.output?.contains("BUILD SUCCESS")
     }
 }


### PR DESCRIPTION
### R2dbc with TestContainers and a Migration didn't work as we end up with 2 datasources.

I added a Validator to stop this combination

### R2dbc with Test containers requires extra dependencies

If you use R2dbc with TestContainers, you also need to pull in the db lib from testcontainers and the jdbc-driver for that db.

See https://www.testcontainers.org/modules/databases/r2dbc/

### Migration requires a pool

If you select r2dbc and flyway (for example), you don't get a connection pool, so you don't get a datasource that the migration can use, so you get no migration.

This PR fixes that

Closes #1588 