### PR TITLE
Build a fully static Linux Image

### DIFF
--- a/.github/workflows/mn-linux-snapshot.yml
+++ b/.github/workflows/mn-linux-snapshot.yml
@@ -2,10 +2,10 @@ name: Linux Native CLI
 on:
   push:
     branches:
-      - 'fully-static-image'
+      - '[1-9]+.[0-9]+.x'
   pull_request:
     branches:
-      - 'fully-static-image'
+      - '[1-9]+.[0-9]+.x'
 jobs:
   build:
     name: Builds Linux Native CLI
@@ -42,7 +42,7 @@ jobs:
           cp ./LICENSE mn-linux-amd64-snapshot/
           zip -r mn-linux-amd64-snapshot.zip ./mn-linux-amd64-snapshot
       - name: Upload Snapshot
-        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/fully-static-image'
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/3.8.x'
         uses: actions/upload-artifact@v3
         with:
           name: mn-linux-amd64-snapshot

--- a/.github/workflows/mn-linux-snapshot.yml
+++ b/.github/workflows/mn-linux-snapshot.yml
@@ -2,10 +2,10 @@ name: Linux Native CLI
 on:
   push:
     branches:
-      - '[1-9]+.[0-9]+.x'
+      - 'fully-static-image'
   pull_request:
     branches:
-      - '[1-9]+.[0-9]+.x'
+      - 'fully-static-image'
 jobs:
   build:
     name: Builds Linux Native CLI
@@ -20,6 +20,7 @@ jobs:
           java-version: '11'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-musl: 'true'
       - name: Build the JAR
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -27,7 +28,7 @@ jobs:
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
         run: ./gradlew micronaut-cli:shadowJar --no-daemon
       - name: Build Native Image
-        run: native-image --no-fallback --allow-incomplete-classpath -cp starter-cli/build/libs/micronaut-cli-*-all.jar
+        run: native-image --static --libc=musl --no-fallback -cp starter-cli/build/libs/micronaut-cli-*-all.jar
       - name: Verify Build
         run: ./mn --version
       - name: Verify Create App
@@ -41,7 +42,7 @@ jobs:
           cp ./LICENSE mn-linux-amd64-snapshot/
           zip -r mn-linux-amd64-snapshot.zip ./mn-linux-amd64-snapshot
       - name: Upload Snapshot
-        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/3.8.x'
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/fully-static-image'
         uses: actions/upload-artifact@v3
         with:
           name: mn-linux-amd64-snapshot

--- a/.github/workflows/mn-linux-snapshot.yml
+++ b/.github/workflows/mn-linux-snapshot.yml
@@ -28,7 +28,7 @@ jobs:
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
         run: ./gradlew micronaut-cli:shadowJar --no-daemon
       - name: Build Native Image
-        run: native-image --static --libc=musl --no-fallback -cp starter-cli/build/libs/micronaut-cli-*-all.jar
+        run: native-image --allow-incomplete-classpath --static --libc=musl --no-fallback -cp starter-cli/build/libs/micronaut-cli-*-all.jar
       - name: Verify Build
         run: ./mn --version
       - name: Verify Create App

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
           java-version: '11'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-musl: 'true'
       - name: Build the JAR
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -114,7 +115,7 @@ jobs:
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
         run: ./gradlew micronaut-cli:shadowJar --no-daemon
       - name: Build Native Image
-        run: native-image --no-fallback --allow-incomplete-classpath -cp starter-cli/build/libs/micronaut-cli-*-all.jar
+        run: native-image --static --libc=musl --no-fallback --allow-incomplete-classpath -cp starter-cli/build/libs/micronaut-cli-*-all.jar
       - name: Verify Build
         run: ./mn --version
       - name: Package Build


### PR DESCRIPTION
Our linux builds currently fail on older versions of Linux. 

This changes the CLI build for Linux to build a fully static image that doesn't require a specific version of libc 