### PR TITLE
Refactor conditional 'http-client' test dependency from gradle/pom rocker templates into Java API.

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/application/generator/DefaultProjectGenerator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/application/generator/DefaultProjectGenerator.java
@@ -22,6 +22,7 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.ContextFactory;
 import io.micronaut.starter.application.OperatingSystem;
 import io.micronaut.starter.application.Project;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.AvailableFeatures;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.cli;
@@ -91,6 +92,8 @@ public class DefaultProjectGenerator implements ProjectGenerator {
                                 applicationType)));
 
         generatorContext.applyFeatures();
+
+        MicronautDependencyUtils.addExtraDependencies(generatorContext);
 
         try (TemplateRenderer templateRenderer = TemplateRenderer.create(project, outputHandler)) {
             for (Template template: generatorContext.getTemplates().values()) {

--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MicronautDependencyUtils.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MicronautDependencyUtils.java
@@ -16,6 +16,8 @@
 package io.micronaut.starter.build.dependencies;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.feature.other.HttpClient;
 
 public final class MicronautDependencyUtils {
     public static final String GROUP_ID_MICRONAUT = "io.micronaut";
@@ -119,5 +121,15 @@ public final class MicronautDependencyUtils {
     @NonNull
     public static Dependency.Builder ociDependency() {
         return micronautDependency(GROUP_ID_MICRONAUT_OCI);
+    }
+
+    // we might need some dependencies if they weren't already added
+    public static void addExtraDependencies(@NonNull GeneratorContext generatorContext) {
+        if (!generatorContext.hasFeature(HttpClient.class)) {
+            generatorContext.addDependency(MicronautDependencyUtils.coreDependency()
+                    .artifactId("micronaut-http-client")
+                    .compile()
+            );
+        }
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dependencies.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dependencies.rocker.raw
@@ -33,9 +33,6 @@ dependencies {
     @dependency.template("io.micronaut","micronaut-function", "testImplementation", null, false)
     }
 }
-@if (!features.contains("http-client")) {
-    @dependency.template("io.micronaut", "micronaut-http-client", "testImplementation", null, false)
-}
 @if (features.contains("google-cloud-function") && features.testFramework().isSpock()) {
     @dependency.template("io.micronaut.servlet","micronaut-servlet-core", "testImplementation", null, false)
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -117,9 +117,6 @@ MavenBuild mavenBuild
 @if (features.language().isKotlin()) {
 @dependency.template("com.fasterxml.jackson.module", "jackson-module-kotlin", "runtime", null, false, null)
 }
-@if (!features.contains("http-client")) {
-@dependency.template("io.micronaut", "micronaut-http-client", "test", null, false, null)
-}
 @if (features.contains("neo4j-bolt")) {
 @dependency.template("org.neo4j.test", "neo4j-harness", "test", null, false, null)
 }


### PR DESCRIPTION
This is an attempt to refactor the 'http-client' test dependency from the pom/gradle Rocker files into the starter Java API. This one in particular is a conditional dependency that doesn't apply specifically to any applied features. The challenge is that a dependency like this has to be applied after all features have been added and 'applied' (`generatorContext.applyFeatures()`) but before the rocker templates are rendered.

In this PR I do just that in `DefaultProjectGenerator.generate()`. That works well enough for Gradle projects (the dependency is added correctly), but doesn't for Maven, where it seems Maven dependencies have already been resolved, and the dependency is never added to the build. I also tried adding the dependencies in the `apply` methods of the `Maven` and `Gradle` `BuildFeature` classes, but that is too early, since not all features have been resolved/applied, and the dependency ends up included where it should not be.

What I have here is a bit of a smell. I tried some other things without success. Any ideas @sdelamo 