### PR TITLE
Jooq feature doesn't work with Java 8

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/Jooq.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/Jooq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,21 @@
  */
 package io.micronaut.starter.feature.database;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.MinJdkFeature;
 import io.micronaut.starter.feature.database.jdbc.JdbcFeature;
 
+import io.micronaut.starter.options.JdkVersion;
 import jakarta.inject.Singleton;
 
 @Singleton
-public class Jooq implements Feature {
+public class Jooq implements Feature, MinJdkFeature {
 
     private final JdbcFeature jdbcFeature;
 
@@ -77,5 +80,11 @@ public class Jooq implements Feature {
     @Override
     public String getMicronautDocumentation() {
         return "https://micronaut-projects.github.io/micronaut-sql/latest/guide/index.html#jooq";
+    }
+
+    @Override
+    @NonNull
+    public JdkVersion minJdk() {
+        return JdkVersion.JDK_11;
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/JooqSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/JooqSpec.groovy
@@ -4,8 +4,8 @@ import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
-import spock.lang.Unroll
 
 class JooqSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
@@ -19,12 +19,12 @@ class JooqSpec extends ApplicationContextSpec  implements CommandOutputFixture {
         readme.contains("https://micronaut-projects.github.io/micronaut-sql/latest/guide/index.html#jooq")
     }
 
-    @Unroll
     void 'test gradle jooq feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
                 .features(['jooq'])
                 .language(language)
+                .jdkVersion(JdkVersion.JDK_11)
                 .render()
 
         then:
@@ -34,12 +34,12 @@ class JooqSpec extends ApplicationContextSpec  implements CommandOutputFixture {
         language << Language.values().toList()
     }
 
-    @Unroll
     void 'test maven jooq feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .features(['jooq'])
                 .language(language)
+                .jdkVersion(JdkVersion.JDK_11)
                 .render()
 
         then:
@@ -55,4 +55,19 @@ class JooqSpec extends ApplicationContextSpec  implements CommandOutputFixture {
         language << Language.values().toList()
     }
 
+    void "test jooq cannot be applied for #language with Java 8"() {
+        when:
+        new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['jooq'])
+                .language(language)
+                .jdkVersion(JdkVersion.JDK_8)
+                .render()
+
+        then:
+        IllegalArgumentException ex = thrown()
+        ex.message == "The selected feature jooq requires at latest Java 11"
+
+        where:
+        language << Language.values().toList()
+    }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/JooqSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/JooqSpec.groovy
@@ -2,16 +2,18 @@ package io.micronaut.starter.feature.database
 
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
 
 class JooqSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature jooq contains links to micronaut docs'() {
         when:
-        def output = generate(['jooq'])
+        def output = generate(ApplicationType.DEFAULT, new Options().withJavaVersion(JdkVersion.JDK_11), ['jooq'])
         def readme = output["README.md"]
 
         then:


### PR DESCRIPTION
As discovered in https://github.com/micronaut-projects/micronaut-sql/pull/822 micronaut-sql:micronaut-jooq requires Java 11+

This adds validation to ensure we don't let people create java 8 apps with jooq