### PR TITLE
Add feature for HTTP Client JDK

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/CommunityFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/CommunityFeatureValidator.java
@@ -25,9 +25,9 @@ import java.util.Set;
 @Singleton
 public class CommunityFeatureValidator implements FeatureValidator {
     public static final boolean ENABLE_COMMUNITY_FEATURES = false;
+
     @Override
     public void validatePreProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
-
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/httpclient/HttpClientJdk.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/httpclient/HttpClientJdk.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.httpclient;
+
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class HttpClientJdk implements HttpClientFeature {
+    public static final String NAME = "http-client-jdk";
+
+    private static final Dependency DEPENDENCY_MICRONAUT_HTTP_CLIENT_JDK = MicronautDependencyUtils.coreDependency()
+            .artifactId("micronaut-http-client-jdk")
+            .compile()
+            .build();
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getTitle() {
+        return "HTTP Client Jdk";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Adds support for the Micronaut HTTP client based on the Java HTTP Client";
+    }
+
+    @Override
+    public String getMicronautDocumentation() {
+        return "https://docs.micronaut.io/latest/guide/index.html#jdkHttpClient";
+    }
+
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://openjdk.org/groups/net/httpclient/intro.html";
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return applicationType != ApplicationType.FUNCTION;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        generatorContext.addDependency(DEPENDENCY_MICRONAUT_HTTP_CLIENT_JDK);
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/httpclient/HttpClientJdk.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/httpclient/HttpClientJdk.java
@@ -21,6 +21,9 @@ import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import jakarta.inject.Singleton;
 
+import java.util.Collections;
+import java.util.List;
+
 @Singleton
 public class HttpClientJdk implements HttpClientFeature {
     public static final String NAME = "http-client-jdk";
@@ -56,11 +59,8 @@ public class HttpClientJdk implements HttpClientFeature {
     }
 
     @Override
-    public void apply(GeneratorContext generatorContext) {
-        addDependencies(generatorContext);
-    }
-
-    protected void addDependencies(@NonNull GeneratorContext generatorContext) {
-        generatorContext.addDependency(DEPENDENCY_MICRONAUT_HTTP_CLIENT_JDK);
+    @NonNull
+    public List<Dependency> getDependencies(@NonNull GeneratorContext generatorContext) {
+        return Collections.singletonList(DEPENDENCY_MICRONAUT_HTTP_CLIENT_JDK);
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/httpclient/HttpClientJdk.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/httpclient/HttpClientJdk.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.starter.feature.httpclient;
 
-import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
@@ -56,12 +56,11 @@ public class HttpClientJdk implements HttpClientFeature {
     }
 
     @Override
-    public boolean supports(ApplicationType applicationType) {
-        return applicationType != ApplicationType.FUNCTION;
+    public void apply(GeneratorContext generatorContext) {
+        addDependencies(generatorContext);
     }
 
-    @Override
-    public void apply(GeneratorContext generatorContext) {
+    protected void addDependencies(@NonNull GeneratorContext generatorContext) {
         generatorContext.addDependency(DEPENDENCY_MICRONAUT_HTTP_CLIENT_JDK);
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/other/HttpClient.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/other/HttpClient.java
@@ -25,6 +25,7 @@ import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.awslambdacustomruntime.AwsLambdaCustomRuntime;
 import io.micronaut.starter.feature.function.FunctionFeature;
 import io.micronaut.starter.feature.httpclient.HttpClientFeature;
+import io.micronaut.starter.feature.httpclient.HttpClientJdk;
 import io.micronaut.starter.options.Options;
 import jakarta.inject.Singleton;
 
@@ -38,7 +39,7 @@ public class HttpClient implements HttpClientFeature, DefaultFeature {
 
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
-        return true;
+        return selectedFeatures.stream().noneMatch(f -> f instanceof HttpClientJdk);
     }
 
     private Scope dependencyScope(GeneratorContext generatorContext) {
@@ -68,7 +69,7 @@ public class HttpClient implements HttpClientFeature, DefaultFeature {
 
     @Override
     public String getMicronautDocumentation() {
-        return "https://docs.micronaut.io/latest/guide/index.html#httpClient";
+        return "https://docs.micronaut.io/latest/guide/index.html#nettyHttpClient";
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/other/HttpClient.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/other/HttpClient.java
@@ -15,42 +15,24 @@
  */
 package io.micronaut.starter.feature.other;
 
-import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
-import io.micronaut.starter.build.dependencies.Scope;
-import io.micronaut.starter.feature.DefaultFeature;
-import io.micronaut.starter.feature.Feature;
-import io.micronaut.starter.feature.awslambdacustomruntime.AwsLambdaCustomRuntime;
-import io.micronaut.starter.feature.function.FunctionFeature;
 import io.micronaut.starter.feature.httpclient.HttpClientFeature;
-import io.micronaut.starter.feature.httpclient.HttpClientJdk;
-import io.micronaut.starter.options.Options;
 import jakarta.inject.Singleton;
 
-import java.util.Set;
+import java.util.Collections;
+import java.util.List;
 
 @Singleton
-public class HttpClient implements HttpClientFeature, DefaultFeature {
+public class HttpClient implements HttpClientFeature {
     public static final String NAME = "http-client";
-    private static final Dependency.Builder DEPENDENCY_MICRONAUT_HTTP_CLIENT = MicronautDependencyUtils.coreDependency()
-            .artifactId("micronaut-http-client");
-
-    @Override
-    public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
-        return selectedFeatures.stream().noneMatch(HttpClientJdk.class::isInstance);
-    }
-
-    private Scope dependencyScope(GeneratorContext generatorContext) {
-        return (
-                generatorContext.getFeatures().hasFeature(AwsLambdaCustomRuntime.class) ||
-                (
-                    generatorContext.getApplicationType() == ApplicationType.DEFAULT &&
-                    generatorContext.getFeatures().getFeatures().stream().noneMatch(f -> f instanceof FunctionFeature)
-                )
-        ) ? Scope.COMPILE : Scope.TEST;
-    }
+    public static final String ARTIFACT_ID_MICRONAUT_HTTP_CLIENT = "micronaut-http-client";
+    public static final Dependency DEPENDENCY_MICRONAUT_HTTP_CLIENT = MicronautDependencyUtils.coreDependency()
+            .artifactId(ARTIFACT_ID_MICRONAUT_HTTP_CLIENT)
+            .compile()
+            .build();
 
     @Override
     public String getName() {
@@ -73,11 +55,8 @@ public class HttpClient implements HttpClientFeature, DefaultFeature {
     }
 
     @Override
-    public void apply(GeneratorContext generatorContext) {
-        addDependencies(generatorContext);
-    }
-
-    protected void addDependencies(GeneratorContext generatorContext) {
-        generatorContext.addDependency(DEPENDENCY_MICRONAUT_HTTP_CLIENT.scope(dependencyScope(generatorContext)));
+    @NonNull
+    public List<Dependency> getDependencies(@NonNull GeneratorContext generatorContext) {
+        return Collections.singletonList(DEPENDENCY_MICRONAUT_HTTP_CLIENT);
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/other/HttpClient.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/other/HttpClient.java
@@ -39,7 +39,7 @@ public class HttpClient implements HttpClientFeature, DefaultFeature {
 
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
-        return selectedFeatures.stream().noneMatch(f -> f instanceof HttpClientJdk);
+        return selectedFeatures.stream().noneMatch(HttpClientJdk.class::isInstance);
     }
 
     private Scope dependencyScope(GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/other/HttpClientTest.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/other/HttpClientTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.other;
+
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
+import io.micronaut.starter.feature.DefaultFeature;
+import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.awslambdacustomruntime.AwsLambdaCustomRuntime;
+import io.micronaut.starter.feature.httpclient.HttpClientFeature;
+import io.micronaut.starter.options.Options;
+import jakarta.inject.Singleton;
+import java.util.Set;
+
+import static io.micronaut.starter.feature.other.HttpClient.ARTIFACT_ID_MICRONAUT_HTTP_CLIENT;
+
+@Singleton
+public class HttpClientTest implements DefaultFeature {
+    private static final Dependency DEPENDENCY_MICRONAUT_HTTP_CLIENT_TEST = MicronautDependencyUtils.coreDependency()
+            .artifactId(ARTIFACT_ID_MICRONAUT_HTTP_CLIENT)
+            .test()
+            .build();
+    @Override
+    public String getName() {
+        return "http-client-test";
+    }
+
+    @Override
+    public boolean isVisible() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
+        return selectedFeatures.stream().noneMatch(HttpClientFeature.class::isInstance);
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        if (generatorContext.getFeatures().hasFeature(AwsLambdaCustomRuntime.class)) {
+            generatorContext.addDependency(HttpClient.DEPENDENCY_MICRONAUT_HTTP_CLIENT);
+        } else if (generatorContext.getApplicationType() == ApplicationType.DEFAULT) {
+            generatorContext.addDependency(DEPENDENCY_MICRONAUT_HTTP_CLIENT_TEST);
+        }
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/reactive/ReactiveHttpClientFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/reactive/ReactiveHttpClientFeature.java
@@ -13,23 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.feature.httpclient;
+package io.micronaut.starter.feature.reactive;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.feature.OneOfFeature;
+import io.micronaut.starter.feature.Feature;
 
 import java.util.List;
 
-public interface HttpClientFeature  extends OneOfFeature {
-    @Override
-    default Class<?> getFeatureClass() {
-        return HttpClientFeature.class;
-    }
-
+/**
+ * Marker feature for Reactive features adding an HTTP Client.
+ */
+public interface ReactiveHttpClientFeature extends Feature {
     @Override
     default boolean supports(ApplicationType applicationType) {
         return true;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/reactive/ReactiveHttpClientFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/reactive/ReactiveHttpClientFeatureValidator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.reactive;
+
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.httpclient.HttpClientJdk;
+import io.micronaut.starter.feature.validation.FeatureValidator;
+import io.micronaut.starter.options.Options;
+import jakarta.inject.Singleton;
+
+import java.util.Set;
+
+@Singleton
+public class ReactiveHttpClientFeatureValidator implements FeatureValidator {
+    @Override
+    public void validatePreProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+        if (features.stream().anyMatch(f -> f instanceof ReactiveHttpClientFeature)) {
+            if (features.stream().anyMatch(f -> f instanceof HttpClientJdk)) {
+                throw new IllegalArgumentException("http-client-jdk feature is not compatible with a reactive HTTP Client");
+            }
+        }
+    }
+
+    @Override
+    public void validatePostProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/reactor/ReactorHttpClient.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/reactor/ReactorHttpClient.java
@@ -16,20 +16,22 @@
 package io.micronaut.starter.feature.reactor;
 
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
-import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.reactive.ReactiveHttpClientFeature;
 import jakarta.inject.Singleton;
 
-@Singleton
-public class ReactorHttpClient implements Feature {
+import java.util.Collections;
+import java.util.List;
 
-    @Override
-    public boolean supports(ApplicationType applicationType) {
-        return true;
-    }
+@Singleton
+public class ReactorHttpClient implements ReactiveHttpClientFeature {
+    public static final String ARTIFACT_ID_MICRONAUT_REACTOR_HTTP_CLIENT = "micronaut-reactor-http-client";
+    public static final Dependency DEPENDENCY_MICRONAUT_REACTOR_HTTP_CLIENT = Dependency.builder()
+            .groupId(Reactor.MICRONAUT_REACTOR_GROUP_ID)
+            .artifactId(ARTIFACT_ID_MICRONAUT_REACTOR_HTTP_CLIENT)
+            .compile()
+            .build();
 
     @NonNull
     @Override
@@ -38,21 +40,18 @@ public class ReactorHttpClient implements Feature {
     }
 
     @Override
-    public boolean isVisible() {
-        return false;
+    public String getTitle() {
+        return "Reactor HTTP Client";
     }
 
     @Override
-    public String getCategory() {
-        return Category.CLIENT;
+    @NonNull
+    public String getDescription() {
+        return "Version of the Http client which supports Project Reactor";
     }
 
     @Override
-    public void apply(GeneratorContext generatorContext) {
-        generatorContext.addDependency(Dependency.builder()
-                .groupId(Reactor.MICRONAUT_REACTOR_GROUP_ID)
-                .artifactId("micronaut-reactor-http-client")
-                .compile());
+    public List<Dependency> getDependencies(GeneratorContext generatorContext) {
+        return Collections.singletonList(DEPENDENCY_MICRONAUT_REACTOR_HTTP_CLIENT);
     }
-
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/rxjava/RxJava2.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/rxjava/RxJava2.java
@@ -30,6 +30,10 @@ import jakarta.inject.Singleton;
 @Singleton
 public class RxJava2 implements Feature {
     public static final String MICRONAUT_RXJAVA2_GROUP_ID = "io.micronaut.rxjava2";
+    public static final Dependency DEPENDENCY_MICRONAUT_RXJAVA2 = Dependency.builder()
+            .groupId(MICRONAUT_RXJAVA2_GROUP_ID)
+            .artifactId("micronaut-rxjava2")
+            .compile().build();
 
     private final RxJava2HttpServerNetty rxJava2HttpServerNetty;
     private final RxJava2HttpClient rxJava2HttpClient;
@@ -82,10 +86,7 @@ public class RxJava2 implements Feature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.addDependency(Dependency.builder()
-                .groupId(MICRONAUT_RXJAVA2_GROUP_ID)
-                .artifactId("micronaut-rxjava2")
-                .compile());
+        generatorContext.addDependency(DEPENDENCY_MICRONAUT_RXJAVA2);
     }
 
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/rxjava/RxJava2HttpClient.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/rxjava/RxJava2HttpClient.java
@@ -16,19 +16,26 @@
 package io.micronaut.starter.feature.rxjava;
 
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
-import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.feature.Feature;
-
+import io.micronaut.starter.feature.reactive.ReactiveHttpClientFeature;
 import jakarta.inject.Singleton;
 
+import java.util.Collections;
+import java.util.List;
+
 @Singleton
-public class RxJava2HttpClient implements Feature {
+public class RxJava2HttpClient implements ReactiveHttpClientFeature {
+
+    private static final String ARTIFACT_ID_MICRONAUT_RXJAVA_2_HTTP_CLIENT = "micronaut-rxjava2-http-client";
+    private static final Dependency DEPENDENCY_MICRONAUT_RXJAVA_2_HTTP_CLIENT = Dependency.builder()
+            .groupId(RxJava2.MICRONAUT_RXJAVA2_GROUP_ID)
+            .artifactId(ARTIFACT_ID_MICRONAUT_RXJAVA_2_HTTP_CLIENT)
+            .compile().build();
+
     @Override
-    public boolean supports(ApplicationType applicationType) {
-        return true;
+    public List<Dependency> getDependencies(GeneratorContext generatorContext) {
+        return Collections.singletonList(DEPENDENCY_MICRONAUT_RXJAVA_2_HTTP_CLIENT);
     }
 
     @NonNull
@@ -38,21 +45,13 @@ public class RxJava2HttpClient implements Feature {
     }
 
     @Override
-    public boolean isVisible() {
-        return false;
+    @NonNull
+    public String getTitle() {
+        return "RxJava 2 HTTP Client";
     }
 
     @Override
-    public String getCategory() {
-        return Category.CLIENT;
+    public String getDescription() {
+        return "RxJava 2 variation of the Micronaut HTTP client.";
     }
-
-    @Override
-    public void apply(GeneratorContext generatorContext) {
-        generatorContext.addDependency(Dependency.builder()
-                .groupId(RxJava2.MICRONAUT_RXJAVA2_GROUP_ID)
-                .artifactId("micronaut-rxjava2-http-client")
-                .compile());
-    }
-
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/rxjava/RxJava3HttpClient.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/rxjava/RxJava3HttpClient.java
@@ -16,19 +16,26 @@
 package io.micronaut.starter.feature.rxjava;
 
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
-import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.reactive.ReactiveHttpClientFeature;
 import jakarta.inject.Singleton;
 
+import java.util.Collections;
+import java.util.List;
+
 @Singleton
-public class RxJava3HttpClient implements Feature {
+public class RxJava3HttpClient implements ReactiveHttpClientFeature {
+
+    private static final String ARTIFACT_ID_MICRONAUT_RXJAVA_3_HTTP_CLIENT = "micronaut-rxjava3-http-client";
+    private static final Dependency DEPENDENCY_MICRONAUT_RXJAVA3_HTTP_CLIENT = Dependency.builder()
+            .groupId(RxJava3.MICRONAUT_RXJAVA3_GROUP_ID)
+            .artifactId(ARTIFACT_ID_MICRONAUT_RXJAVA_3_HTTP_CLIENT)
+            .compile().build();
 
     @Override
-    public boolean supports(ApplicationType applicationType) {
-        return true;
+    public List<Dependency> getDependencies(GeneratorContext generatorContext) {
+        return Collections.singletonList(DEPENDENCY_MICRONAUT_RXJAVA3_HTTP_CLIENT);
     }
 
     @NonNull
@@ -38,21 +45,13 @@ public class RxJava3HttpClient implements Feature {
     }
 
     @Override
-    public boolean isVisible() {
-        return false;
+    @NonNull
+    public String getTitle() {
+        return "RxJava 3 HTTP Client";
     }
 
     @Override
-    public String getCategory() {
-        return Category.CLIENT;
+    public String getDescription() {
+        return "RxJava 3 variation of the Micronaut HTTP client.";
     }
-
-    @Override
-    public void apply(GeneratorContext generatorContext) {
-        generatorContext.addDependency(Dependency.builder()
-                .groupId(RxJava3.MICRONAUT_RXJAVA3_GROUP_ID)
-                .artifactId("micronaut-rxjava3-http-client")
-                .compile());
-    }
-
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/httpclient/HttpClientFeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/httpclient/HttpClientFeatureSpec.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.starter.feature.httpclient
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.fixture.CommandOutputFixture
+
+class HttpClientFeatureSpec extends ApplicationContextSpec implements CommandOutputFixture {
+
+    void 'test only one of the HttpClient features can be selected'() {
+        when:
+        generate(['http-client', 'http-client-jdk'])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.startsWith("There can only be one of the following features selected:")
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/httpclient/HttpClientJdkSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/httpclient/HttpClientJdkSpec.groovy
@@ -16,8 +16,8 @@ class HttpClientJdkSpec extends BeanContextSpec  implements CommandOutputFixture
 
     void 'test readme.md with feature http-client-jdk contains links to micronaut and 3rd party docs'() {
         when:
-        def output = generate(['http-client-jdk'])
-        def readme = output["README.md"]
+        Map<String, String> output = generate(['http-client-jdk'])
+        String readme = output["README.md"]
 
         then:
         readme

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/httpclient/HttpClientJdkSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/httpclient/HttpClientJdkSpec.groovy
@@ -41,16 +41,11 @@ class HttpClientJdkSpec extends BeanContextSpec  implements CommandOutputFixture
         buildTool << BuildTool.values().toList()
     }
 
-    void "http-client-jdk does not support applicationType FUNCTION"() {
-        expect:
-        !httpClientJdk.supports(ApplicationType.FUNCTION)
-    }
-
     void "http-client-jdk supports #applicationType application type"(ApplicationType applicationType) {
         expect:
         httpClientJdk.supports(applicationType)
 
         where:
-        applicationType << (ApplicationType.values() - ApplicationType.FUNCTION)
+        applicationType << ApplicationType.values()
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/httpclient/HttpClientJdkSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/httpclient/HttpClientJdkSpec.groovy
@@ -1,0 +1,56 @@
+package io.micronaut.starter.feature.httpclient
+
+import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import spock.lang.Subject
+
+class HttpClientJdkSpec extends BeanContextSpec  implements CommandOutputFixture {
+    @Subject
+    HttpClientJdk httpClientJdk = beanContext.getBean(HttpClientJdk)
+
+    void 'test readme.md with feature http-client-jdk contains links to micronaut and 3rd party docs'() {
+        when:
+        def output = generate(['http-client-jdk'])
+        def readme = output["README.md"]
+
+        then:
+        readme
+        readme.contains("https://docs.micronaut.io/latest/guide/index.html#jdkHttpClient")
+        readme.contains("https://openjdk.org/groups/net/httpclient/intro.html")
+    }
+
+    void "dependency added for http-client-jdk feature for buildTool=#buildTool"(BuildTool buildTool) {
+        when:
+        String template = new BuildBuilder(beanContext, buildTool)
+                .features(['http-client-jdk'])
+                .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
+
+        then:
+        verifier.hasDependency("io.micronaut", "micronaut-http-client-jdk", Scope.COMPILE)
+        !verifier.hasDependency("io.micronaut", "micronaut-http-client", Scope.COMPILE)
+        !verifier.hasDependency("io.micronaut", "micronaut-http-client", Scope.TEST)
+
+        where:
+        buildTool << BuildTool.values().toList()
+    }
+
+    void "http-client-jdk does not support applicationType FUNCTION"() {
+        expect:
+        !httpClientJdk.supports(ApplicationType.FUNCTION)
+    }
+
+    void "http-client-jdk supports #applicationType application type"(ApplicationType applicationType) {
+        expect:
+        httpClientJdk.supports(applicationType)
+
+        where:
+        applicationType << (ApplicationType.values() - ApplicationType.FUNCTION)
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/other/HttpClientSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/other/HttpClientSpec.groovy
@@ -18,7 +18,7 @@ class HttpClientSpec extends BeanContextSpec  implements CommandOutputFixture {
 
         then:
         readme
-        readme.contains("https://docs.micronaut.io/latest/guide/index.html#httpClient")
+        readme.contains("https://docs.micronaut.io/latest/guide/index.html#nettyHttpClient")
     }
 
     void "dependency added for http-client feature in the main classpath"(BuildTool buildTool, List<String> features) {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/other/HttpClientSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/other/HttpClientSpec.groovy
@@ -13,8 +13,8 @@ class HttpClientSpec extends BeanContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature http-client contains links to micronaut docs'() {
         when:
-        def output = generate(['http-client'])
-        def readme = output["README.md"]
+        Map<String, String> output = generate(['http-client'])
+        String readme = output["README.md"]
 
         then:
         readme
@@ -27,24 +27,31 @@ class HttpClientSpec extends BeanContextSpec  implements CommandOutputFixture {
         BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
 
         then:
-        verifier.hasDependency("io.micronaut", "micronaut-http-client", Scope.COMPILE)
-        !verifier.hasDependency("io.micronaut", "micronaut-http-client", Scope.TEST)
+        if (features.isEmpty()) { // default feature
+            assert verifier.hasDependency("io.micronaut", "micronaut-http-client", Scope.TEST)
+        } else {
+            assert verifier.hasDependency("io.micronaut", "micronaut-http-client", Scope.COMPILE)
+            assert !verifier.hasDependency("io.micronaut", "micronaut-http-client", Scope.TEST)
+        }
 
         where:
         [buildTool, features] << combinations()
     }
 
-    void "dependency added for http-client feature in the test classpath for function"(BuildTool buildTool, List<String> features) {
+    void "dependency http-client not added by default for function"(BuildTool buildTool) {
         when:
-        String template = new BuildBuilder(beanContext, buildTool).applicationType(ApplicationType.FUNCTION).features(features).render()
+        String template = new BuildBuilder(beanContext, buildTool)
+                .applicationType(ApplicationType.FUNCTION)
+                .features([])
+                .render()
         BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
 
         then:
         !verifier.hasDependency("io.micronaut", "micronaut-http-client", Scope.COMPILE)
-        verifier.hasDependency("io.micronaut", "micronaut-http-client", Scope.TEST)
+        !verifier.hasDependency("io.micronaut", "micronaut-http-client", Scope.TEST)
 
         where:
-        [buildTool, features] << combinations()
+        buildTool << BuildTool.values()
     }
 
     private static List combinations() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/reactive/ReactiveHttpClientFeatureValidatorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/reactive/ReactiveHttpClientFeatureValidatorSpec.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.starter.feature.reactive
+
+import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.Options
+
+class ReactiveHttpClientFeatureValidatorSpec extends BeanContextSpec  implements CommandOutputFixture {
+
+    void 'test third part server validation fails with micronaut server features'() {
+        when:
+        Options options = new Options()
+        generate(ApplicationType.DEFAULT, options, ['reactor-http-client', 'http-client-jdk'])
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message.startsWith("http-client-jdk feature is not compatible with a reactive HTTP Client")
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/reactor/ReactorHttpClientSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/reactor/ReactorHttpClientSpec.groovy
@@ -1,0 +1,51 @@
+package io.micronaut.starter.feature.reactor
+
+import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import spock.lang.Shared
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class ReactorHttpClientSpec extends BeanContextSpec implements CommandOutputFixture {
+
+    @Shared
+    @Subject
+    ReactorHttpClient reactorHttpClient = beanContext.getBean(ReactorHttpClient)
+
+    void "reactor-http-client supports #description application type"(ApplicationType applicationType, String description) {
+        expect:
+        reactorHttpClient.supports(applicationType)
+
+        where:
+        applicationType << ApplicationType.values()
+        description = applicationType.name
+    }
+
+    void "reactor-http-client is visible"() {
+        expect:
+        reactorHttpClient.isVisible()
+    }
+
+    @Unroll
+    void 'dependency is included with #buildTool and feature reactor for language=#language'(Language language, BuildTool buildTool) {
+        when:
+        String template = new BuildBuilder(beanContext, buildTool)
+                .features(['reactor-http-client'])
+                .language(language)
+                .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
+
+        then:
+        verifier.hasDependency("io.micronaut.reactor", "micronaut-reactor-http-client", Scope.COMPILE)
+
+        where:
+        [language, buildTool] << [Language.values().toList(), BuildTool.values()].combinations()
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJava2HttpClientSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJava2HttpClientSpec.groovy
@@ -1,0 +1,52 @@
+package io.micronaut.starter.feature.rxjava
+
+import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
+import io.micronaut.starter.feature.reactor.ReactorHttpClient
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import spock.lang.Shared
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class RxJava2HttpClientSpec extends BeanContextSpec implements CommandOutputFixture {
+
+    @Shared
+    @Subject
+    ReactorHttpClient rxjava2HttpClient = beanContext.getBean(ReactorHttpClient)
+
+    void "rxjava2-http-client supports #description application type"(ApplicationType applicationType, String description) {
+        expect:
+        rxjava2HttpClient.supports(applicationType)
+
+        where:
+        applicationType << ApplicationType.values()
+        description = applicationType.name
+    }
+
+    void "rxjava2-http-client is visible"() {
+        expect:
+        rxjava2HttpClient.isVisible()
+    }
+
+    @Unroll
+    void 'dependency is included with #buildTool and feature rxjava2 for language=#language'(Language language, BuildTool buildTool) {
+        when:
+        String template = new BuildBuilder(beanContext, buildTool)
+                .features(['rxjava2-http-client'])
+                .language(language)
+                .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
+
+        then:
+        verifier.hasDependency("io.micronaut.rxjava2", "micronaut-rxjava2-http-client", Scope.COMPILE)
+
+        where:
+        [language, buildTool] << [Language.values().toList(), BuildTool.values()].combinations()
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJava2Spec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJava2Spec.groovy
@@ -3,6 +3,9 @@ package io.micronaut.starter.feature.rxjava
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
@@ -13,19 +16,19 @@ import spock.lang.Unroll
 
 class RxJava2Spec extends ApplicationContextSpec implements CommandOutputFixture {
 
+    @Subject
+    @Shared
+    RxJava3 rxJavaThree = beanContext.getBean(RxJava3)
+
     void 'test readme.md with feature rxjava2 contains links to micronaut docs'() {
         when:
-        def output = generate(['rxjava2'])
-        def readme = output["README.md"]
+        Map<String, String> output = generate(['rxjava2'])
+        String readme = output["README.md"]
 
         then:
         readme
         readme.contains("https://micronaut-projects.github.io/micronaut-rxjava2/snapshot/guide/index.html")
     }
-
-    @Subject
-    @Shared
-    RxJava3 rxJavaThree = beanContext.getBean(RxJava3)
 
     void "rxjava2 belongs to Reactive category"() {
         expect:
@@ -42,55 +45,20 @@ class RxJava2Spec extends ApplicationContextSpec implements CommandOutputFixture
     }
 
     @Unroll
-    void 'dependency is included with maven and feature rxjava2 for language=#language'(Language language) {
+    void 'dependency is included with gradle and feature rxjava2 for language=#language'(Language language, BuildTool buildTool) {
         when:
-        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .features(['rxjava2'])
+        String template = new BuildBuilder(beanContext, buildTool)
                 .language(language)
+                .features(['http-client', 'rxjava2'])
                 .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, language, template)
 
         then:
-        template.contains("""
-    <dependency>
-      <groupId>io.micronaut.rxjava2</groupId>
-      <artifactId>micronaut-rxjava2</artifactId>
-      <scope>compile</scope>
-    </dependency>
-""")
-        and:
-        template.contains("""
-    <dependency>
-      <groupId>io.micronaut.rxjava2</groupId>
-      <artifactId>micronaut-rxjava2-http-client</artifactId>
-      <scope>compile</scope>
-    </dependency>
-""")
-        and:
-        template.contains("""
-    <dependency>
-      <groupId>io.micronaut.rxjava2</groupId>
-      <artifactId>micronaut-rxjava2-http-server-netty</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-""")
-        where:
-        language << Language.values().toList()
-    }
-
-    @Unroll
-    void 'dependency is included with gradle and feature rxjava2 for language=#language'(Language language) {
-        when:
-        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .language(language)
-                .features(['rxjava2'])
-                .render()
-
-        then:
-        template.contains('implementation("io.micronaut.rxjava2:micronaut-rxjava2")')
-        template.contains('implementation("io.micronaut.rxjava2:micronaut-rxjava2-http-client")')
-        template.contains('runtimeOnly("io.micronaut.rxjava2:micronaut-rxjava2-http-server-netty")')
+        verifier.hasDependency("io.micronaut.rxjava2", "micronaut-rxjava2", Scope.COMPILE)
+        verifier.hasDependency("io.micronaut.rxjava2", "micronaut-rxjava2-http-client", Scope.COMPILE)
+        verifier.hasDependency("io.micronaut.rxjava2", "micronaut-rxjava2-http-server-netty", Scope.RUNTIME)
 
         where:
-        language << Language.values()
+        [language, buildTool] << [Language.values(), BuildTool.values()].combinations()
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJava3HttpClientSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJava3HttpClientSpec.groovy
@@ -1,0 +1,51 @@
+package io.micronaut.starter.feature.rxjava
+
+import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import spock.lang.Shared
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class RxJava3HttpClientSpec extends BeanContextSpec implements CommandOutputFixture {
+
+    @Shared
+    @Subject
+    RxJava3HttpClient rxjava3HttpClient = beanContext.getBean(RxJava3HttpClient)
+
+    void "rxjava3-http-client supports #description application type"(ApplicationType applicationType, String description) {
+        expect:
+        rxjava3HttpClient.supports(applicationType)
+
+        where:
+        applicationType << ApplicationType.values()
+        description = applicationType.name
+    }
+
+    void "rxjava3-http-client is visible"() {
+        expect:
+        rxjava3HttpClient.isVisible()
+    }
+
+    @Unroll
+    void 'dependency is included with #buildTool and feature rxjava3 for language=#language'(Language language, BuildTool buildTool) {
+        when:
+        String template = new BuildBuilder(beanContext, buildTool)
+                .features(['rxjava3-http-client'])
+                .language(language)
+                .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
+
+        then:
+        verifier.hasDependency("io.micronaut.rxjava3", "micronaut-rxjava3-http-client", Scope.COMPILE)
+
+        where:
+        [language, buildTool] << [Language.values().toList(), BuildTool.values()].combinations()
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJava3Spec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJava3Spec.groovy
@@ -3,6 +3,9 @@ package io.micronaut.starter.feature.rxjava
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
 import io.micronaut.starter.feature.Category
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
@@ -42,46 +45,19 @@ class RxJava3Spec extends ApplicationContextSpec implements CommandOutputFixture
     }
 
     @Unroll
-    void 'dependency is included with maven and feature rxjava3 for language=#language'(Language language) {
+    void 'dependency is included with gradle and feature rxjava3 for language=#language'(Language language, BuildTool buildTool) {
         when:
-        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .features(['rxjava3'])
+        String template = new BuildBuilder(beanContext, buildTool)
                 .language(language)
+                .features(['http-client', 'rxjava3'])
                 .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, language, template)
 
         then:
-        template.contains("""
-    <dependency>
-      <groupId>io.micronaut.rxjava3</groupId>
-      <artifactId>micronaut-rxjava3</artifactId>
-      <scope>compile</scope>
-    </dependency>
-""")
-        and:
-        template.contains("""
-    <dependency>
-      <groupId>io.micronaut.rxjava3</groupId>
-      <artifactId>micronaut-rxjava3-http-client</artifactId>
-      <scope>compile</scope>
-    </dependency>
-""")
-        where:
-        language << Language.values().toList()
-    }
-
-    @Unroll
-    void 'dependency is included with gradle and feature rxjava3 for language=#language'(Language language) {
-        when:
-        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .language(language)
-                .features(['rxjava3'])
-                .render()
-
-        then:
-        template.contains('implementation("io.micronaut.rxjava3:micronaut-rxjava3")')
-        template.contains('implementation("io.micronaut.rxjava3:micronaut-rxjava3-http-client")')
+        verifier.hasDependency("io.micronaut.rxjava3", "micronaut-rxjava3", Scope.COMPILE)
+        verifier.hasDependency("io.micronaut.rxjava3", "micronaut-rxjava3-http-client", Scope.COMPILE)
 
         where:
-        language << Language.values()
+        [language, buildTool] << [Language.values(), BuildTool.values()].combinations()
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJava3Spec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/rxjava/RxJava3Spec.groovy
@@ -45,7 +45,7 @@ class RxJava3Spec extends ApplicationContextSpec implements CommandOutputFixture
     }
 
     @Unroll
-    void 'dependency is included with gradle and feature rxjava3 for language=#language'(Language language, BuildTool buildTool) {
+    void 'dependency is included with #buildTool and feature rxjava3 for language=#language'(Language language, BuildTool buildTool) {
         when:
         String template = new BuildBuilder(beanContext, buildTool)
                 .language(language)

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/httpclient/HttpClientJdkSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/httpclient/HttpClientJdkSpec.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.starter.core.test.feature.httpclient
+
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.test.CommandSpec
+import io.micronaut.starter.test.LanguageBuildCombinations
+import spock.lang.Unroll
+
+class HttpClientJdkSpec extends CommandSpec {
+
+    @Unroll
+    void 'test basic http-client-jdk for #lang and #buildTool'(Language lang, BuildTool buildTool) {
+        given:
+        generateProject(lang, buildTool, ['http-client-jdk'])
+
+        when:
+        String output = executeBuild(buildTool, "test")
+
+        then:
+        output.contains("BUILD SUCCESS")
+
+        where:
+        [lang, buildTool] << LanguageBuildCombinations.combinations()
+    }
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "test-app"
+    }
+}


### PR DESCRIPTION
closes #1726

@sdelamo @timyates 
I am not entirely sure about two things for this PR:
1. whether the behavior of the Netty 'http-client' feature as a default feature should change (I didn't change it)
2. what application types this feature supports (I made it all but FUNCTION).