### PR TITLE
Fix AOT Maven feature

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAot.java
@@ -86,7 +86,7 @@ public class MicronautAot implements Feature {
 
             generatorContext.addTemplate("aotJitProperties", new RockerTemplate("aot-jar.properties", aot.template("jar")));
             if (generatorContext.isFeaturePresent(GraalVM.class)) {
-                generatorContext.addTemplate("aotNativeProperties", new RockerTemplate("aot-native-image.properties", aot.template("jar")));
+                generatorContext.addTemplate("aotNativeProperties", new RockerTemplate("aot-native-image.properties", aot.template("native-image")));
             }
         }
     }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/MicronautAotSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/MicronautAotSpec.groovy
@@ -120,19 +120,26 @@ class MicronautAotSpec extends ApplicationContextSpec implements CommandOutputFi
     void 'aot properties file is generated when aot feature is selected'() {
         given:
         def output = generate(DEFAULT, mavenAotOptions(), [MicronautAot.FEATURE_NAME_AOT])
+        String expected = getClass().getResource("/expected-aot-jar.properties").text
 
         expect:
         output.containsKey('aot-jar.properties')
+        output["aot-jar.properties"] == expected
         !output.containsKey('aot-native-image.properties')
     }
 
     void 'aot properties files are generated when aot and graalvm features are selected'() {
         given:
         def output = generate(DEFAULT, mavenAotOptions(), [MicronautAot.FEATURE_NAME_AOT, GraalVM.FEATURE_NAME_GRAALVM])
+        String expectedAotJar = getClass().getResource("/expected-aot-jar.properties").text
+        String expectedAotNativeImage = getClass().getResource("/expected-aot-native-image.properties").text
 
         expect:
         output.containsKey('aot-jar.properties')
+        output["aot-jar.properties"] == expectedAotJar
+
         output.containsKey('aot-native-image.properties')
+        output["aot-native-image.properties"] == expectedAotNativeImage
     }
 
     private String build(BuildTool buildTool, Language language) {


### PR DESCRIPTION
This PR fixes the generation of the file `aot-native-image.properties`, which incorrectly had the same contents as `aot-jar.properties`