### PR TITLE
Create feature for Retry

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/retry/Retry.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/retry/Retry.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.retry;
+
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
+import io.micronaut.starter.feature.Category;
+import io.micronaut.starter.feature.Feature;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class Retry implements Feature {
+
+    @Override
+    public boolean isVisible() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "retry";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Retry";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Adds support for fallbacks or retries from operation failure.";
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        generatorContext.addDependency(MicronautDependencyUtils.coreDependency()
+                .artifactId("micronaut-retry")
+                .compile());
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
+    public String getMicronautDocumentation() {
+        return "https://docs.micronaut.io/latest/guide/#retry";
+    }
+
+    @Override
+    public String getCategory() {
+        return Category.API;
+    }
+
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/retry/Retry.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/retry/Retry.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.feature.retry;
 
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
@@ -25,6 +26,13 @@ import jakarta.inject.Singleton;
 @Singleton
 public class Retry implements Feature {
 
+    public static final String NAME = "retry";
+
+    private static final Dependency DEPENDENCY_RETRY = MicronautDependencyUtils
+            .coreDependency()
+            .artifactId("micronaut-retry")
+            .compile().build();
+
     @Override
     public boolean isVisible() {
         return false;
@@ -32,12 +40,12 @@ public class Retry implements Feature {
 
     @Override
     public String getName() {
-        return "retry";
+        return NAME;
     }
 
     @Override
     public String getTitle() {
-        return "Retry";
+        return "Micronaut Retry";
     }
 
     @Override
@@ -47,9 +55,7 @@ public class Retry implements Feature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.addDependency(MicronautDependencyUtils.coreDependency()
-                .artifactId("micronaut-retry")
-                .compile());
+        generatorContext.addDependency(DEPENDENCY_RETRY);
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/retry/RetrySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/retry/RetrySpec.groovy
@@ -1,0 +1,65 @@
+package io.micronaut.starter.feature.retry
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.feature.build.gradle.MicronautGradleEnterprise
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import spock.lang.PendingFeature
+import spock.lang.Unroll
+
+class RetrySpec extends ApplicationContextSpec implements CommandOutputFixture {
+
+    @PendingFeature(reason = 'The Retry feature is for Micronaut 4, and should be visible for Starter 4.0.0')
+    void "Retry feature is visible"() {
+        expect:
+        beanContext.getBean(Retry).isVisible()
+    }
+
+    void 'test readme.md with feature retry contains links to micronaut docs'() {
+        when:
+        def output = generate(['retry'])
+        def readme = output["README.md"]
+
+        then:
+        readme
+        readme.contains("https://docs.micronaut.io/latest/guide/#retry")
+    }
+
+    @Unroll
+    void 'test gradle retry feature for language=#language'() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(language)
+                .features(['retry'])
+                .render()
+
+        then:
+        template.contains('implementation("io.micronaut:micronaut-retry")')
+
+        where:
+        language << Language.values().toList()
+    }
+
+    @Unroll
+    void 'test maven retry feature for language=#language'() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
+                .features(['retry'])
+                .render()
+
+        then:
+        template.contains("""
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-retry</artifactId>
+      <scope>compile</scope>
+    </dependency>
+""")
+
+        where:
+        language << Language.values().toList()
+    }
+}


### PR DESCRIPTION
see https://github.com/micronaut-projects/micronaut-core/pull/8235

This is really for Micronaut 4. Once the 4.0.x branch is ready and this gets merged up, then `Retry.isVisble()` should be changed to no longer return `false`, and the test for it in `RetrySpec` should remove the `@PedningFeature` annotation. 

Until then closing this PR should not close #1512
