### PR TITLE
AWS-lambda features without GraalVM feature raises validation error when Java 17 is selected

### DIFF
--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
@@ -27,6 +27,7 @@ import io.micronaut.starter.feature.architecture.CpuArchitecture;
 import io.micronaut.starter.feature.architecture.X86;
 import io.micronaut.starter.feature.aws.AmazonApiGateway;
 import io.micronaut.starter.feature.aws.AwsApiFeature;
+import io.micronaut.starter.feature.aws.AwsLambdaFeatureValidator;
 import io.micronaut.starter.feature.aws.Cdk;
 import io.micronaut.starter.feature.aws.LambdaFunctionUrl;
 import io.micronaut.starter.feature.aws.LambdaTrigger;
@@ -165,10 +166,10 @@ public class CreateLambdaBuilderCommand extends BuilderCommand {
                 };
             default:
             case FAT_JAR:
-                return new JdkVersion[] {
-                        JdkVersion.JDK_11,
-                        JdkVersion.JDK_8,
-                };
+                List<JdkVersion> supportedJdks = AwsLambdaFeatureValidator.supportedJdks();
+                JdkVersion[] arr = new JdkVersion[supportedJdks.size()];
+                supportedJdks.toArray(arr);
+                return arr;
         }
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaFeatureValidator.java
@@ -52,8 +52,16 @@ public class AwsLambdaFeatureValidator implements FeatureValidator {
                 .collect(Collectors.toList());
     }
 
+    public static JdkVersion firstSupportedJdk() {
+        return Stream.of(JdkVersion.values())
+                .filter(AwsLambdaFeatureValidator::supports)
+                .findFirst()
+                .orElse(JdkVersion.JDK_11);
+    }
+
     public static boolean supports(JdkVersion jdkVersions) {
         return !jdkVersions.greaterThanEqual(JdkVersion.JDK_17);
     }
+
 
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaFeatureValidator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.aws;
+
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.function.awslambda.AwsLambda;
+import io.micronaut.starter.feature.graalvm.GraalVM;
+import io.micronaut.starter.feature.validation.FeatureValidator;
+import io.micronaut.starter.options.JdkVersion;
+import io.micronaut.starter.options.Options;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Singleton
+public class AwsLambdaFeatureValidator implements FeatureValidator {
+    @Override
+    public void validatePreProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+        if (features.stream().anyMatch(f -> f instanceof AwsLambda) && features.stream().noneMatch(f -> f instanceof GraalVM)) {
+            JdkVersion javaVersion = options.getJavaVersion();
+            if (!supports(options.getJavaVersion())) {
+                throw new IllegalArgumentException(String.format("AWS Lambda does not have a Java %s runtime", javaVersion.majorVersion()));
+            }
+        }
+    }
+
+    @Override
+    public void validatePostProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+
+    }
+
+    public static List<JdkVersion> supportedJdks() {
+        return Stream.of(JdkVersion.values())
+                .filter(AwsLambdaFeatureValidator::supports)
+                .collect(Collectors.toList());
+    }
+
+    public static boolean supports(JdkVersion jdkVersions) {
+        return !jdkVersions.greaterThanEqual(JdkVersion.JDK_17);
+    }
+
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/ArmSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/ArmSpec.groovy
@@ -8,9 +8,10 @@ import io.micronaut.starter.feature.aws.Cdk
 import io.micronaut.starter.feature.function.awslambda.AwsLambda
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
-import spock.lang.IgnoreIf
+import io.micronaut.starter.options.TestFramework
 import spock.lang.Subject
 import spock.util.environment.Jvm
 
@@ -38,10 +39,10 @@ class ArmSpec extends ApplicationContextSpec implements CommandOutputFixture {
         applicationType << ApplicationType.values()
     }
 
-    @IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
     void 'arm plus cdk feature sets lambda function architecture'() {
         when:
-        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),
+
+        Map<String, String> output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
                 [Cdk.NAME, AwsLambda.FEATURE_NAME_AWS_LAMBDA, Arm.NAME])
 
         then:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/ArmSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/ArmSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.starter.feature.architecture
 
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.Category
 import io.micronaut.starter.feature.OneOfFeature
 import io.micronaut.starter.feature.aws.Cdk
 import io.micronaut.starter.feature.function.awslambda.AwsLambda
@@ -9,8 +10,9 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
+import spock.lang.IgnoreIf
 import spock.lang.Subject
-import io.micronaut.starter.feature.Category
+import spock.util.environment.Jvm
 
 class ArmSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
@@ -36,6 +38,7 @@ class ArmSpec extends ApplicationContextSpec implements CommandOutputFixture {
         applicationType << ApplicationType.values()
     }
 
