### PR TITLE
Show the available JDK options in the CLI --help

### DIFF
--- a/starter-cli/src/main/java/io/micronaut/starter/cli/MicronautStarter.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/MicronautStarter.java
@@ -31,6 +31,7 @@ import io.micronaut.starter.cli.command.CreateFunctionCommand;
 import io.micronaut.starter.cli.command.CreateGrpcCommand;
 import io.micronaut.starter.cli.command.CreateLambdaBuilderCommand;
 import io.micronaut.starter.cli.command.CreateMessagingCommand;
+import io.micronaut.starter.cli.command.JdkVersionCandidates;
 import io.micronaut.starter.cli.command.LanguageCandidates;
 import io.micronaut.starter.cli.command.LanguageConverter;
 import io.micronaut.starter.cli.command.TestFrameworkCandidates;
@@ -70,6 +71,7 @@ import java.util.function.BiFunction;
 @Prototype
 @TypeHint({
     MicronautStarter.class,
+    JdkVersionCandidates.class,
     LanguageCandidates.class,
     LanguageConverter.class,
     BuildToolCandidates.class,

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateCommand.java
@@ -70,7 +70,7 @@ public abstract class CreateCommand extends BaseCommand implements Callable<Inte
     protected boolean listFeatures;
 
     @ReflectiveAccess
-    @Option(names = {"--jdk", "--java-version"}, description = "The JDK version the project should target")
+    @Option(names = {"--jdk", "--java-version"}, description = "The JDK version the project should target. Possible values: ${COMPLETION-CANDIDATES}", completionCandidates = JdkVersionCandidates.class)
     protected Integer javaVersion;
 
     protected final ContextFactory contextFactory;

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/JdkVersionCandidates.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/JdkVersionCandidates.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.cli.command;
+
+import io.micronaut.starter.options.JdkVersion;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class JdkVersionCandidates extends ArrayList<String> {
+
+    public JdkVersionCandidates() {
+        super(Stream.of(JdkVersion.values()).map(JdkVersion::majorVersion).map(Object::toString).collect(Collectors.toList()));
+    }
+}


### PR DESCRIPTION
I was going to go further, and show the default, but the default for AWS is 11 (depending on service). Also, the default language changes the default gradle dsl and the default test framework. This means I don't believe there's much more we can do of value.