### PR TITLE
Fixing missing dependencies for Gradle projects with "azure-function-http" feature

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MicronautDependencyUtils.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MicronautDependencyUtils.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.NonNull;
 public final class MicronautDependencyUtils {
     public static final String GROUP_ID_MICRONAUT = "io.micronaut";
     public static final String GROUP_ID_MICRONAUT_AWS = "io.micronaut.aws";
+    public static final String GROUP_ID_MICRONAUT_AZURE = "io.micronaut.azure";
     public static final String GROUP_ID_MICRONAUT_CRAC = "io.micronaut.crac";
     public static final String GROUP_ID_MICRONAUT_GCP = "io.micronaut.gcp";
     public static final String GROUP_ID_MICRONAUT_SERDE = "io.micronaut.serde";
@@ -46,6 +47,11 @@ public final class MicronautDependencyUtils {
     @NonNull
     public static Dependency.Builder awsDependency() {
         return micronautDependency(GROUP_ID_MICRONAUT_AWS);
+    }
+
+    @NonNull
+    public static Dependency.Builder azureDependency() {
+        return micronautDependency(GROUP_ID_MICRONAUT_AZURE);
     }
 
     @NonNull

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dependencies.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dependencies.rocker.raw
@@ -33,12 +33,6 @@ dependencies {
     }
 }
 
-@if (features.contains("azure-function")) {
-    @if (!features.contains("azure-function-http")) {
-    @dependency.template("com.microsoft.azure.functions", "azure-functions-java-library", "implementation", null, false)
-    @dependency.template("io.micronaut.azure", "micronaut-azure-function", "implementation", null, false)
-    }
-}
 @if (features.language().isKotlin()) {
     @dependency.template("com.fasterxml.jackson.module", "jackson-module-kotlin", "runtimeOnly", null, false)
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -108,15 +108,6 @@ MavenBuild mavenBuild
 @dependency.template("io.micronaut.gcp", "micronaut-gcp-function", "compile", null, false, null)
     }
 }
-@if (features.contains("azure-function")) {
-@dependency.template("com.microsoft.azure.functions", "azure-functions-java-library", "provided", null, false, null)
-@if (features.contains("azure-function-http")) {
-@dependency.template("io.micronaut.azure", "micronaut-azure-function-http", "compile", null, false, null)
-@dependency.template("io.micronaut.azure", "micronaut-azure-function-http-test", "test", null, false, null)
-} else {
-@dependency.template("io.micronaut.azure", "micronaut-azure-function", "compile", null, false, null)
-}
-}
 
 @if (features.contains("oracle-function")) {
 @dependency.template("com.fnproject.fn", "runtime", "runtime", null, false, null)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
@@ -22,6 +22,8 @@ import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.BuildProperties;
 import io.micronaut.starter.build.dependencies.CoordinateResolver;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.build.gradle.GradleDsl;
 import io.micronaut.starter.build.gradle.GradlePlugin;
 import io.micronaut.starter.build.maven.MavenPlugin;
@@ -51,6 +53,15 @@ import java.util.Optional;
 public abstract class AbstractAzureFunction extends AbstractFunctionFeature implements AzureCloudFeature, AzureMicronautRuntimeFeature {
 
     public static final String NAME = "azure-function";
+
+    private static final Dependency MICRONAUT_AZURE_FUNCTION = MicronautDependencyUtils
+            .azureDependency()
+            .artifactId("micronaut-azure-function")
+            .compile()
+            .build();
+    private static final Dependency.Builder AZURE_FUNCTION_JAVA_LIBRARY = Dependency.builder()
+            .groupId("com.microsoft.azure.functions")
+            .artifactId("azure-functions-java-library");
 
     private final CoordinateResolver coordinateResolver;
 
@@ -94,6 +105,7 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
                     .lookupArtifactId("azure-functions-gradle-plugin")
                     .extension(new RockerWritable(azurefunctions.template(generatorContext.getProject(), generatorContext.getBuildTool().getGradleDsl().orElse(GradleDsl.GROOVY), javaVersionValue(generatorContext).orElse("null"))))
                     .build());
+            generatorContext.addDependency(AZURE_FUNCTION_JAVA_LIBRARY.compile());
         } else if (buildTool == BuildTool.MAVEN) {
             String mavenPluginArtifactId = "azure-functions-maven-plugin";
             generatorContext.addBuildPlugin(MavenPlugin.builder()
@@ -109,7 +121,9 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
             props.put("functionRuntimeOs", "windows");
             javaVersionValue(generatorContext).ifPresent(value -> props.put("functionRuntimeJavaVersion", value));
             props.put("stagingDirectory", "${project.build.directory}/azure-functions/${functionAppName}");
+            generatorContext.addDependency(AZURE_FUNCTION_JAVA_LIBRARY.developmentOnly());
         }
+        generatorContext.addDependency(MICRONAUT_AZURE_FUNCTION);
         addFunctionTemplate(generatorContext, project);
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
@@ -123,7 +123,9 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
             props.put("stagingDirectory", "${project.build.directory}/azure-functions/${functionAppName}");
             generatorContext.addDependency(AZURE_FUNCTION_JAVA_LIBRARY.developmentOnly());
         }
