### PR TITLE
Fix missing dependencies for Gradle projects with "oracle-function-http" feature,

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MicronautDependencyUtils.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MicronautDependencyUtils.java
@@ -22,6 +22,7 @@ public final class MicronautDependencyUtils {
     public static final String GROUP_ID_MICRONAUT_AWS = "io.micronaut.aws";
     public static final String GROUP_ID_MICRONAUT_CRAC = "io.micronaut.crac";
     public static final String GROUP_ID_MICRONAUT_GCP = "io.micronaut.gcp";
+    public static final String GROUP_ID_MICRONAUT_OCI = "io.micronaut.oraclecloud";
     public static final String GROUP_ID_MICRONAUT_SERDE = "io.micronaut.serde";
     public static final String GROUP_ID_MICRONAUT_SECURITY = "io.micronaut.security";
     public static final String GROUP_ID_MICRONAUT_TRACING = "io.micronaut.tracing";
@@ -107,5 +108,10 @@ public final class MicronautDependencyUtils {
     @NonNull
     public static Dependency.Builder gcpDependency() {
         return micronautDependency(GROUP_ID_MICRONAUT_GCP);
+    }
+
+    @NonNull
+    public static Dependency.Builder ociDependency() {
+        return micronautDependency(GROUP_ID_MICRONAUT_OCI);
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dependencies.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dependencies.rocker.raw
@@ -17,14 +17,6 @@ dependencies {
     @dependency.toSnippet()
 }
     @dependency.template("io.micronaut", "micronaut-validation", "implementation", null, false)
-@if (features.contains("oracle-function")) {
-    @if (!features.contains("oracle-function-http")) {
-    @dependency.template("io.micronaut.oraclecloud", "micronaut-oraclecloud-function", "implementation", null, false)
-    @dependency.template("com.fnproject.fn", "api", "implementation", null, false)
-    @dependency.template("com.fnproject.fn", "runtime", "runtimeOnly", null, false)
-    @dependency.template("com.fnproject.fn", "testing-junit4", "testImplementation", null, false)
-    }
-}
 @if (features.contains("google-cloud-function")) {
     @if (!features.contains("google-cloud-function-http")) {
     @dependency.template("com.google.cloud.functions", "functions-framework-api", "compileOnly", null, false)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -118,18 +118,6 @@ MavenBuild mavenBuild
 }
 }
 
-@if (features.contains("oracle-function")) {
-@dependency.template("com.fnproject.fn", "runtime", "runtime", null, false, null)
-@if (features.contains("oracle-function-http")) {
-@dependency.template("io.micronaut.oraclecloud", "micronaut-oraclecloud-function-http", "compile", null, false, null)
-@dependency.template("io.micronaut.oraclecloud", "micronaut-oraclecloud-function-http-test", "test", null, false, null)
-} else {
-@dependency.template("io.micronaut.oraclecloud", "micronaut-oraclecloud-function", "compile", null, false, null)
-@dependency.template("com.fnproject.fn", "api", "compile", null, false, null)
-@dependency.template("com.fnproject.fn", "testing-junit4", "test", null, false, null)
-}
-}
-
 @if (features.contains("openapi")) {
 @if (features.language().isGroovy()) {
 @dependency.template("io.micronaut.openapi", "micronaut-openapi", "compile", null, false, null)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/oraclefunction/OracleFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/oraclefunction/OracleFunction.java
@@ -22,6 +22,8 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.function.AbstractFunctionFeature;
 import io.micronaut.starter.feature.function.oraclefunction.template.projectFnFunc;
@@ -40,6 +42,17 @@ import jakarta.inject.Singleton;
 @Singleton
 @Primary
 public class OracleFunction extends AbstractFunctionFeature implements OracleCloudFeature {
+    private static final Dependency MICRONAUT_OCI_FUNCTION_HTTP = MicronautDependencyUtils
+            .ociDependency()
+            .artifactId("micronaut-oraclecloud-function-http")
+            .compile()
+            .build();
+
+    private static final Dependency MICRONAUT_OCI_FUNCTION_HTTP_TEST = MicronautDependencyUtils
+            .ociDependency()
+            .artifactId("micronaut-oraclecloud-function-http-test")
+            .test()
+            .build();
 
     private final SimpleLogging simpleLogging;
 
@@ -68,6 +81,8 @@ public class OracleFunction extends AbstractFunctionFeature implements OracleClo
                         projectFnFunc.template(generatorContext.getProject()
                 ))
         );
+        generatorContext.addDependency(MICRONAUT_OCI_FUNCTION_HTTP);
+        generatorContext.addDependency(MICRONAUT_OCI_FUNCTION_HTTP_TEST);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/oraclefunction/OracleFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/oraclefunction/OracleFunction.java
@@ -42,6 +42,12 @@ import jakarta.inject.Singleton;
 @Singleton
 @Primary
 public class OracleFunction extends AbstractFunctionFeature implements OracleCloudFeature {
+    public static final String GROUP_ID_COM_FNPROJECT_FN = "com.fnproject.fn";
+    public static final Dependency COM_FNPROJECT_RUNTIME = Dependency.builder()
+            .groupId(GROUP_ID_COM_FNPROJECT_FN)
+            .artifactId("runtime")
+            .runtime()
+            .build();
     private static final Dependency MICRONAUT_OCI_FUNCTION_HTTP = MicronautDependencyUtils
             .ociDependency()
             .artifactId("micronaut-oraclecloud-function-http")
@@ -53,7 +59,6 @@ public class OracleFunction extends AbstractFunctionFeature implements OracleClo
             .artifactId("micronaut-oraclecloud-function-http-test")
             .test()
             .build();
-
     private final SimpleLogging simpleLogging;
 
     public OracleFunction(SimpleLogging simpleLogging) {
@@ -75,17 +80,12 @@ public class OracleFunction extends AbstractFunctionFeature implements OracleClo
     @Override
     public void apply(GeneratorContext generatorContext) {
         super.apply(generatorContext);
-        generatorContext.addTemplate(
-                "func.yml", new RockerTemplate(
-                        "func.yml",
-                        projectFnFunc.template(generatorContext.getProject()
-                ))
-        );
-        generatorContext.addDependency(MICRONAUT_OCI_FUNCTION_HTTP);
-        generatorContext.addDependency(MICRONAUT_OCI_FUNCTION_HTTP_TEST);
+        addDependencies(generatorContext);
+        addFuncYamlTemplate(generatorContext);
     }
 
     @Override
+    @NonNull
     public String getName() {
         return "oracle-function-http";
     }
@@ -96,6 +96,7 @@ public class OracleFunction extends AbstractFunctionFeature implements OracleClo
     }
 
     @Override
+    @NonNull
     public String getDescription() {
         return "Adds support for writing functions to deploy to Oracle Cloud Function";
     }
@@ -168,5 +169,22 @@ public class OracleFunction extends AbstractFunctionFeature implements OracleClo
     @NonNull
     public String resolveMicronautRuntime(@NonNull GeneratorContext generatorContext) {
         return "oracle_function";
+    }
+
+    protected void addDependencies(GeneratorContext generatorContext) {
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
+            generatorContext.addDependency(COM_FNPROJECT_RUNTIME);
+            generatorContext.addDependency(MICRONAUT_OCI_FUNCTION_HTTP);
+            generatorContext.addDependency(MICRONAUT_OCI_FUNCTION_HTTP_TEST);
+        }
+    }
+
+    protected void addFuncYamlTemplate(GeneratorContext generatorContext) {
+        generatorContext.addTemplate(
+                "func.yml", new RockerTemplate(
+                        "func.yml",
+                        projectFnFunc.template(generatorContext.getProject()
+                        ))
+        );
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/oraclefunction/OracleRawFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/oraclefunction/OracleRawFunction.java
@@ -20,6 +20,8 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.function.oraclefunction.template.raw.oracleRawFunctionGroovy;
 import io.micronaut.starter.feature.function.oraclefunction.template.raw.oracleRawFunctionGroovyJunit;
@@ -38,6 +40,15 @@ import jakarta.inject.Singleton;
 @Singleton
 public class OracleRawFunction extends OracleFunction {
     public static final String FEATURE_NAME_ORACLE_RAW_FUNCTION = "oracle-function";
+
+    private static final Dependency MICRONAUT_OCI_FUNCTION = MicronautDependencyUtils
+            .ociDependency()
+            .artifactId("micronaut-oraclecloud-function")
+            .compile()
+            .build();
+
+    private static final Dependency.Builder COM_FNPROJECT = Dependency.builder()
+            .groupId("com.fnproject.fn");
 
     private final OracleFunction httpFunction;
 
@@ -96,6 +107,25 @@ public class OracleRawFunction extends OracleFunction {
             }
 
             applyTestTemplate(generatorContext, project, "Function");
+        }
+        addDependencies(generatorContext);
+    }
+
+    private void addDependencies(GeneratorContext generatorContext) {
+        generatorContext.addDependency(COM_FNPROJECT
+                .artifactId("runtime")
+                .runtime()
+        );
+        if (generatorContext.getApplicationType() == ApplicationType.FUNCTION) {
+            generatorContext.addDependency(MICRONAUT_OCI_FUNCTION);
+            generatorContext.addDependency(COM_FNPROJECT
+                    .artifactId("api")
+                    .compile()
+            );
+            generatorContext.addDependency(COM_FNPROJECT
+                    .artifactId("testing-junit4")
+                    .test()
+            );
         }
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/oraclefunction/OracleRawFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/oraclefunction/OracleRawFunction.java
@@ -16,6 +16,7 @@
 package io.micronaut.starter.feature.function.oraclefunction;
 
 import com.fizzed.rocker.RockerModel;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.Project;
@@ -46,9 +47,17 @@ public class OracleRawFunction extends OracleFunction {
             .artifactId("micronaut-oraclecloud-function")
             .compile()
             .build();
+    private static final Dependency COM_FNPROJECT_API = Dependency.builder()
+            .groupId(GROUP_ID_COM_FNPROJECT_FN)
+            .artifactId("api")
+            .compile()
+            .build();
 
-    private static final Dependency.Builder COM_FNPROJECT = Dependency.builder()
-            .groupId("com.fnproject.fn");
+    private static final Dependency COM_FNPROJECT_TESTING_JUNIT4 = Dependency.builder()
+            .groupId(GROUP_ID_COM_FNPROJECT_FN)
+            .artifactId("testing-junit4")
+            .test()
+            .build();
 
     private final OracleFunction httpFunction;
 
@@ -58,6 +67,7 @@ public class OracleRawFunction extends OracleFunction {
     }
 
     @Override
+    @NonNull
     public String getName() {
         return FEATURE_NAME_ORACLE_RAW_FUNCTION;
     }
@@ -111,21 +121,13 @@ public class OracleRawFunction extends OracleFunction {
         addDependencies(generatorContext);
     }
 
-    private void addDependencies(GeneratorContext generatorContext) {
-        generatorContext.addDependency(COM_FNPROJECT
-                .artifactId("runtime")
-                .runtime()
-        );
+    @Override
+    protected void addDependencies(GeneratorContext generatorContext) {
         if (generatorContext.getApplicationType() == ApplicationType.FUNCTION) {
             generatorContext.addDependency(MICRONAUT_OCI_FUNCTION);
-            generatorContext.addDependency(COM_FNPROJECT
-                    .artifactId("api")
-                    .compile()
-            );
-            generatorContext.addDependency(COM_FNPROJECT
-                    .artifactId("testing-junit4")
-                    .test()
-            );
+            generatorContext.addDependency(COM_FNPROJECT_RUNTIME);
+            generatorContext.addDependency(COM_FNPROJECT_API);
+            generatorContext.addDependency(COM_FNPROJECT_TESTING_JUNIT4);
         }
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifier.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifier.groovy
@@ -55,7 +55,7 @@ class GradleBuildTestVerifier implements BuildTestVerifier {
     boolean hasDependency(String groupId, String artifactId, String scope) {
         // this needs to support ignoring versions for non-managed dependencies
         // but it also needs to return false for ("com.foo":"foo") when ("com.foo":"foo-bar") is present
-        String expected = /(?s).*${scope}\("${groupId}:${artifactId}(:.+)?\"\).*/
+        String expected = /(?s).*${scope}\("${groupId}:${artifactId}(?::.+)?\"\).*/
         template.matches(Pattern.compile(expected))
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifier.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifier.groovy
@@ -8,7 +8,6 @@ import io.micronaut.starter.options.TestFramework
 import java.util.regex.Pattern
 
 class GradleBuildTestVerifier implements BuildTestVerifier {
-
     final String template
     final Language language
     final TestFramework testFramework
@@ -53,10 +52,8 @@ class GradleBuildTestVerifier implements BuildTestVerifier {
 
     @Override
     boolean hasDependency(String groupId, String artifactId, String scope) {
-        // this needs to support ignoring versions for non-managed dependencies
-        // but it also needs to return false for ("com.foo":"foo") when ("com.foo":"foo-bar") is present
-        String expected = /(?s).*${scope}\("${groupId}:${artifactId}(?::.+)?\"\).*/
-        template.matches(Pattern.compile(expected))
+        String regex = /(?s).*${scope}\("${groupId}:${artifactId}(?::.+)?\"\).*/
+        template.matches(Pattern.compile(regex))
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifier.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifier.groovy
@@ -53,7 +53,9 @@ class GradleBuildTestVerifier implements BuildTestVerifier {
 
     @Override
     boolean hasDependency(String groupId, String artifactId, String scope) {
-        String expected = """(?s).*${scope}\\("${groupId}:${artifactId}(?:.+)?\\).*"""
+        // this needs to support ignoring versions for non-managed dependencies
+        // but it also needs to return false for ("com.foo":"foo") when ("com.foo":"foo-bar") is present
+        String expected = /(?s).*${scope}\("${groupId}:${artifactId}(:.+)?\"\).*/
         template.matches(Pattern.compile(expected))
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifierSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifierSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.starter.build.gradle
+
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class GradleBuildTestVerifierSpec extends Specification {
+
+    @Unroll
+    void "hasDependencyRegex"(boolean expected, String template, String groupId, String artifactId, String scope) {
+        given:
+        GradleBuildTestVerifier verifier = new GradleBuildTestVerifier(template, Language.JAVA, TestFramework.JUNIT)
+
+        expect:
+        expected == verifier.hasDependency(groupId, artifactId, scope)
+
+        where:
+        expected | template | groupId | artifactId | scope
+        false    | 'implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-function-http")'       |  "io.micronaut.oraclecloud" | "micronaut-oraclecloud-function-http" | GradleConfiguration.TEST_IMPLEMENTATION.toString()
+        true     | 'implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-function-http")'       |  "io.micronaut.oraclecloud" | "micronaut-oraclecloud-function-http" | GradleConfiguration.IMPLEMENTATION.toString()
+        true     | 'implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-function-http:2.0.0")' |  "io.micronaut.oraclecloud" | "micronaut-oraclecloud-function-http" | GradleConfiguration.IMPLEMENTATION.toString()
+        false    | 'implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-function-http")'       |  "io.micronaut"             | "micronaut-oraclecloud-function-http" | GradleConfiguration.IMPLEMENTATION.toString()
+        false    | 'implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-function-http")'       |  "io.micronaut.oraclecloud" | "micronaut-oraclecloud-function"      | GradleConfiguration.IMPLEMENTATION.toString()
+
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/oraclefunction/OracleFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/oraclefunction/OracleFunctionSpec.groovy
@@ -185,9 +185,16 @@ class OracleFunctionSpec extends BeanContextSpec  implements CommandOutputFixtur
         BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
 
         then:
-        verifier.hasDependency("com.fnproject.fn", "runtime", Scope.RUNTIME)
-        verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function-http", Scope.COMPILE)
-        verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function-http-test", Scope.TEST)
+
+        if (buildTool.isGradle()) {
+            assert !verifier.hasDependency("com.fnproject.fn", "runtime", Scope.RUNTIME)
+            assert !verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function-http", Scope.COMPILE)
+            assert !verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function-http-test", Scope.TEST)
+        } else if (buildTool == BuildTool.MAVEN) {
+            assert verifier.hasDependency("com.fnproject.fn", "runtime", Scope.RUNTIME)
+            assert verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function-http", Scope.COMPILE)
+            assert verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function-http-test", Scope.TEST)
+        }
         verifier.hasDependency("org.slf4j", "slf4j-simple", Scope.RUNTIME)
 
         !verifier.hasDependency("com.fnproject.fn", "api")

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/oraclefunction/OracleFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/oraclefunction/OracleFunctionSpec.groovy
@@ -3,6 +3,9 @@ package io.micronaut.starter.feature.function.oraclefunction
 import io.micronaut.starter.BeanContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.*
 
@@ -69,7 +72,6 @@ class OracleFunctionSpec extends BeanContextSpec  implements CommandOutputFixtur
 
         then:
         build.contains('runtime("oracle_function")')
-        build.contains('runtimeOnly("org.slf4j:slf4j-simple")')
 
         where:
         language << Language.values().toList()
@@ -90,13 +92,6 @@ class OracleFunctionSpec extends BeanContextSpec  implements CommandOutputFixtur
         readme
         funcYaml
         build.contains('<micronaut.runtime>oracle_function</micronaut.runtime>')
-
-        build.contains('''
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>runtime</scope>
-    </dependency>''')
 
         output.containsKey("${language.srcDir}/example/micronaut/Application.${language.extension}".toString())
 
@@ -152,28 +147,54 @@ class OracleFunctionSpec extends BeanContextSpec  implements CommandOutputFixtur
           </container>
         </configuration>''')
 
-        build.contains('''
-    <dependency>
-      <groupId>com.fnproject.fn</groupId>
-      <artifactId>api</artifactId>
-      <scope>compile</scope>
-    </dependency>''')
-
-        build.contains('''
-    <dependency>
-      <groupId>com.fnproject.fn</groupId>
-      <artifactId>runtime</artifactId>
-      <scope>runtime</scope>
-    </dependency>''')
-
-        build.contains('''
-    <dependency>
-      <groupId>com.fnproject.fn</groupId>
-      <artifactId>testing-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>''')
-
         where:
         [language, useSerde] << [Language.values().toList(), [true, false]].combinations()
+    }
+
+    void 'test oracle cloud function dependencies for language=#language and buildtool=#buildTool'(Language language, BuildTool buildTool) {
+        when:
+        String template = new BuildBuilder(beanContext, buildTool)
+                .features(['oracle-function'])
+                .applicationType(ApplicationType.FUNCTION)
+                .language(language)
+                .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
+
+        then:
+        verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function", Scope.COMPILE)
+        verifier.hasDependency("com.fnproject.fn", "runtime", Scope.RUNTIME)
+        verifier.hasDependency("com.fnproject.fn", "api", Scope.COMPILE)
+        verifier.hasDependency("com.fnproject.fn", "testing-junit4", Scope.TEST)
+        verifier.hasDependency("org.slf4j", "slf4j-simple", Scope.RUNTIME)
+
+        !verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function-http")
+        !verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function-http-test")
+
+        where:
+        [language, buildTool] << [Language.values().toList(), BuildTool.values().toList()].combinations()
+
+    }
+
+    void 'test oracle cloud application dependencies for language=#language and buildtool=#buildTool'(Language language, BuildTool buildTool) {
+        when:
+        String template = new BuildBuilder(beanContext, buildTool)
+                .features(['oracle-function'])
+                .applicationType(ApplicationType.DEFAULT)
+                .language(language)
+                .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
+
+        then:
+        verifier.hasDependency("com.fnproject.fn", "runtime", Scope.RUNTIME)
+        verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function-http", Scope.COMPILE)
+        verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function-http-test", Scope.TEST)
+        verifier.hasDependency("org.slf4j", "slf4j-simple", Scope.RUNTIME)
+
+        !verifier.hasDependency("com.fnproject.fn", "api")
+        !verifier.hasDependency("com.fnproject.fn", "testing-junit4")
+        !verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function")
+
+        where:
+        [language, buildTool] << [Language.values().toList(), BuildTool.values().toList()].combinations()
     }
 }


### PR DESCRIPTION
Fixing missing dependencies for Gradle projects with "oracle-function-http" feature, to make consistent with Maven projects. Refactor dependency logic from Rocker files to Feature classes.

This also fixes a bug from a change to `GradleBuildTestVerifier` in #1689  For example, with the following,

```
        verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function-http", Scope.COMPILE)
        !verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-function")
```

The second check fails because the check for "micronaut-oraclecloud-function" is matching "micronaut-oraclecloud-function-http". 

This fixes the regex in `GradleBuildTestVerifier.hasDependency()` to restore previous behavior while also supporting the change as intended?

