### PR TITLE
Add configuration to camunda-platform7 and update metadata of Camunda related projects

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/camunda/ExternalWorker.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/camunda/ExternalWorker.java
@@ -26,6 +26,12 @@ import jakarta.inject.Singleton;
 @Singleton
 public class ExternalWorker implements CamundaCommunityFeature {
 
+    public static final String NAME = "camunda-external-worker";
+
+    private static final Dependency.Builder DEPENDENCY_EXTERNAL_WORKER = Dependency.builder()
+            .lookupArtifactId("micronaut-camunda-external-client-feature")
+            .compile();
+
     @NonNull
     @Override
     public String getCommunityFeatureName() {
@@ -40,7 +46,7 @@ public class ExternalWorker implements CamundaCommunityFeature {
 
     @Override
     public String getDescription() {
-        return "Bringing process automation to Micronaut: Implement Camunda External Workers for the Camunda Platform";
+        return "Bringing process automation to Micronaut: Implement Camunda External Workers for the Camunda Platform 7";
     }
 
     @Override
@@ -51,9 +57,7 @@ public class ExternalWorker implements CamundaCommunityFeature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         generatorContext.getConfiguration().put("camunda.external-client.base-url", "http://localhost:8080/engine-rest");
-        generatorContext.addDependency(Dependency.builder()
-                .lookupArtifactId("micronaut-camunda-external-client-feature")
-                .compile());
+        generatorContext.addDependency(DEPENDENCY_EXTERNAL_WORKER);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/camunda/Zeebe.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/camunda/Zeebe.java
@@ -26,6 +26,12 @@ import jakarta.inject.Singleton;
 @Singleton
 public class Zeebe implements CamundaCommunityFeature {
 
+    public static final String NAME = "camunda-zeebe";
+
+    private static final Dependency.Builder DEPENDENCY_ZEEBE = Dependency.builder()
+            .lookupArtifactId("micronaut-zeebe-client-feature")
+            .compile();
+
     @NonNull
     @Override
     public String getCommunityFeatureName() {
@@ -45,7 +51,7 @@ public class Zeebe implements CamundaCommunityFeature {
 
     @Override
     public String getDescription() {
-        return "Bringing cloud native process automation to Micronaut: Implement Zeebe Workers for Camunda Cloud or a local broker";
+        return "Bringing cloud native process automation to Micronaut: Implement Zeebe Workers for Camunda Platform 8";
     }
 
     @Override
@@ -55,9 +61,7 @@ public class Zeebe implements CamundaCommunityFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.addDependency(Dependency.builder()
-                .lookupArtifactId("micronaut-zeebe-client-feature")
-                .compile());
+        generatorContext.addDependency(DEPENDENCY_ZEEBE);
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifier.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifier.groovy
@@ -53,8 +53,8 @@ class GradleBuildTestVerifier implements BuildTestVerifier {
 
     @Override
     boolean hasDependency(String groupId, String artifactId, String scope) {
-        String expected = """${scope}("${groupId}:${artifactId}")"""
-        template.contains(expected)
+        String expected = """(?s).*${scope}\\("${groupId}:${artifactId}(?:.+)?\\).*"""
+        template.matches(Pattern.compile(expected))
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/ExternalWorkerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/ExternalWorkerSpec.groovy
@@ -18,10 +18,11 @@ package io.micronaut.starter.feature.camunda
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.generator.GeneratorContext
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
-import io.micronaut.starter.options.Language
-import spock.lang.Unroll
 
 class ExternalWorkerSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
@@ -35,37 +36,18 @@ class ExternalWorkerSpec extends ApplicationContextSpec implements CommandOutput
         readme.contains("https://github.com/camunda-community-hub/micronaut-camunda-external-client")
     }
 
-    @Unroll
-    void 'test gradle camunda-external-worker feature for language=#language'() {
+    void "test dependency added for camunda-external-worker feature"(BuildTool buildTool) {
         when:
-        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .language(language)
-                .features(['camunda-external-worker'])
+        String template = new BuildBuilder(beanContext, buildTool)
+                .features([ExternalWorker.NAME])
                 .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
 
         then:
-        template.count('implementation("info.novatec:micronaut-camunda-external-client-feature:') == 1
+        verifier.hasDependency("info.novatec", "micronaut-camunda-external-client-feature", Scope.COMPILE)
 
         where:
-        language << Language.values().toList()
-    }
-
-    @Unroll
-    void 'test maven camunda-external-worker feature for language=#language'() {
-        when:
-        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .language(language)
-                .features(['camunda-external-worker'])
-                .render()
-
-        then:
-        template.count('''\
-    <dependency>
-      <groupId>info.novatec</groupId>
-      <artifactId>micronaut-camunda-external-client-feature</artifactId>
- ''') == 1
-        where:
-        language << Language.values().toList()
+        buildTool << BuildTool.values()
     }
 
     void 'test camunda-external-worker configuration'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/ZeebeSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/camunda/ZeebeSpec.groovy
@@ -17,10 +17,11 @@ package io.micronaut.starter.feature.camunda
 
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
-import io.micronaut.starter.options.Language
-import spock.lang.Unroll
 
 class ZeebeSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
@@ -34,36 +35,17 @@ class ZeebeSpec extends ApplicationContextSpec implements CommandOutputFixture {
         readme.contains("https://github.com/camunda-community-hub/micronaut-zeebe-client")
     }
 
-    @Unroll
-    void 'test gradle camunda-zeebe feature for language=#language'() {
+    void "test dependency added for camunda-zeebe feature"(BuildTool buildTool) {
         when:
-        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .language(language)
-                .features(['camunda-zeebe'])
+        String template = new BuildBuilder(beanContext, buildTool)
+                .features([Zeebe.NAME])
                 .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
 
         then:
-        template.count('implementation("info.novatec:micronaut-zeebe-client-feature:') == 1
+        verifier.hasDependency("info.novatec", "micronaut-zeebe-client-feature", Scope.COMPILE)
 
         where:
-        language << Language.values().toList()
-    }
-
-    @Unroll
-    void 'test maven camunda-zeebe feature for language=#language'() {
-        when:
-        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .language(language)
-                .features(['camunda-zeebe'])
-                .render()
-
-        then:
-        template.count('''\
-    <dependency>
-      <groupId>info.novatec</groupId>
-      <artifactId>micronaut-zeebe-client-feature</artifactId>
- ''') == 1
-        where:
-        language << Language.values().toList()
+        buildTool << BuildTool.values()
     }
 }


### PR DESCRIPTION
I'm the lead developer of the Micronaut Camunda Integration Project.

Please merge this PR which adds configuration options and makes the setup easier.

I tested the following:
./gradlew micronaut-cli:run --args="create-app --list-features" -> Looks good, feature is listed

Both the following look good
./gradlew micronaut-cli:run --args="create-app --features=camunda-platform7 temp-gradle"
./gradlew micronaut-cli:run --args="create-app --build=maven --features=camunda-platform7 temp-maven"

and build successfully.

FYI: @sdelamo 