+    @IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
     void 'arm plus cdk feature sets lambda function architecture'() {
         when:
         def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/X86Spec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/X86Spec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.starter.feature.architecture
 
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.Category
 import io.micronaut.starter.feature.OneOfFeature
 import io.micronaut.starter.feature.aws.Cdk
 import io.micronaut.starter.feature.function.awslambda.AwsLambda
@@ -9,8 +10,9 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
+import spock.lang.IgnoreIf
 import spock.lang.Subject
-import io.micronaut.starter.feature.Category
+import spock.util.environment.Jvm
 
 class X86Spec extends ApplicationContextSpec implements CommandOutputFixture {
 
@@ -36,6 +38,7 @@ class X86Spec extends ApplicationContextSpec implements CommandOutputFixture {
         applicationType << ApplicationType.values()
     }
 
+    @IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
     void 'x86 plus cdk feature sets lambda function architecture'() {
         when:
         def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/X86Spec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/X86Spec.groovy
@@ -4,15 +4,16 @@ import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.feature.OneOfFeature
+import io.micronaut.starter.feature.aws.AwsLambdaFeatureValidator
 import io.micronaut.starter.feature.aws.Cdk
 import io.micronaut.starter.feature.function.awslambda.AwsLambda
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
-import spock.lang.IgnoreIf
+import io.micronaut.starter.options.TestFramework
 import spock.lang.Subject
-import spock.util.environment.Jvm
 
 class X86Spec extends ApplicationContextSpec implements CommandOutputFixture {
 
@@ -38,10 +39,11 @@ class X86Spec extends ApplicationContextSpec implements CommandOutputFixture {
         applicationType << ApplicationType.values()
     }
 
-    @IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
+
     void 'x86 plus cdk feature sets lambda function architecture'() {
         when:
-        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),
+        Options options = new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, AwsLambdaFeatureValidator.firstSupportedJdk())
+        Map<String, String> output = generate(ApplicationType.FUNCTION, options,
                 [Cdk.NAME, AwsLambda.FEATURE_NAME_AWS_LAMBDA, X86.NAME])
 
         then:
@@ -49,7 +51,7 @@ class X86Spec extends ApplicationContextSpec implements CommandOutputFixture {
         output."$Cdk.INFRA_MODULE/src/main/java/example/micronaut/AppStack.java".contains($/.architecture(Architecture.X86_64)/$)
 
         when: 'x86 is the default'
-        output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),
+        output = generate(ApplicationType.FUNCTION, options,
                 [Cdk.NAME, AwsLambda.FEATURE_NAME_AWS_LAMBDA])
 
         then:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AmazonApiGatewayHttpSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AmazonApiGatewayHttpSpec.groovy
@@ -6,17 +6,20 @@ import io.micronaut.starter.feature.Category
 import io.micronaut.starter.feature.architecture.Arm
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
-import spock.lang.IgnoreIf
+import io.micronaut.starter.options.TestFramework
+import spock.lang.Shared
 import spock.lang.Subject
-import spock.util.environment.Jvm
 
-@IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
 class AmazonApiGatewayHttpSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Subject
     AmazonApiGatewayHttp amazonApiGatewayHttp = beanContext.getBean(AmazonApiGatewayHttp)
+
+    @Shared
+    Options options = new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, AwsLambdaFeatureValidator.firstSupportedJdk())
 
     void 'amazon-api-gateway-http feature is in the cloud category'() {
         expect:
@@ -45,7 +48,9 @@ class AmazonApiGatewayHttpSpec extends ApplicationContextSpec implements Command
 
     void 'amazon-api-gateway-http feature has dependencies, imports and code'() {
         when:
-        Map<String, String> output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),
+
+
+        Map<String, String> output = generate(ApplicationType.FUNCTION, options,
                 [Cdk.NAME, AmazonApiGatewayHttp.NAME])
 
         then:
@@ -76,7 +81,7 @@ class AmazonApiGatewayHttpSpec extends ApplicationContextSpec implements Command
 
     void 'amazon-api-gateway-http and arm do not use SnapStart'() {
         when:
-        Map<String, String> output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),
+        Map<String, String> output = generate(ApplicationType.FUNCTION, options,
                 [Cdk.NAME, AmazonApiGatewayHttp.NAME, Arm.NAME])
         String appStack = output."$Cdk.INFRA_MODULE/src/main/java/example/micronaut/AppStack.java"
         then:
@@ -87,7 +92,7 @@ class AmazonApiGatewayHttpSpec extends ApplicationContextSpec implements Command
 
     void 'amazon-api-gateway-http feature without Cdk has dependency in project and doc links'() {
         when:
-        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),
+        def output = generate(ApplicationType.FUNCTION, options,
                 [AmazonApiGatewayHttp.NAME])
 
         then:
@@ -99,7 +104,7 @@ class AmazonApiGatewayHttpSpec extends ApplicationContextSpec implements Command
 
     void 'Selecting more than one AmazonApiGateway feature fails with exception'() {
         when:
-        generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE), [Cdk.NAME, AmazonApiGatewayHttp.NAME, AmazonApiGateway.NAME])
+        generate(ApplicationType.FUNCTION, options, [Cdk.NAME, AmazonApiGatewayHttp.NAME, AmazonApiGateway.NAME])
 
         then:
         def e = thrown(IllegalArgumentException)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AmazonApiGatewayHttpSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AmazonApiGatewayHttpSpec.groovy
@@ -8,8 +8,11 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
+import spock.lang.IgnoreIf
 import spock.lang.Subject
+import spock.util.environment.Jvm
 
+@IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
 class AmazonApiGatewayHttpSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Subject

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AmazonApiGatewaySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AmazonApiGatewaySpec.groovy
@@ -7,8 +7,11 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
+import spock.lang.IgnoreIf
 import spock.lang.Subject
+import spock.util.environment.Jvm
 
+@IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
 class AmazonApiGatewaySpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Subject
@@ -39,6 +42,7 @@ class AmazonApiGatewaySpec extends ApplicationContextSpec implements CommandOutp
         amazonApiGateway.supports(ApplicationType.DEFAULT)
     }
 
+    @IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
     void 'amazon-api-gateway feature with Cdk has doc links'() {
         when:
         def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),
@@ -49,6 +53,7 @@ class AmazonApiGatewaySpec extends ApplicationContextSpec implements CommandOutp
         output."README.md".contains($/https://docs.aws.amazon.com/apigateway/$)
     }
 
+    @IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
     void 'amazon-api-gateway feature without Cdk has doc links'() {
         when:
         def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AmazonApiGatewaySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AmazonApiGatewaySpec.groovy
@@ -5,17 +5,20 @@ import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
-import spock.lang.IgnoreIf
+import io.micronaut.starter.options.TestFramework
+import spock.lang.Shared
 import spock.lang.Subject
-import spock.util.environment.Jvm
 
-@IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
 class AmazonApiGatewaySpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Subject
     AmazonApiGateway amazonApiGateway = beanContext.getBean(AmazonApiGateway)
+
+    @Shared
+    Options options = new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, AwsLambdaFeatureValidator.firstSupportedJdk())
 
     void 'amazon-api-gateway feature is in the cloud category'() {
         expect:
@@ -42,10 +45,9 @@ class AmazonApiGatewaySpec extends ApplicationContextSpec implements CommandOutp
         amazonApiGateway.supports(ApplicationType.DEFAULT)
     }
 
-    @IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
     void 'amazon-api-gateway feature with Cdk has doc links'() {
         when:
-        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),
+        def output = generate(ApplicationType.FUNCTION, options,
                 [Cdk.NAME, AmazonApiGateway.NAME])
 
         then:
@@ -53,10 +55,9 @@ class AmazonApiGatewaySpec extends ApplicationContextSpec implements CommandOutp
         output."README.md".contains($/https://docs.aws.amazon.com/apigateway/$)
     }
 
-    @IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
     void 'amazon-api-gateway feature without Cdk has doc links'() {
         when:
-        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),
+        def output = generate(ApplicationType.FUNCTION, options,
                 [AmazonApiGateway.NAME])
 
         then:
@@ -67,7 +68,7 @@ class AmazonApiGatewaySpec extends ApplicationContextSpec implements CommandOutp
 
     void 'amazon-api-gateway feature is a OneOfFeature with amazon-api-gateway-http'() {
         when:
-        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, BuildTool.GRADLE),
+        def output = generate(ApplicationType.FUNCTION, options,
                 [AmazonApiGateway.NAME, AmazonApiGatewayHttp.NAME])
 
         then:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AwsLambdaFeatureValidatorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AwsLambdaFeatureValidatorSpec.groovy
@@ -1,0 +1,74 @@
+package io.micronaut.starter.feature.aws
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
+import io.micronaut.starter.options.Language
+
+class AwsLambdaFeatureValidatorSpec extends ApplicationContextSpec  implements CommandOutputFixture {
+
+    static final List<String> AWS_LAMBDA_FEATURES = [
+            "aws-lambda",
+            "amazon-api-gateway",
+            "amazon-api-gateway-http",
+            "aws-lambda-s3-event-notification",
+            "aws-lambda-scheduled-event",
+            "aws-lambda-s3-event-notification"
+    ]
+
+    void 'test AWS Lambda feature validation fails for Java 17 for feature=#feature'() {
+        when:
+        new BuildBuilder(beanContext, buildtool)
+                .applicationType(ApplicationType.FUNCTION)
+                .language(Language.JAVA)
+                .jdkVersion(JdkVersion.JDK_17)
+                .features([feature])
+                .render()
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "AWS Lambda does not have a Java 17 runtime"
+
+        where:
+        [buildtool, feature] << [BuildTool.values().toList(), AWS_LAMBDA_FEATURES].combinations()
+    }
+
+    void 'test AWS Lambda feature validation succeeds for Java 17 for feature=#feature with graalvm'() {
+        when:
+        new BuildBuilder(beanContext, buildtool)
+                .applicationType(ApplicationType.FUNCTION)
+                .language(Language.JAVA)
+                .jdkVersion(JdkVersion.JDK_17)
+                .features([feature, "graalvm"])
+                .render()
+
+        then:
+        noExceptionThrown()
+
+        where:
+        [buildtool, feature] << [BuildTool.values().toList(), AWS_LAMBDA_FEATURES].combinations()
+    }
+
+    void 'test AWS Lambda feature validation succeeds for jdk=#jdk and buildtool=#buildtool for feature=#feature'() {
+        when:
+        new BuildBuilder(beanContext, buildtool)
+                .applicationType(ApplicationType.FUNCTION)
+                .language(Language.JAVA)
+                .jdkVersion(jdk)
+                .features([feature])
+                .render()
+
+        then:
+        noExceptionThrown()
+
+        where:
+        [buildtool, feature, jdk] << [
+                BuildTool.values().toList(),
+                AWS_LAMBDA_FEATURES,
+                AwsLambdaFeatureValidator.supportedJdks()
+            ].combinations()
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AwsSnapStartFeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AwsSnapStartFeatureSpec.groovy
@@ -7,17 +7,16 @@ import io.micronaut.starter.feature.function.awslambda.AwsLambda
 import io.micronaut.starter.feature.graalvm.GraalVM
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
-import spock.lang.IgnoreIf
-import spock.util.environment.Jvm
+import io.micronaut.starter.options.TestFramework
 
-@IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
 class AwsSnapStartFeatureSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
-    void 'SnapStart does not support ARM #buildTool'() {
+    void 'SnapStart does not support ARM #buildTool'(BuildTool buildTool) {
         when:
-        Map<String, String> output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool),
+        Map<String, String> output = generate(ApplicationType.FUNCTION, createOptions(buildTool),
                 [AwsLambda.FEATURE_NAME_AWS_LAMBDA, Cdk.NAME, AmazonApiGateway.NAME, Arm.NAME])
         String text = output['infra/src/main/java/example/micronaut/AppStack.java']
         then:
@@ -32,7 +31,7 @@ class AwsSnapStartFeatureSpec extends ApplicationContextSpec implements CommandO
 
     void 'Function AppStack imports included for SnapStart #buildTool'(BuildTool buildTool) {
         when:
-        Map<String, String> output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool),
+        Map<String, String> output = generate(ApplicationType.FUNCTION, createOptions(buildTool),
                 [AwsLambda.FEATURE_NAME_AWS_LAMBDA, Cdk.NAME, AmazonApiGateway.NAME])
         String text = output['infra/src/main/java/example/micronaut/AppStack.java']
 
@@ -48,7 +47,7 @@ class AwsSnapStartFeatureSpec extends ApplicationContextSpec implements CommandO
 
     void 'Function AppStack does not use SnapStart when using graalvm feature #buildTool'(BuildTool buildTool) {
         when:
-        Map<String, String> output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool),
+        Map<String, String> output = generate(ApplicationType.FUNCTION, createOptions(buildTool),
                 [AwsLambda.FEATURE_NAME_AWS_LAMBDA, Cdk.NAME, AmazonApiGateway.NAME, GraalVM.FEATURE_NAME_GRAALVM])
         String text = output['infra/src/main/java/example/micronaut/AppStack.java']
 
@@ -59,9 +58,9 @@ class AwsSnapStartFeatureSpec extends ApplicationContextSpec implements CommandO
         buildTool << graalVmAndCdkSupportedBuilds()
     }
 
-    void 'Function AppStack with SnapStart is included for #buildTool'() {
+    void 'Function AppStack with SnapStart is included for #buildTool'(BuildTool buildTool) {
         when:
-        Map<String, String> output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool),
+        Map<String, String> output = generate(ApplicationType.FUNCTION, createOptions(buildTool),
                 [AwsLambda.FEATURE_NAME_AWS_LAMBDA, Cdk.NAME, AmazonApiGateway.NAME])
         String text = output['infra/src/main/java/example/micronaut/AppStack.java']
 
@@ -74,9 +73,9 @@ class AwsSnapStartFeatureSpec extends ApplicationContextSpec implements CommandO
         buildTool << BuildTool.values()
     }
 
-    void 'SnapStart is enabled by default even without a API Gateway #buildTool'() {
+    void 'SnapStart is enabled by default even without a API Gateway #buildTool'(BuildTool buildTool) {
         when:
-        Map<String, String> output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool),
+        Map<String, String> output = generate(ApplicationType.FUNCTION, createOptions(buildTool),
                 [AwsLambda.FEATURE_NAME_AWS_LAMBDA, Cdk.NAME])
         String text = output['infra/src/main/java/example/micronaut/AppStack.java']
 
@@ -98,5 +97,9 @@ class AwsSnapStartFeatureSpec extends ApplicationContextSpec implements CommandO
 
     private static List<BuildTool> graalVmAndCdkSupportedBuilds() {
         BuildTool.values() - BuildTool.MAVEN
+    }
+
+    private static Options createOptions(BuildTool buildTool) {
+        new Options(Language.JAVA, TestFramework.JUNIT, buildTool, AwsLambdaFeatureValidator.firstSupportedJdk())
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AwsSnapStartFeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AwsSnapStartFeatureSpec.groovy
@@ -9,7 +9,10 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
+import spock.lang.IgnoreIf
+import spock.util.environment.Jvm
 
+@IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
 class AwsSnapStartFeatureSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'SnapStart does not support ARM #buildTool'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/CdkFeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/CdkFeatureSpec.groovy
@@ -12,8 +12,11 @@ import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.template.Template
+import spock.lang.IgnoreIf
 import spock.lang.Subject
+import spock.util.environment.Jvm
 
+@IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
 class CdkFeatureSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Subject

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/CdkFeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/CdkFeatureSpec.groovy
@@ -9,14 +9,13 @@ import io.micronaut.starter.feature.awsalexa.AwsAlexa
 import io.micronaut.starter.feature.function.awslambda.AwsLambda
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.template.Template
-import spock.lang.IgnoreIf
 import spock.lang.Subject
-import spock.util.environment.Jvm
 
-@IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
 class CdkFeatureSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Subject
@@ -31,7 +30,7 @@ class CdkFeatureSpec extends ApplicationContextSpec implements CommandOutputFixt
 
     void 'submodules are created for #buildTool'() {
         when:
-        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, buildTool), [Cdk.NAME, AwsLambda.FEATURE_NAME_AWS_LAMBDA])
+        def output = generate(ApplicationType.DEFAULT, createOptions(buildTool), [Cdk.NAME, AwsLambda.FEATURE_NAME_AWS_LAMBDA])
 
         then:
         output.'micronaut-cli.yml'
@@ -49,9 +48,9 @@ class CdkFeatureSpec extends ApplicationContextSpec implements CommandOutputFixt
         BuildTool.MAVEN         | "pom.xml"
     }
 
-    void 'Function AppStack log retention is included for #buildTool'() {
+    void 'Function AppStack log retention is included for #buildTool'(BuildTool buildTool) {
         when:
-        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool), [Cdk.NAME])
+        def output = generate(ApplicationType.FUNCTION, createOptions(buildTool), [Cdk.NAME])
 
         then:
         output.'infra/src/main/java/example/micronaut/AppStack.java'.contains('import software.amazon.awscdk.services.logs.RetentionDays;')
@@ -61,9 +60,9 @@ class CdkFeatureSpec extends ApplicationContextSpec implements CommandOutputFixt
         buildTool << BuildTool.values()
     }
 
-    void 'architecture defaults to X86 for  #buildTool'() {
+    void 'architecture defaults to X86 for  #buildTool'(BuildTool buildTool) {
         when:
-        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool), [Cdk.NAME])
+        def output = generate(ApplicationType.FUNCTION, createOptions(buildTool), [Cdk.NAME])
 
         then:
         output.'infra/src/main/java/example/micronaut/AppStack.java'.contains('.architecture(Architecture.X86_64)')
@@ -74,9 +73,9 @@ class CdkFeatureSpec extends ApplicationContextSpec implements CommandOutputFixt
     }
 
 
-    void 'Function AppStack with Alexa Skills is included for #buildTool'() {
+    void 'Function AppStack with Alexa Skills is included for #buildTool'(BuildTool buildTool) {
         when:
-        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool), [Cdk.NAME,AwsAlexa.NAME])
+        def output = generate(ApplicationType.FUNCTION, createOptions(buildTool), [Cdk.NAME,AwsAlexa.NAME])
 
         then:
         // aws-lambda is automatic, but if that assumption changes might need to fix cdkappstack rocker file
@@ -95,9 +94,9 @@ class CdkFeatureSpec extends ApplicationContextSpec implements CommandOutputFixt
         buildTool << BuildTool.values()
     }
 
