### PR TITLE
Move the GradleEnteprise features to a more logical place

### DIFF
--- a/starter-api/src/test/groovy/io/micronaut/starter/api/FeatureOperationsSpec.groovy
+++ b/starter-api/src/test/groovy/io/micronaut/starter/api/FeatureOperationsSpec.groovy
@@ -1,6 +1,6 @@
 package io.micronaut.starter.api
 
-import io.micronaut.starter.feature.build.gradle.MicronautGradleEnterprise
+import io.micronaut.starter.feature.build.MicronautGradleEnterprise
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/GradleEnterprise.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/GradleEnterprise.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.feature.build.gradle;
+package io.micronaut.starter.feature.build;
 
 import com.fizzed.rocker.RockerModel;
 import io.micronaut.core.annotation.NonNull;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/GradleEnterpriseConfiguration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/GradleEnterpriseConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.feature.build.gradle;
+package io.micronaut.starter.feature.build;
 
 import io.micronaut.core.annotation.Nullable;
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautGradleEnterprise.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautGradleEnterprise.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.feature.build.gradle;
+package io.micronaut.starter.feature.build;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.generator.GeneratorContext;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/gradleEnterprise.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/gradleEnterprise.rocker.raw
@@ -1,4 +1,4 @@
-@import io.micronaut.starter.feature.build.gradle.GradleEnterpriseConfiguration
+@import io.micronaut.starter.feature.build.GradleEnterpriseConfiguration
 @args (GradleEnterpriseConfiguration config)
 gradleEnterprise {
 @if (config.getServer() != null) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/gradleEnterprise.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/gradleEnterprise.rocker.raw
@@ -1,4 +1,4 @@
-@import io.micronaut.starter.feature.build.gradle.GradleEnterpriseConfiguration
+@import io.micronaut.starter.feature.build.GradleEnterpriseConfiguration
 @args (GradleEnterpriseConfiguration config)
 <gradleEnterprise xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                           xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/GradleEnterpriseSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/GradleEnterpriseSpec.groovy
@@ -1,4 +1,4 @@
-package io.micronaut.starter.feature.build.gradle
+package io.micronaut.starter.feature.build
 
 import groovy.namespace.QName
 import groovy.xml.XmlParser

--- a/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
+++ b/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
@@ -20,7 +20,7 @@ import io.micronaut.core.util.functional.ThrowingSupplier
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.application.Project
 import io.micronaut.starter.application.generator.ProjectGenerator
-import io.micronaut.starter.feature.build.gradle.MicronautGradleEnterprise
+import io.micronaut.starter.feature.build.MicronautGradleEnterprise
 import io.micronaut.starter.io.ConsoleOutput
 import io.micronaut.starter.io.FileSystemOutputHandler
 import io.micronaut.starter.io.OutputHandler


### PR DESCRIPTION
Now we support Gradle and Maven, having these in the Maven package doesn't make sense.

This PR moves them to the parent package.

Closes #1711