-        generatorContext.addDependency(MICRONAUT_AZURE_FUNCTION);
+        if (type == ApplicationType.FUNCTION) {
+            generatorContext.addDependency(MICRONAUT_AZURE_FUNCTION);
+        }
         addFunctionTemplate(generatorContext, project);
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
@@ -32,6 +32,7 @@ import io.micronaut.starter.feature.function.azure.template.azureFunctionSpock;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionTriggerGroovy;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionTriggerJava;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionTriggerKotlin;
+import io.micronaut.starter.options.BuildTool;
 import jakarta.inject.Singleton;
 
 @Singleton
@@ -104,12 +105,18 @@ public class AzureHttpFunction extends AbstractAzureFunction implements Feature 
     @Override
     public void apply(GeneratorContext generatorContext) {
         super.apply(generatorContext);
-        generatorContext.addDependency(MICRONAUT_AZURE_FUNCTION_HTTP);
-        generatorContext.addDependency(MICRONAUT_AZURE_FUNCTION_HTTP_TEST);
+        addDependencies(generatorContext);
     }
 
     @Override
     public String getMicronautDocumentation() {
         return "https://micronaut-projects.github.io/micronaut-azure/latest/guide/index.html#azureHttpFunctions";
+    }
+    
+    protected void addDependencies(GeneratorContext generatorContext) {
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
+            generatorContext.addDependency(MICRONAUT_AZURE_FUNCTION_HTTP);
+            generatorContext.addDependency(MICRONAUT_AZURE_FUNCTION_HTTP_TEST);
+        }
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
@@ -103,17 +103,13 @@ public class AzureHttpFunction extends AbstractAzureFunction implements Feature 
     }
 
     @Override
-    public void apply(GeneratorContext generatorContext) {
-        super.apply(generatorContext);
-        addDependencies(generatorContext);
-    }
-
-    @Override
     public String getMicronautDocumentation() {
         return "https://micronaut-projects.github.io/micronaut-azure/latest/guide/index.html#azureHttpFunctions";
     }