-    void "dependencies are added for cdk to infra project for #buildTool"() {
+    void "dependencies are added for cdk to infra project for #buildTool"(BuildTool buildTool, String buildFile) {
         when:
-        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, buildTool), [Cdk.NAME, AwsLambda.FEATURE_NAME_AWS_LAMBDA])
+        def output = generate(ApplicationType.DEFAULT, createOptions(buildTool), [Cdk.NAME, AwsLambda.FEATURE_NAME_AWS_LAMBDA])
 
         then:
         output."$Cdk.INFRA_MODULE/$buildFile".contains($/implementation("io.micronaut.aws:micronaut-aws-cdk/$)
@@ -110,7 +109,7 @@ class CdkFeatureSpec extends ApplicationContextSpec implements CommandOutputFixt
 
     void "dependencies are added for cdk to infra project for maven"() {
         when:
-        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.MAVEN), [Cdk.NAME, AwsLambda.FEATURE_NAME_AWS_LAMBDA])
+        def output = generate(ApplicationType.DEFAULT, createOptions(BuildTool.MAVEN), [Cdk.NAME, AwsLambda.FEATURE_NAME_AWS_LAMBDA])
         def dependency = new XmlParser().parseText(output."$Cdk.INFRA_MODULE/pom.xml").dependencies.dependency.find {
             it.artifactId.text() == 'micronaut-aws-cdk'
         }
@@ -119,5 +118,9 @@ class CdkFeatureSpec extends ApplicationContextSpec implements CommandOutputFixt
         with(dependency) {
             it.groupId.text() == 'io.micronaut.aws'
         }
+    }
+
+    private static Options createOptions(BuildTool buildTool) {
+        new Options(Language.JAVA, TestFramework.JUNIT, buildTool, AwsLambdaFeatureValidator.firstSupportedJdk())
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/LambdaFunctionUrlSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/LambdaFunctionUrlSpec.groovy
@@ -5,11 +5,11 @@ import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
-import spock.lang.IgnoreIf
+import io.micronaut.starter.options.TestFramework
 import spock.lang.Subject
-import spock.util.environment.Jvm
 
 class LambdaFunctionUrlSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
@@ -39,10 +39,9 @@ class LambdaFunctionUrlSpec extends ApplicationContextSpec implements CommandOut
         lambdaFunctionUrl.supports(ApplicationType.FUNCTION)
     }
 
