### PR TITLE
refactor: move GE Feature out of gradle package

### DIFF
--- a/starter-api/src/test/groovy/io/micronaut/starter/api/FeatureOperationsSpec.groovy
+++ b/starter-api/src/test/groovy/io/micronaut/starter/api/FeatureOperationsSpec.groovy
@@ -1,6 +1,6 @@
 package io.micronaut.starter.api
 
-import io.micronaut.starter.feature.build.gradle.MicronautGradleEnterprise
+import io.micronaut.starter.feature.build.MicronautGradleEnterprise
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/GradleEnterprise.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/GradleEnterprise.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.feature.build.gradle;
+package io.micronaut.starter.feature.build;
 
 import com.fizzed.rocker.RockerModel;
 import io.micronaut.core.annotation.NonNull;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/GradleEnterpriseConfiguration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/GradleEnterpriseConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.feature.build.gradle;
+package io.micronaut.starter.feature.build;
 
 import io.micronaut.core.annotation.Nullable;
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautGradleEnterprise.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautGradleEnterprise.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.feature.build.gradle;
+package io.micronaut.starter.feature.build;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.generator.GeneratorContext;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/gradleEnterprise.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/gradleEnterprise.rocker.raw
@@ -1,4 +1,4 @@
-@import io.micronaut.starter.feature.build.gradle.GradleEnterpriseConfiguration
+@import io.micronaut.starter.feature.build.GradleEnterpriseConfiguration
 @args (GradleEnterpriseConfiguration config)
 gradleEnterprise {
 @if (config.getServer() != null) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/gradleEnterprise.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/gradleEnterprise.rocker.raw
@@ -1,4 +1,4 @@
-@import io.micronaut.starter.feature.build.gradle.GradleEnterpriseConfiguration
+@import io.micronaut.starter.feature.build.GradleEnterpriseConfiguration
 @args (GradleEnterpriseConfiguration config)
 <gradleEnterprise xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                           xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/GradleEnterpriseSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/GradleEnterpriseSpec.groovy
@@ -1,4 +1,4 @@
-package io.micronaut.starter.feature.build.gradle
+package io.micronaut.starter.feature.build
 
 import groovy.namespace.QName
 import groovy.xml.XmlParser

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/MicronautGradleEnterpriseSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/MicronautGradleEnterpriseSpec.groovy
@@ -1,4 +1,4 @@
-package io.micronaut.starter.feature.build.gradle
+package io.micronaut.starter.feature.build
 
 import groovy.namespace.QName
 import groovy.xml.XmlParser


### PR DESCRIPTION
This used to be Gradle only.  For 3.9.0 it also works for Maven.

This PR moves it out of the gradle package into the parent, where it's more logically correct