-    
+
+    @Override
     protected void addDependencies(GeneratorContext generatorContext) {
+        super.addDependencies(generatorContext);
         if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
             generatorContext.addDependency(MICRONAUT_AZURE_FUNCTION_HTTP);
             generatorContext.addDependency(MICRONAUT_AZURE_FUNCTION_HTTP_TEST);

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
@@ -24,7 +24,6 @@ import io.micronaut.starter.build.dependencies.CoordinateResolver;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.Feature;
-import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionGroovyJunit;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionJavaJunit;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionKoTest;
@@ -33,7 +32,6 @@ import io.micronaut.starter.feature.function.azure.template.azureFunctionSpock;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionTriggerGroovy;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionTriggerJava;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionTriggerKotlin;
-
 import jakarta.inject.Singleton;
 
 @Singleton

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
@@ -21,7 +21,10 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.CoordinateResolver;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionGroovyJunit;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionJavaJunit;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionKoTest;
@@ -35,6 +38,18 @@ import jakarta.inject.Singleton;
 
 @Singleton
 public class AzureHttpFunction extends AbstractAzureFunction implements Feature {
+
+    private static final Dependency MICRONAUT_AZURE_FUNCTION_HTTP = MicronautDependencyUtils
+            .azureDependency()
+            .artifactId("micronaut-azure-function-http")
+            .compile()
+            .build();
+
+    private static final Dependency MICRONAUT_AZURE_FUNCTION_HTTP_TEST = MicronautDependencyUtils
+            .azureDependency()
+            .artifactId("micronaut-azure-function-http-test")
+            .test()
+            .build();
 
     public AzureHttpFunction(CoordinateResolver coordinateResolver) {
         super(coordinateResolver);
@@ -86,6 +101,13 @@ public class AzureHttpFunction extends AbstractAzureFunction implements Feature 
                     azureFunctionTriggerGroovy.template(project));
         }
 
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        super.apply(generatorContext);
+        generatorContext.addDependency(MICRONAUT_AZURE_FUNCTION_HTTP);
+        generatorContext.addDependency(MICRONAUT_AZURE_FUNCTION_HTTP_TEST);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureRawFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureRawFunction.java
@@ -20,6 +20,8 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.CoordinateResolver;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionReadme;
 import io.micronaut.starter.feature.function.azure.template.raw.azureRawFunctionHttpRequestJava;
@@ -36,6 +38,11 @@ import java.util.Optional;
 
 @Singleton
 public class AzureRawFunction extends AbstractAzureFunction {
+    private static final Dependency MICRONAUT_AZURE_FUNCTION = MicronautDependencyUtils
+            .azureDependency()
+            .artifactId("micronaut-azure-function")
+            .compile()
+            .build();
     private final AzureHttpFunction httpFunction;
 
     public AzureRawFunction(CoordinateResolver coordinateResolver, AzureHttpFunction httpFunction) {
@@ -113,5 +120,11 @@ public class AzureRawFunction extends AbstractAzureFunction {
     @Override
     public String getThirdPartyDocumentation() {
         return "https://docs.microsoft.com/azure";
+    }
+
+    @Override
+    protected void addDependencies(GeneratorContext generatorContext) {
+        super.addDependencies(generatorContext);
+        generatorContext.addDependency(MICRONAUT_AZURE_FUNCTION);
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureHttpFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureHttpFunctionSpec.groovy
@@ -63,7 +63,7 @@ class AzureHttpFunctionSpec extends BeanContextSpec  implements CommandOutputFix
         readme.contains("The application's build uses [Azure Functions Plugin for Gradle](https://plugins.gradle.org/plugin/com.microsoft.azure.azurefunctions).")
     }
 
-    void 'test gradle azure-function-http feature for language=#language and buildTool=#buildTool'() {
+    void 'test gradle azure-function-http feature for language=#language and buildTool=#buildTool'(Language language, BuildTool buildTool) {
         when:
         String template = new BuildBuilder(beanContext, buildTool)
                 .features(['azure-function-http'])
@@ -72,9 +72,16 @@ class AzureHttpFunctionSpec extends BeanContextSpec  implements CommandOutputFix
         BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
 
         then:
-        verifier.hasDependency("io.micronaut.azure", "micronaut-azure-function-http", Scope.COMPILE)
-        verifier.hasDependency("io.micronaut.azure", "micronaut-azure-function-http-test", Scope.TEST)
-        verifier.hasDependency("com.microsoft.azure.functions", "azure-functions-java-library")
+        if (buildTool.isGradle()) {
+            assert !verifier.hasDependency("io.micronaut.azure", "micronaut-azure-function-http", Scope.COMPILE)
+            assert !verifier.hasDependency("io.micronaut.azure", "micronaut-azure-function-http-test", Scope.TEST)
+            assert !verifier.hasDependency("com.microsoft.azure.functions", "azure-functions-java-library")
+
+        } else if (buildTool == BuildTool.MAVEN) {
+            assert verifier.hasDependency("io.micronaut.azure", "micronaut-azure-function-http", Scope.COMPILE)
+            assert verifier.hasDependency("io.micronaut.azure", "micronaut-azure-function-http-test", Scope.TEST)
+            assert verifier.hasDependency("com.microsoft.azure.functions", "azure-functions-java-library")
+        }
 
         where:
         [language, buildTool] << [Language.values().toList(), BuildTool.values().toList()].combinations()

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureHttpFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureHttpFunctionSpec.groovy
@@ -1,7 +1,11 @@
 package io.micronaut.starter.feature.function.azure
 
 import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.*
 
@@ -57,5 +61,22 @@ class AzureHttpFunctionSpec extends BeanContextSpec  implements CommandOutputFix
 
         and: 'link to Azure Gradle Plugin'
         readme.contains("The application's build uses [Azure Functions Plugin for Gradle](https://plugins.gradle.org/plugin/com.microsoft.azure.azurefunctions).")
+    }
+
+    void 'test gradle azure-function-http feature for language=#language and buildTool=#buildTool'() {
+        when:
+        String template = new BuildBuilder(beanContext, buildTool)
+                .features(['azure-function-http'])
+                .language(language)
+                .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
+
+        then:
+        verifier.hasDependency("io.micronaut.azure", "micronaut-azure-function-http", Scope.COMPILE)
+        verifier.hasDependency("io.micronaut.azure", "micronaut-azure-function-http-test", Scope.TEST)
+        verifier.hasDependency("com.microsoft.azure.functions", "azure-functions-java-library")
+
+        where:
+        [language, buildTool] << [Language.values().toList(), BuildTool.values().toList()].combinations()
     }
 }


### PR DESCRIPTION
Fixing missing dependencies for Gradle projects with "azure-function-http" feature, to make that consistent with Maven projects. Refactor dependency logic from Rocker files to Feature classes.