### PR TITLE
Expose additional options via generator context

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
@@ -250,6 +250,13 @@ public class GeneratorContext implements DependencyContext {
     }
 
     /**
+     * @return A map containing additional options
+     */
+    @NonNull public Map<String, Object> getAdditionalOptions() {
+        return options.getAdditionalOptions();
+    }
+
+    /**
      * @return The project
      */
     @NonNull public Project getProject() {

--- a/starter-core/src/main/java/io/micronaut/starter/options/Options.java
+++ b/starter-core/src/main/java/io/micronaut/starter/options/Options.java
@@ -101,6 +101,10 @@ public class Options implements ConvertibleValues<Object> {
         return javaVersion;
     }
 
+    public Map<String, Object> getAdditionalOptions() {
+        return additionalOptions.asMap();
+    }
+
     public Options withLanguage(Language language) {
         return new Options(language, testFramework, buildTool, javaVersion, additionalOptions.asMap());
     }


### PR DESCRIPTION
Exposing additional options via generator context would allow features to inspect those options when they are being applied, which would make features more configurable and extensible.