### PR TITLE
fix: for SQLServer generate test-resources accept license

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DatabaseDriverConfigurationFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DatabaseDriverConfigurationFeature.java
@@ -45,7 +45,7 @@ public interface DatabaseDriverConfigurationFeature extends Feature {
         }
         Optional.ofNullable(dbFeature.getDriverClass()).ifPresent(driver -> config.put(getDriverKey(), driver));
         dbFeature.getDbType().ifPresent(dbType -> config.put(PROPERTY_DATASOURCES_DEFAULT_DB_TYPE, dbType.toString()));
-        final Map<String, Object> additionalConfig = dbFeature.getAdditionalConfig();
+        final Map<String, Object> additionalConfig = dbFeature.getAdditionalConfig(generatorContext);
         if (!additionalConfig.isEmpty()) {
             config.putAll(additionalConfig);
         }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/DatabaseDriverFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/DatabaseDriverFeature.java
@@ -104,7 +104,7 @@ public abstract class DatabaseDriverFeature extends EaseTestingFeature implement
         return Optional.empty();
     }
 
-    public Map<String, Object> getAdditionalConfig() {
+    public Map<String, Object> getAdditionalConfig(GeneratorContext generatorContext) {
         return Collections.emptyMap();
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/SQLServer.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/SQLServer.java
@@ -16,7 +16,6 @@
 package io.micronaut.starter.feature.database;
 
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.database.jdbc.JdbcFeature;
@@ -24,8 +23,6 @@ import io.micronaut.starter.feature.testresources.DbType;
 import io.micronaut.starter.feature.testresources.TestResources;
 import jakarta.inject.Singleton;
 
-import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 
 import static io.micronaut.starter.feature.database.DataHibernateReactive.IO_VERTX_DEPENDENCY_GROUP;
@@ -135,9 +132,14 @@ public class SQLServer extends DatabaseDriverFeature {
     }
 
     @Override
-    public Map<String, Object> getAdditionalConfig(GeneratorContext generatorContext) {
-        return generatorContext.hasFeature(TestResources.class) ?
-                Collections.singletonMap("test-resources.containers.mssql.accept-license", StringUtils.TRUE) :
-                Collections.emptyMap();
+    public void apply(GeneratorContext generatorContext) {
+        super.apply(generatorContext);
+        if (generatorContext.hasFeature(TestResources.class)) {
+            generatorContext.getConfiguration().put("test-resources.containers.mssql.accept-license", acceptLicense());
+        }
+    }
+
+    protected boolean acceptLicense() {
+        return false;
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/SQLServer.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/SQLServer.java
@@ -16,12 +16,16 @@
 package io.micronaut.starter.feature.database;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.database.jdbc.JdbcFeature;
 import io.micronaut.starter.feature.testresources.DbType;
 import io.micronaut.starter.feature.testresources.TestResources;
 import jakarta.inject.Singleton;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 import static io.micronaut.starter.feature.database.DataHibernateReactive.IO_VERTX_DEPENDENCY_GROUP;
@@ -128,5 +132,12 @@ public class SQLServer extends DatabaseDriverFeature {
     @Override
     public boolean embedded() {
         return false;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalConfig(GeneratorContext generatorContext) {
+        return generatorContext.hasFeature(TestResources.class) ?
+                Collections.singletonMap("test-resources.containers.mssql.accept-license", StringUtils.TRUE) :
+                Collections.emptyMap();
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/oraclecloud/OracleCloudAutonomousDatabase.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/oraclecloud/OracleCloudAutonomousDatabase.java
@@ -136,7 +136,7 @@ public class OracleCloudAutonomousDatabase extends DatabaseDriverFeature {
     }
 
     @Override
-    public Map<String, Object> getAdditionalConfig() {
+    public Map<String, Object> getAdditionalConfig(GeneratorContext generatorContext) {
         Map<String, Object> config = new LinkedHashMap<>(2);
         config.put("datasources.default.ocid", "");
         config.put("datasources.default.walletPassword", "");

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/BuildTestUtil.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/BuildTestUtil.groovy
@@ -18,9 +18,15 @@ class BuildTestUtil {
     }
 
     static BuildTestVerifier verifier(BuildTool buildTool,
+                                      Language language,
                                       String template) {
-        Language language = Language.DEFAULT_OPTION
         TestFramework testFramework = language.defaults.test
         verifier(buildTool, language, testFramework, template)
+    }
+
+    static BuildTestVerifier verifier(BuildTool buildTool,
+                                      String template) {
+        Language language = Language.DEFAULT_OPTION
+        return verifier(buildTool, language, template);
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/SQLServerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/SQLServerSpec.groovy
@@ -5,10 +5,11 @@ import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.build.BuildTestUtil
 import io.micronaut.starter.build.BuildTestVerifier
 import io.micronaut.starter.build.dependencies.Scope
-import io.micronaut.starter.feature.Feature
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
+import spock.lang.IgnoreIf
+import spock.lang.Requires
 import spock.lang.Unroll
 
 class SQLServerSpec extends ApplicationContextSpec implements CommandOutputFixture {
@@ -40,6 +41,7 @@ class SQLServerSpec extends ApplicationContextSpec implements CommandOutputFixtu
         output["src/main/resources/application.properties"].contains("test-resources.containers.mssql.accept-license=false\n")
     }
 
+    @Requires({ jvm.current.isJava11Compatible() })
     void 'test for test-resources the accept-license property is set to false with hibernate reactive=#hibernateReactiveFeature'(
             String hibernateReactiveFeature) {
         when:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/SQLServerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/SQLServerSpec.groovy
@@ -5,6 +5,7 @@ import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.build.BuildTestUtil
 import io.micronaut.starter.build.BuildTestVerifier
 import io.micronaut.starter.build.dependencies.Scope
+import io.micronaut.starter.feature.Feature
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
@@ -31,11 +32,23 @@ class SQLServerSpec extends ApplicationContextSpec implements CommandOutputFixtu
         [language, buildTool] << [Language.values().toList(), BuildTool.values()].combinations()
     }
 
-    void 'test for test-resources the accept-license property is set to true'() {
+    void 'test for test-resources the accept-license property is set to false'() {
         when:
         Map<String, String> output = generate(["sqlserver", "properties"])
 
         then:
-        output["src/main/resources/application.properties"].contains("test-resources.containers.mssql.accept-license=true\n")
+        output["src/main/resources/application.properties"].contains("test-resources.containers.mssql.accept-license=false\n")
+    }
+
+    void 'test for test-resources the accept-license property is set to false with hibernate reactive=#hibernateReactiveFeature'(
+            String hibernateReactiveFeature) {
+        when:
+        Map<String, String> output = generate(["sqlserver", "properties", hibernateReactiveFeature])
+
+        then:
+        output["src/main/resources/application.properties"].contains("test-resources.containers.mssql.accept-license=false\n")
+
+        where:
+        hibernateReactiveFeature << [HibernateReactiveJpa.NAME, DataHibernateReactive.NAME]
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/SQLServerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/SQLServerSpec.groovy
@@ -2,46 +2,40 @@ package io.micronaut.starter.feature.database
 
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
+import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import spock.lang.Unroll
 
-class SQLServerSpec extends ApplicationContextSpec {
+class SQLServerSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Unroll
-    void 'test gradle sqlserver feature for language=#language'() {
+    void 'test #buildTool sqlserver feature for language=#language'(Language language, BuildTool buildTool) {
         when:
-        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+        String template = new BuildBuilder(beanContext, buildTool)
                 .features(['sqlserver'])
                 .language(language)
                 .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, language, template)
 
         then:
-        template.contains('runtimeOnly("com.microsoft.sqlserver:mssql-jdbc")')
+        verifier.hasDependency("com.microsoft.sqlserver", "mssql-jdbc", Scope.RUNTIME)
+        if (buildTool.isGradle()) {
+            assert verifier.hasBuildPlugin("io.micronaut.test-resources")
+        }
 
         where:
-        language << Language.values().toList()
+        [language, buildTool] << [Language.values().toList(), BuildTool.values()].combinations()
     }
 
-    @Unroll
-    void 'test maven sqlserver feature for language=#language'() {
+    void 'test for test-resources the accept-license property is set to true'() {
         when:
-        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .features(['sqlserver'])
-                .language(language)
-                .render()
+        Map<String, String> output = generate(["sqlserver", "properties"])
 
         then:
-        template.contains("""
-    <dependency>
-      <groupId>com.microsoft.sqlserver</groupId>
-      <artifactId>mssql-jdbc</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-""")
-
-        where:
-        language << Language.values().toList()
+        output["src/main/resources/application.properties"].contains("test-resources.containers.mssql.accept-license=true\n")
     }
-
 }

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/AcceptLicenseSqlServer.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/AcceptLicenseSqlServer.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.starter.core.test.feature.database
+
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.starter.feature.database.SQLServer
+import io.micronaut.starter.feature.database.TestContainers
+import io.micronaut.starter.feature.database.jdbc.JdbcFeature
+import io.micronaut.starter.feature.testresources.TestResources
+import jakarta.inject.Singleton
+
+@Replaces(SQLServer.class)
+@Singleton
+class AcceptLicenseSqlServer extends SQLServer {
+
+    AcceptLicenseSqlServer(JdbcFeature jdbcFeature, TestContainers testContainers, TestResources testResources) {
+        super(jdbcFeature, testContainers, testResources)
+    }
+
+    @Override
+    boolean isVisible() {
+        return false
+    }
+
+    @Override
+    protected boolean acceptLicense() {
+        return true
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/DataHibernateReactiveSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/DataHibernateReactiveSpec.groovy
@@ -30,12 +30,6 @@ class DataHibernateReactiveSpec extends CommandSpec {
         def fsoh = new FileSystemOutputHandler(dir, ConsoleOutput.NOOP)
         fsoh.write("src/main/java/example/micronaut/Book.java", new RockerWritable(book.template()))
 
-        // If SqlServer, we need to accept the license
-        if (db == SQLServer.NAME) {
-            new File(dir, "src/test/resources/").mkdirs()
-            fsoh.write("src/test/resources/application-test.yml", { OutputStream output -> output.write("\ntest-resources.containers.mssql.accept-license: true".bytes) })
-        }
-
         String output = executeMaven("-DtrimStackTrace=false compile test")
 
         then:
@@ -50,12 +44,6 @@ class DataHibernateReactiveSpec extends CommandSpec {
         generateProject(Language.JAVA, BuildTool.GRADLE, [DataHibernateReactive.NAME, db])
         def fsoh = new FileSystemOutputHandler(dir, ConsoleOutput.NOOP)
         fsoh.write("src/main/java/example/micronaut/Book.java", new RockerWritable(book.template()))
-
-        // If SqlServer, we need to accept the license
-        if (db == SQLServer.NAME) {
-            new File(dir, "src/test/resources/").mkdirs()
-            fsoh.write("src/test/resources/application-test.yml", { OutputStream output -> output.write("\ntest-resources.containers.mssql.accept-license: true".bytes) })
-        }
 
         BuildResult result = executeGradle("test")
 

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/HibernateReactiveJpaSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/HibernateReactiveJpaSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.starter.core.test.feature.database
 
+import io.micronaut.starter.core.test.feature.database.templates.book
 import io.micronaut.starter.feature.database.HibernateReactiveJpa
 import io.micronaut.starter.feature.database.MariaDB
 import io.micronaut.starter.feature.database.MySQL
@@ -13,7 +14,6 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.template.RockerWritable
 import io.micronaut.starter.test.CommandSpec
 import org.gradle.testkit.runner.BuildResult
-import io.micronaut.starter.core.test.feature.database.templates.book
 import spock.lang.Requires
 
 @Requires({ jvm.current.isJava11Compatible() })

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/HibernateReactiveJpaSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/HibernateReactiveJpaSpec.groovy
@@ -30,12 +30,6 @@ class HibernateReactiveJpaSpec extends CommandSpec {
         def fsoh = new FileSystemOutputHandler(dir, ConsoleOutput.NOOP)
         fsoh.write("src/main/java/example/micronaut/Book.java", new RockerWritable(book.template()))
 
-        // If SqlServer, we need to accept the license
-        if (db == SQLServer.NAME) {
-            new File(dir, "src/test/resources/").mkdirs()
-            fsoh.write("src/test/resources/application-test.yml", { OutputStream output -> output.write("\ntest-resources.containers.mssql.accept-license: true".bytes) })
-        }
-
         String output = executeMaven("compile test")
 
         then:
@@ -50,12 +44,6 @@ class HibernateReactiveJpaSpec extends CommandSpec {
         generateProject(Language.JAVA, BuildTool.GRADLE, [HibernateReactiveJpa.NAME, db])
         def fsoh = new FileSystemOutputHandler(dir, ConsoleOutput.NOOP)
         fsoh.write("src/main/java/example/micronaut/Book.java", new RockerWritable(book.template()))
-
-        // If SqlServer, we need to accept the license
-        if (db == SQLServer.NAME) {
-            new File(dir, "src/test/resources/").mkdirs()
-            fsoh.write("src/test/resources/application-test.yml", { OutputStream output -> output.write("\ntest-resources.containers.mssql.accept-license: true".bytes) })
-        }
 
         BuildResult result = executeGradle("test")
 

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/testcontainers/TestcontainersSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/testcontainers/TestcontainersSpec.groovy
@@ -43,11 +43,6 @@ class TestcontainersSpec extends CommandSpec {
         fsoh.write("src/main/java/example/micronaut/Book.java", new RockerWritable(book.template()))
         fsoh.write("src/main/test/example/micronaut/BookRepositoryTest.java", new RockerWritable(bookRepositoryTest.template()))
 
-        // If SqlServer, we need to accept the license
-        if (driverFeature instanceof SQLServer) {
-            fsoh.write("/src/test/resources/application-test.yml", { OutputStream output -> output.write("\ntest-resources.containers.mssql.accept-license: true".bytes) }, true)
-        }
-
         String output = null
         if (driverFeature.getName() == "oracle" || driverFeature.getName() == "oracle-cloud-atp") {
             output = "BUILD SUCCESS"


### PR DESCRIPTION
Currently, we are doing the generation of the property directly in the tests. I don't know why we did it that way. The generated applications should include this property. 