### PR TITLE
Fix typo in application template `dekorate-jeager` => `dekorate-jaeger`

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/java/application.rocker.raw
@@ -38,7 +38,7 @@ import io.dekorate.kubernetes.annotation.Probe;
 @if (features.contains("dekorate-prometheus")) {
 import io.dekorate.prometheus.annotation.EnableServiceMonitor;
 }
-@if (features.contains("dekorate-jeager")) {
+@if (features.contains("dekorate-jaeger")) {
 import io.dekorate.jaeger.annotation.EnableJaegerAgent;
 }
 @if (features.contains("dekorate-halkyon")) {
@@ -74,7 +74,7 @@ import io.dekorate.halkyon.annotation.HalkyonComponent;
 @if (features.contains("dekorate-prometheus")) {
 @@EnableServiceMonitor(port = "http", path="/prometheus")
 }
-@if (features.contains("dekorate-jeager")) {
+@if (features.contains("dekorate-jaeger")) {
 @@EnableJaegerAgent
 }
 @if (features.contains("dekorate-halkyon")) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/application.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/lang/kotlin/application.rocker.raw
@@ -33,7 +33,7 @@ import io.dekorate.kubernetes.annotation.Probe
 @if (features.contains("dekorate-prometheus")) {
 import io.dekorate.prometheus.annotation.EnableServiceMonitor
 }
-@if (features.contains("dekorate-jeager")) {
+@if (features.contains("dekorate-jaeger")) {
 import io.dekorate.jaeger.annotation.EnableJaegerAgent
 }
 @if (features.contains("dekorate-halkyon")) {
@@ -73,7 +73,7 @@ object Api {
 @if (features.contains("dekorate-prometheus")) {
 @@EnableServiceMonitor(port = "http", path="/prometheus")
 }
-@if (features.contains("dekorate-jeager")) {
+@if (features.contains("dekorate-jaeger")) {
 @@EnableJaegerAgent
 }
 @if (features.contains("dekorate-tekton")) {


### PR DESCRIPTION
I found a typo in some templates. The [actual feature name](https://github.com/micronaut-projects/micronaut-starter/blob/3.9.x/starter-core/src/main/java/io/micronaut/starter/feature/dekorate/DekorateJaeger.java#L41) is `dekorate-jaeger`.