### PR TITLE
Cleanup generation of maven-kotlin-graalvm projects

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
@@ -100,7 +100,7 @@ public class MavenBuildCreator {
         if (testCombineAttribute == MavenCombineAttribute.OVERRIDE) {
             testAnnotationProcessorsCoordinates.add(injectJava);
             testAnnotationProcessorsCoordinates.add(validation);
-            annotationProcessorsCoordinates.add(mnGraal);
+            testAnnotationProcessorsCoordinates.add(mnGraal);
         }
 
         annotationProcessorsCoordinates.sort(Coordinate.COMPARATOR);

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dependencies.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dependencies.rocker.raw
@@ -16,9 +16,6 @@ dependencies {
 @for (GradleDependency dependency : gradleBuild.getDependencies()) {
     @dependency.toSnippet()
 }
-@if (features.contains("graalvm")) {
-    @dependency.template("org.graalvm.nativeimage", "svm", "compileOnly", null, false)
-}
     @dependency.template("io.micronaut", "micronaut-validation", "implementation", null, false)
 @if (features.contains("oracle-function")) {
     @if (!features.contains("oracle-function-http")) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -130,9 +130,6 @@ MavenBuild mavenBuild
 }
 }
 
-@if (features.contains("graalvm") && features.language().isGroovy()) {
-@dependency.template("io.micronaut", "micronaut-graal", "provided", null, false, null)
-}
 @if (features.contains("openapi")) {
 @if (features.language().isGroovy()) {
 @dependency.template("io.micronaut.openapi", "micronaut-openapi", "compile", null, false, null)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/graalvm/GraalVM.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/graalvm/GraalVM.java
@@ -18,23 +18,19 @@ package io.micronaut.starter.feature.graalvm;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
-import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
-import io.micronaut.starter.options.BuildTool;
-import io.micronaut.starter.options.Language;
-
 import jakarta.inject.Singleton;
 
 @Singleton
 public class GraalVM implements Feature {
-    Dependency GRAAL_SVM = Dependency.builder()
+    public static final String FEATURE_NAME_GRAALVM = "graalvm";
+
+    static final Dependency GRAAL_SVM = Dependency.builder()
             .groupId("org.graalvm.nativeimage")
             .artifactId("svm")
             .compileOnly()
             .build();
-
-    public static final String FEATURE_NAME_GRAALVM = "graalvm";
 
     @Override
     public String getName() {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/graalvm/GraalVM.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/graalvm/GraalVM.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.feature.graalvm;
 
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
@@ -27,6 +28,11 @@ import jakarta.inject.Singleton;
 
 @Singleton
 public class GraalVM implements Feature {
+    Dependency GRAAL_SVM = Dependency.builder()
+            .groupId("org.graalvm.nativeimage")
+            .artifactId("svm")
+            .compileOnly()
+            .build();
 
     public static final String FEATURE_NAME_GRAALVM = "graalvm";
 
@@ -57,11 +63,8 @@ public class GraalVM implements Feature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        if (generatorContext.getBuildTool() == BuildTool.MAVEN && generatorContext.getLanguage() == Language.KOTLIN) {
-            generatorContext.addDependency(MicronautDependencyUtils.coreDependency()
-                    .artifactId("micronaut-graal")
-                    .versionProperty("micronaut.version")
-                    .annotationProcessor());
+        if (generatorContext.getBuildTool().isGradle()) {
+            generatorContext.addDependency(GRAAL_SVM);
         }
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
@@ -10,7 +10,6 @@ import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
-import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.util.VersionInfo
 import spock.lang.Shared
 import spock.lang.Unroll


### PR DESCRIPTION
Projects with Maven/Koltin/GraalVM features had `micronaut-graal` added to kapt plugin annotationProcessorPaths three times.