-    @IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
-    void 'Function AppStack log retention is included for #buildTool'() {
+    void 'Function AppStack log retention is included for #buildTool'(BuildTool buildTool) {
         when:
-        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool), [LambdaFunctionUrl.NAME])
+        def output = generate(ApplicationType.FUNCTION, createOptions(buildTool), [LambdaFunctionUrl.NAME])
 
         then:
         output.'infra/src/main/java/example/micronaut/AppStack.java'.contains('import software.amazon.awscdk.services.logs.RetentionDays;')
@@ -50,5 +49,9 @@ class LambdaFunctionUrlSpec extends ApplicationContextSpec implements CommandOut
 
         where:
         buildTool << BuildTool.values()
+    }
+
+    private static Options createOptions(BuildTool buildTool) {
+        new Options(Language.JAVA, TestFramework.JUNIT, buildTool, AwsLambdaFeatureValidator.firstSupportedJdk())
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/LambdaFunctionUrlSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/LambdaFunctionUrlSpec.groovy
@@ -7,7 +7,9 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
+import spock.lang.IgnoreIf
 import spock.lang.Subject
+import spock.util.environment.Jvm
 
 class LambdaFunctionUrlSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
@@ -37,6 +39,7 @@ class LambdaFunctionUrlSpec extends ApplicationContextSpec implements CommandOut
         lambdaFunctionUrl.supports(ApplicationType.FUNCTION)
     }
 
