### PR TITLE
Switch default JDK in Micronaut Launch to 17

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation "io.sdkman:gradle-sdkvendor-plugin:2.0.0"
     implementation "org.asciidoctor:asciidoctor-gradle-jvm:2.4.0"
     implementation "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
+    implementation "com.microsoft.azure:azure-functions-gradle-plugin:1.12.1"
 }
 
 gradlePlugin {

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,6 @@ pluginManagement {
     }
     plugins {
         id 'io.micronaut.application' version '3.7.4'
-        id 'com.microsoft.azure.azurefunctions' version '1.4.0'
     }
 }
 

--- a/starter-api/src/test/groovy/io/micronaut/starter/api/preview/PreviewControllerKotlinTestSpec.groovy
+++ b/starter-api/src/test/groovy/io/micronaut/starter/api/preview/PreviewControllerKotlinTestSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.starter.api.preview
 
 import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpRequest
 import io.micronaut.starter.api.EmbeddedServerSpecification
 import io.micronaut.starter.application.ApplicationType
@@ -14,7 +15,6 @@ import io.micronaut.starter.io.ConsoleOutput
 import io.micronaut.starter.io.OutputHandler
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
-import org.jetbrains.annotations.Nullable
 
 import jakarta.inject.Singleton
 

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
@@ -151,7 +151,7 @@ public class CreateLambdaBuilderCommand extends BuilderCommand {
         return getEnumOption(
                 versions,
                 jdkVersion -> Integer.toString(jdkVersion.majorVersion()),
-                versions.length > 0 ? versions[0] : JdkVersion.DEFAULT_OPTION,
+                versions.length > 0 ? versions[0] : JdkVersion.JDK_11,
                 reader
         );
     }

--- a/starter-core/src/main/java/io/micronaut/starter/options/JdkVersion.java
+++ b/starter-core/src/main/java/io/micronaut/starter/options/JdkVersion.java
@@ -30,7 +30,7 @@ public enum JdkVersion {
     JDK_11(11),
     JDK_17(17);
 
-    public static final JdkVersion DEFAULT_OPTION = JDK_11;
+    public static final JdkVersion DEFAULT_OPTION = JDK_17;
 
     private static final List<Integer> SUPPORTED_JDKS = Arrays.stream(JdkVersion.values()).map(JdkVersion::majorVersion).collect(Collectors.toList());
 


### PR DESCRIPTION
This leaves the default as 11 when creating a lambda (as AWS don't yet fully support 17)