### PR TITLE
Expand support of Azure functions to include jdk 17 

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureFeatureValidator.java
@@ -19,10 +19,9 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.validation.FeatureValidator;
 import io.micronaut.starter.options.BuildTool;
-import io.micronaut.starter.options.JdkVersion;
 import io.micronaut.starter.options.Options;
-
 import jakarta.inject.Singleton;
+
 import java.util.Set;
 
 @Singleton
@@ -39,8 +38,11 @@ public class AzureFeatureValidator implements FeatureValidator  {
             if (options.getBuildTool() == BuildTool.GRADLE_KOTLIN) {
                 throw new IllegalArgumentException("The Azure Gradle plugin currently does not support the Kotlin Gradle DSL.");
             }
-            if (!(options.getJavaVersion() == JdkVersion.JDK_8 || options.getJavaVersion() == JdkVersion.JDK_11)) {
-                throw new IllegalArgumentException("The Azure Functions runtime only supports Java 8 or Java 11.");
+            switch (options.getJavaVersion()) {
+                case JDK_8: case JDK_11: case JDK_17:
+                    break;
+                default:
+                    throw new IllegalArgumentException("The Azure Functions runtime only supports Java 8, Java 11 or Java 11.");
             }
         }
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureFeatureValidator.java
@@ -38,12 +38,6 @@ public class AzureFeatureValidator implements FeatureValidator  {
             if (options.getBuildTool() == BuildTool.GRADLE_KOTLIN) {
                 throw new IllegalArgumentException("The Azure Gradle plugin currently does not support the Kotlin Gradle DSL.");
             }
-            switch (options.getJavaVersion()) {
-                case JDK_8: case JDK_11: case JDK_17:
-                    break;
-                default:
-                    throw new IllegalArgumentException("The Azure Functions runtime only supports Java 8, Java 11 or Java 11.");
-            }
         }
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
@@ -1,6 +1,5 @@
 package io.micronaut.starter.feature.function.azure
 
-
 import io.micronaut.core.version.SemanticVersion
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
@@ -11,37 +10,12 @@ import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
-import spock.lang.PendingFeature
 import spock.lang.Unroll
 
 class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
-    // PendingFeature doesn't work here, because "if every iteration of a data-driven test passes it will be reported as error"
-    // and apparently zero iterations means every iteration
-    @PendingFeature(reason = "This test won't execute until we add another Java version, e.g. `JdkVersion.JDK_19`")
     @Unroll("#jdkVersion not supported for #feature")
-    void "verify for not supported JDK Versions by azure-function an IllegalArgumentException is thrown"(ApplicationType applicationType, JdkVersion jdkVersion, String feature) {
-        when:
-        generate(
-                applicationType,
-                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, jdkVersion),
-                [feature],
-        )
-        then:
-        thrown(IllegalArgumentException)
-
-        where:
-        [applicationType, jdkVersion, feature] << [
-                [ApplicationType.FUNCTION, ApplicationType.DEFAULT],
-                // TODO: this is an empty list until an unsupported JDK is added to JdkVersion,
-                //  and prevents test from executing with 'Data provider has no data' exception
-                ((JdkVersion.values() as List<JdkVersion>) - AzureFeatureValidatorSpec.supportedVersionsByAzureFunction()) as List<JdkVersion>,
-                ['azure-function']
-        ].combinations()
-    }
-
-    @Unroll("#jdkVersion supported for #feature")
-    void "verify for supported JDK Versions by azure-function no exception is thrown"(ApplicationType applicationType, JdkVersion jdkVersion, String feature) {
+    void "verify for all JDK Versions by azure-function no exception is thrown"(ApplicationType applicationType, JdkVersion jdkVersion, String feature) {
         when:
         generate(
                 applicationType,
@@ -54,7 +28,7 @@ class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOu
         where:
         [applicationType, jdkVersion, feature] << [
                 [ApplicationType.FUNCTION, ApplicationType.DEFAULT],
-                AzureFeatureValidatorSpec.supportedVersionsByAzureFunction(),
+                JdkVersion.values(),
                 ['azure-function']
         ].combinations()
     }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
@@ -1,15 +1,24 @@
 package io.micronaut.starter.feature.function.azure
 
+
 import io.micronaut.core.version.SemanticVersion
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.fixture.CommandOutputFixture
-import io.micronaut.starter.options.*
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
+import spock.lang.PendingFeature
 import spock.lang.Unroll
 
 class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
+    // PendingFeature doesn't work here, because "if every iteration of a data-driven test passes it will be reported as error"
+    // and apparently zero iterations means every iteration
+    @PendingFeature(reason = "This test won't execute until we add another Java version, e.g. `JdkVersion.JDK_19`")
     @Unroll("#jdkVersion not supported for #feature")
     void "verify for not supported JDK Versions by azure-function an IllegalArgumentException is thrown"(ApplicationType applicationType, JdkVersion jdkVersion, String feature) {
         when:
@@ -24,6 +33,8 @@ class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOu
         where:
         [applicationType, jdkVersion, feature] << [
                 [ApplicationType.FUNCTION, ApplicationType.DEFAULT],
+                // TODO: this is an empty list until an unsupported JDK is added to JdkVersion,
+                //  and prevents test from executing with 'Data provider has no data' exception
                 ((JdkVersion.values() as List<JdkVersion>) - AzureFeatureValidatorSpec.supportedVersionsByAzureFunction()) as List<JdkVersion>,
                 ['azure-function']
         ].combinations()

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureFeatureValidatorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureFeatureValidatorSpec.groovy
@@ -33,6 +33,6 @@ class AzureFeatureValidatorSpec extends Specification {
     }
 
     static List<JdkVersion> supportedVersionsByAzureFunction() {
-        [JdkVersion.JDK_8, JdkVersion.JDK_11]
+        [JdkVersion.JDK_8, JdkVersion.JDK_11, JdkVersion.JDK_17]
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureFeatureValidatorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureFeatureValidatorSpec.groovy
@@ -3,7 +3,11 @@ package io.micronaut.starter.feature.function.azure
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.build.dependencies.DefaultCoordinateResolver
 import io.micronaut.starter.feature.Feature
-import io.micronaut.starter.options.*
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -27,12 +31,9 @@ class AzureFeatureValidatorSpec extends Specification {
 
         where:
         [javaVersion, feature] << [
-                supportedVersionsByAzureFunction(),
+                JdkVersion.values(),
                 [new AzureHttpFunction(new DefaultCoordinateResolver()), new AzureRawFunction(new DefaultCoordinateResolver(), new AzureHttpFunction(new DefaultCoordinateResolver()))]
         ].combinations()
     }
 
-    static List<JdkVersion> supportedVersionsByAzureFunction() {
-        [JdkVersion.JDK_8, JdkVersion.JDK_11, JdkVersion.JDK_17]
-    }
 }


### PR DESCRIPTION
(currently limited to 8 and 11)

fixes #1629