+    @IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
     void 'Function AppStack log retention is included for #buildTool'() {
         when:
         def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool), [LambdaFunctionUrl.NAME])

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/awsalexa/AwsAlexaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/awsalexa/AwsAlexaSpec.groovy
@@ -8,9 +8,11 @@ import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
+import spock.util.environment.Jvm
 
 class AwsAlexaSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
@@ -153,6 +155,7 @@ class AwsAlexaSpec extends ApplicationContextSpec implements CommandOutputFixtur
     }
 
     @Unroll
+    @IgnoreIf({ Jvm.current.isJava17Compatible() })
     void 'book pojos and request handler are not generated for function, even if aws-lambda is the default feature, if you apply feature aws-alexa with maven for language=#language'() {
         when:
         def output = generate(
@@ -180,6 +183,7 @@ class AwsAlexaSpec extends ApplicationContextSpec implements CommandOutputFixtur
     }
 
     @Unroll
+    @IgnoreIf({ Jvm.current.isJava17Compatible() })
     void 'book pojos and request handler are not generated for function, even if aws-lambda is the default feature, if you apply feature aws-alexa with gradle for language=#language'() {
         when:
         def output = generate(

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/awsalexa/AwsAlexaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/awsalexa/AwsAlexaSpec.groovy
@@ -3,16 +3,16 @@ package io.micronaut.starter.feature.awsalexa
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.aws.AwsLambdaFeatureValidator
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
-import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
-import spock.util.environment.Jvm
 
 class AwsAlexaSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
@@ -155,12 +155,11 @@ class AwsAlexaSpec extends ApplicationContextSpec implements CommandOutputFixtur
     }
 
     @Unroll
-    @IgnoreIf({ Jvm.current.isJava17Compatible() })
     void 'book pojos and request handler are not generated for function, even if aws-lambda is the default feature, if you apply feature aws-alexa with maven for language=#language'() {
         when:
         def output = generate(
                 ApplicationType.FUNCTION,
-                new Options(language, BuildTool.MAVEN),
+                createOptions(language, BuildTool.MAVEN),
                 ['aws-alexa']
         )
 
@@ -183,12 +182,11 @@ class AwsAlexaSpec extends ApplicationContextSpec implements CommandOutputFixtur
     }
 
     @Unroll
-    @IgnoreIf({ Jvm.current.isJava17Compatible() })
     void 'book pojos and request handler are not generated for function, even if aws-lambda is the default feature, if you apply feature aws-alexa with gradle for language=#language'() {
         when:
-        def output = generate(
+        Map<String, String> output = generate(
                 ApplicationType.FUNCTION,
-                new Options(language),
+                createOptions(language),
                 ['aws-alexa']
         )
 
@@ -232,5 +230,9 @@ class AwsAlexaSpec extends ApplicationContextSpec implements CommandOutputFixtur
         extension << Language.extensions()
         srcDir << Language.srcDirs()
         testSrcDir << Language.testSrcDirs()
+    }
+
+    private static Options createOptions(Language language, BuildTool buildTool = BuildTool.GRADLE) {
+        new Options(language, language.getDefaults().getTest(), buildTool, AwsLambdaFeatureValidator.firstSupportedJdk())
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/gradle/GradleSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/gradle/GradleSpec.groovy
@@ -4,6 +4,7 @@ import io.micronaut.starter.BeanContextSpec
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.build.Property
 import io.micronaut.starter.build.gradle.GradleBuild
+import io.micronaut.starter.feature.aws.AwsLambdaFeatureValidator
 import io.micronaut.starter.feature.build.MicronautBuildPlugin
 import io.micronaut.starter.feature.build.gradle.templates.gradleProperties
 import io.micronaut.starter.feature.build.gradle.templates.settingsGradle
@@ -12,6 +13,7 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
 import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Unroll
@@ -127,11 +129,11 @@ class GradleSpec extends BeanContextSpec implements CommandOutputFixture {
         BuildTool.GRADLE_KOTLIN | 'build.gradle.kts' | 'graalvmNative.toolchainDetection.set(false)'
     }
 
-    void 'Supporeted langaues have both Gradle and Graalvm plugin docs (lang = #lang, buildTool = #buildTool, apptype = #apptype)'(
+    void 'Supported languages have both Gradle and Graalvm plugin docs (lang = #lang, buildTool = #buildTool, apptype = #apptype)'(
             ApplicationType apptype, Language lang, BuildTool buildTool
     ) {
         when:
-        def output = generate(apptype, new Options(lang, buildTool))
+        def output = generate(apptype, new Options(lang, TestFramework.DEFAULT_OPTION, buildTool, jdk))
         def readme = output["README.md"]
 
         then:
@@ -140,8 +142,9 @@ class GradleSpec extends BeanContextSpec implements CommandOutputFixture {
         readme.contains(MicronautBuildPlugin.GRAALVM_GRADLE_DOCS_URL)
 
         where:
-        [lang, buildTool, apptype] << [
+        [lang, jdk, buildTool, apptype] << [
                 GraalVMFeatureValidator.supportedLanguages(),
+                AwsLambdaFeatureValidator.supportedJdks(),
                 BuildTool.valuesGradle(),
                 ApplicationType.values().toList()
         ].combinations()
@@ -151,7 +154,7 @@ class GradleSpec extends BeanContextSpec implements CommandOutputFixture {
             ApplicationType apptype, Language lang, BuildTool buildTool
     ) {
         when:
-        def output = generate(apptype, new Options(lang, buildTool))
+        def output = generate(apptype, new Options(lang, TestFramework.DEFAULT_OPTION, buildTool, jdk))
         def readme = output["README.md"]
 
         then:
@@ -160,8 +163,9 @@ class GradleSpec extends BeanContextSpec implements CommandOutputFixture {
         !readme.contains(MicronautBuildPlugin.GRAALVM_GRADLE_DOCS_URL)
 
         where:
-        [lang, buildTool, apptype] << [
+        [lang, jdk, buildTool, apptype] << [
                 Language.values().toList() - GraalVMFeatureValidator.supportedLanguages(),
+                AwsLambdaFeatureValidator.supportedJdks(),
                 BuildTool.valuesGradle(),
                 ApplicationType.values().toList()
         ].combinations()

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
@@ -4,21 +4,16 @@ import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.application.generator.GeneratorContext
-import io.micronaut.starter.build.maven.MavenBuild
-import io.micronaut.starter.build.maven.MavenCombineAttribute
-import io.micronaut.starter.build.maven.MavenPlugin
-import io.micronaut.starter.feature.Features
-import io.micronaut.starter.feature.build.MicronautBuildPlugin
-import io.micronaut.starter.feature.build.gradle.Gradle
-import io.micronaut.starter.feature.build.maven.templates.pom
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.util.VersionInfo
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Unroll
+import spock.util.environment.Jvm
 
 class MavenSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
@@ -43,7 +38,21 @@ class MavenSpec extends ApplicationContextSpec implements CommandOutputFixture {
         readme.contains(Maven.MICRONAUT_MAVEN_DOCS_URL)
 
         where:
-        [lang, apptype] << [ Language.values().toList(), ApplicationType.values().toList() ].combinations()
+        [lang, apptype] << [ Language.values().toList(), ApplicationType.values() - ApplicationType.FUNCTION ].combinations()
+    }
+
+    @IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
+    void 'Readme has Maven plugin docs (lang = #lang) for FUNCTION'(Language lang) {
+        when:
+        def output = generate(ApplicationType.FUNCTION, new Options(lang, BuildTool.MAVEN))
+        def readme = output["README.md"]
+
+        then:
+        readme
+        readme.contains(Maven.MICRONAUT_MAVEN_DOCS_URL)
+
+        where:
+        lang << Language.values().toList()
     }
 
     void "multi-module-pom isn't created for single-module builds"() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/awslambda/AwsLambdaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/awslambda/AwsLambdaSpec.groovy
@@ -8,11 +8,18 @@ import io.micronaut.starter.build.BuildTestVerifier
 import io.micronaut.starter.feature.MicronautRuntimeFeature
 import io.micronaut.starter.feature.graalvm.GraalVMFeatureValidator
 import io.micronaut.starter.fixture.CommandOutputFixture
-import io.micronaut.starter.options.*
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
+import spock.util.environment.Jvm
 
+@IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
 class AwsLambdaSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Shared

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/LogbackSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/LogbackSpec.groovy
@@ -1,12 +1,20 @@
 package io.micronaut.starter.feature.logging
 
 import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.aws.AwsLambdaFeatureValidator
 import io.micronaut.starter.feature.function.awslambda.AwsLambda
 import io.micronaut.starter.fixture.CommandOutputFixture
-import spock.lang.IgnoreIf
-import spock.util.environment.Jvm
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
+import spock.lang.Shared
 
 class LogbackSpec extends ApplicationContextSpec  implements CommandOutputFixture {
+    @Shared
+    Options options = new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, AwsLambdaFeatureValidator.firstSupportedJdk())
+
     void 'by default jansi true'() {
         when:
         Map<String, String> output = generate([])
@@ -18,10 +26,9 @@ class LogbackSpec extends ApplicationContextSpec  implements CommandOutputFixtur
         xml.contains("<pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>")
     }
 
-    @IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
     void 'with aws-lambda with jansi false since CloudWatch does not works with jansi'() {
         when:
-        Map<String, String> output = generate([AwsLambda.FEATURE_NAME_AWS_LAMBDA])
+        Map<String, String> output = generate(ApplicationType.FUNCTION, options, [AwsLambda.FEATURE_NAME_AWS_LAMBDA])
         String xml = output["src/main/resources/logback.xml"]
 
         then:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/LogbackSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/LogbackSpec.groovy
@@ -3,6 +3,8 @@ package io.micronaut.starter.feature.logging
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.feature.function.awslambda.AwsLambda
 import io.micronaut.starter.fixture.CommandOutputFixture
+import spock.lang.IgnoreIf
+import spock.util.environment.Jvm
 
 class LogbackSpec extends ApplicationContextSpec  implements CommandOutputFixture {
     void 'by default jansi true'() {
@@ -16,6 +18,7 @@ class LogbackSpec extends ApplicationContextSpec  implements CommandOutputFixtur
         xml.contains("<pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>")
     }
 
+    @IgnoreIf( value = { Jvm.current.isJava17Compatible() }, reason = "AWS Lambda does not have a Java 17 runtime" )
     void 'with aws-lambda with jansi false since CloudWatch does not works with jansi'() {
         when:
         Map<String, String> output = generate([AwsLambda.FEATURE_NAME_AWS_LAMBDA])

--- a/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
+++ b/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
@@ -30,6 +30,7 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.util.NameUtils
+import io.micronaut.starter.util.VersionInfo
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import spock.lang.AutoCleanup
@@ -125,11 +126,14 @@ abstract class CommandSpec extends Specification {
                          ApplicationType applicationType = ApplicationType.DEFAULT,
                          TestFramework testFramework = lang.getDefaults().test,
                          boolean addMicronautGradleEnterpriseFeature = true,
-                         JdkVersion jdkVersion = JdkVersion.JDK_11) {
+                         JdkVersion maxJdkVersion = JdkVersion.JDK_11) {
         if (addMicronautGradleEnterpriseFeature) {
             features += [MicronautGradleEnterprise.NAME]
         }
-
+        JdkVersion jdkVersion = VersionInfo.getJavaVersion();
+        if (jdkVersion.greaterThanEqual(maxJdkVersion)) {
+            jdkVersion = maxJdkVersion
+        }
         beanContext.getBean(ProjectGenerator).generate(applicationType,
                 NameUtils.parse("example.micronaut.foo"),
                 new Options(lang, testFramework, buildTool, jdkVersion),

--- a/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
+++ b/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
@@ -25,6 +25,7 @@ import io.micronaut.starter.io.ConsoleOutput
 import io.micronaut.starter.io.FileSystemOutputHandler
 import io.micronaut.starter.io.OutputHandler
 import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
@@ -123,15 +124,15 @@ abstract class CommandSpec extends Specification {
                          List<String> features = [],
                          ApplicationType applicationType = ApplicationType.DEFAULT,
                          TestFramework testFramework = lang.getDefaults().test,
-                         boolean addMicronautGradleEnterpriseFeature = true
-    ) {
+                         boolean addMicronautGradleEnterpriseFeature = true,
+                         JdkVersion jdkVersion = JdkVersion.JDK_11) {
         if (addMicronautGradleEnterpriseFeature) {
             features += [MicronautGradleEnterprise.NAME]
         }
 
         beanContext.getBean(ProjectGenerator).generate(applicationType,
                 NameUtils.parse("example.micronaut.foo"),
-                new Options(lang, testFramework, buildTool),
+                new Options(lang, testFramework, buildTool, jdkVersion),
                 io.micronaut.starter.application.OperatingSystem.LINUX,
                 features,
                 new FileSystemOutputHandler(dir, ConsoleOutput.NOOP),


### PR DESCRIPTION
closes #1699

This PR validates that AWS Lambda features cannot be selected for JDK 17, unless the GraalVM featre is also selected, since AWS doesn't yet have a a runtime. 

However, this is a bit more invloved than just changing the feature and adding new tests for the validator. I had to disable tests for JDK 17 that use AWS Lambda features without Graalvm feature, a combination no longer allowed with `AwsLambdaFeatureValidator`.

But this is rather a bit of smell. Some of these tests are not directly related to testing `AwsLambda` features, but merely test something else for all application types, where `ApplicationType.FUNCTION` by default selects the "aws-lambda" feature, which in turn now results in raising an  exception for JDK 17. With Micronaut 3.x these tests will run when CI is JDK 8 and JDK 11. However, with Micronaut 4 they won't run at all. Maybe an alternative is to rewrite those tests to either include the "graalvm" feature or a JDK 17-supported FUNCTION feature (OCI or Azure).

It also seems to me that for Micronaut 4, Creating a "Function Application for Serverless" should no longer apply the "aws-lambda" feature by default, or if it does it needs to include the "graalvm' feature to work. Maybe this is the fix for this situation?

@sdelamo thoughts?