### PR TITLE
Ktor failure

### DIFF
--- a/gradle/templates.versions.toml
+++ b/gradle/templates.versions.toml
@@ -107,9 +107,9 @@ log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 log4j-over-slf4j = { module = "org.slf4j:log4j-over-slf4j", version.ref = "slf4j" }
 log4j-slf4j = { module = "org.apache.logging.log4j:log4j-slf4j-impl", version.ref = "log4j" }
-ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
-ktor-serialization-jackson = { module = "io.ktor:ktor-serialization-jackson", version.ref = "ktor" }
-ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-netty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }
+ktor-serialization-jackson = { module = "io.ktor:ktor-serialization-jackson-jvm", version.ref = "ktor" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation-jvm", version.ref = "ktor" }
 micronaut-aot = { module = "io.micronaut.aot:micronaut-aot-core", version.ref = "micronaut-aot" }
 micronaut-build-plugins = { module = "io.micronaut.build.internal:micronaut-gradle-plugins", version.ref = "micronaut-build-plugins" }
 micronaut-crac-plugin = { module = "io.micronaut.gradle:micronaut-crac-plugin", version.ref = "micronaut-gradle-plugin" }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/kotlin/Ktor.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/kotlin/Ktor.java
@@ -35,6 +35,7 @@ import io.micronaut.starter.feature.kotlin.templates.nameTransformerKotlin;
 import io.micronaut.starter.feature.kotlin.templates.uppercaseTransformerKotlin;
 import io.micronaut.starter.feature.lang.kotlin.KotlinApplicationFeature;
 import io.micronaut.starter.feature.server.ThirdPartyServerFeature;
+import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.Language;
 import io.micronaut.starter.template.RockerTemplate;
 import jakarta.inject.Singleton;
@@ -121,12 +122,16 @@ public class Ktor implements KotlinApplicationFeature, ThirdPartyServerFeature, 
                 .artifactId("micronaut-ktor")
                 .compile());
 
+        generatorContext.addDependency(MicronautDependencyUtils.validationDependency()
+                .artifactId("micronaut-validation")
+                .compile());
+
         coordinateResolver.resolve(ARTIFACT_ID_KTOR_SERVER_NETTY)
                 .map(Coordinate::getVersion)
                 .ifPresent(version -> {
                     generatorContext.addDependency(Dependency.builder()
                             .groupId(GROUP_ID_IO_KTOR)
-                            .artifactId(ARTIFACT_ID_KTOR_SERVER_NETTY)
+                            .artifactId(mavenArtifactFix(generatorContext.getBuildTool(), ARTIFACT_ID_KTOR_SERVER_NETTY))
                             .version(version)
                             .compile());
                 });
@@ -135,7 +140,7 @@ public class Ktor implements KotlinApplicationFeature, ThirdPartyServerFeature, 
                 .ifPresent(version -> {
                     generatorContext.addDependency(Dependency.builder()
                             .groupId(GROUP_ID_IO_KTOR)
-                            .artifactId(ARTIFACT_ID_KTOR_SERIALIZATION_JACKSON)
+                            .artifactId(mavenArtifactFix(generatorContext.getBuildTool(), ARTIFACT_ID_KTOR_SERIALIZATION_JACKSON))
                             .version(version)
                             .compile());
                 });
@@ -144,10 +149,18 @@ public class Ktor implements KotlinApplicationFeature, ThirdPartyServerFeature, 
                 .ifPresent(version -> {
                     generatorContext.addDependency(Dependency.builder()
                             .groupId(GROUP_ID_IO_KTOR)
-                            .artifactId(ARTIFACT_ID_KTOR_SERVER_CONTENT_NEGOTIATION)
+                            .artifactId(mavenArtifactFix(generatorContext.getBuildTool(), ARTIFACT_ID_KTOR_SERVER_CONTENT_NEGOTIATION))
                             .version(version)
                             .compile());
                 });
+    }
+
+    /**
+     * Maven dependencies require a platform suffix for maven.
+     * <a href="https://ktor.io/docs/server-dependencies.html#core-dependencies">As described here</a>.
+     */
+    private String mavenArtifactFix(BuildTool buildTool, String artifact) {
+        return buildTool == BuildTool.MAVEN ? artifact + "-jvm" : artifact;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/kotlin/Ktor.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/kotlin/Ktor.java
@@ -44,6 +44,7 @@ import java.util.Optional;
 @Singleton
 public class Ktor implements KotlinApplicationFeature, ThirdPartyServerFeature, KotlinSpecificFeature {
 
+    public static final String NAME = "ktor";
     public static final String GROUP_ID_IO_KTOR = "io.ktor";
     public static final String ARTIFACT_ID_KTOR_SERVER_NETTY = "ktor-server-netty-jvm";
     public static final String ARTIFACT_ID_KTOR_SERIALIZATION_JACKSON = "ktor-serialization-jackson-jvm";
@@ -79,7 +80,7 @@ public class Ktor implements KotlinApplicationFeature, ThirdPartyServerFeature, 
     @NonNull
     @Override
     public String getName() {
-        return "ktor";
+        return NAME;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/kotlin/Ktor.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/kotlin/Ktor.java
@@ -35,7 +35,6 @@ import io.micronaut.starter.feature.kotlin.templates.nameTransformerKotlin;
 import io.micronaut.starter.feature.kotlin.templates.uppercaseTransformerKotlin;
 import io.micronaut.starter.feature.lang.kotlin.KotlinApplicationFeature;
 import io.micronaut.starter.feature.server.ThirdPartyServerFeature;
-import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.Language;
 import io.micronaut.starter.template.RockerTemplate;
 import jakarta.inject.Singleton;
@@ -46,9 +45,9 @@ import java.util.Optional;
 public class Ktor implements KotlinApplicationFeature, ThirdPartyServerFeature, KotlinSpecificFeature {
 
     public static final String GROUP_ID_IO_KTOR = "io.ktor";
-    public static final String ARTIFACT_ID_KTOR_SERVER_NETTY = "ktor-server-netty";
-    public static final String ARTIFACT_ID_KTOR_SERIALIZATION_JACKSON = "ktor-serialization-jackson";
-    public static final String ARTIFACT_ID_KTOR_SERVER_CONTENT_NEGOTIATION = "ktor-server-content-negotiation";
+    public static final String ARTIFACT_ID_KTOR_SERVER_NETTY = "ktor-server-netty-jvm";
+    public static final String ARTIFACT_ID_KTOR_SERIALIZATION_JACKSON = "ktor-serialization-jackson-jvm";
+    public static final String ARTIFACT_ID_KTOR_SERVER_CONTENT_NEGOTIATION = "ktor-server-content-negotiation-jvm";
     private final CoordinateResolver coordinateResolver;
 
     public Ktor(CoordinateResolver coordinateResolver) {
@@ -131,7 +130,7 @@ public class Ktor implements KotlinApplicationFeature, ThirdPartyServerFeature, 
                 .ifPresent(version -> {
                     generatorContext.addDependency(Dependency.builder()
                             .groupId(GROUP_ID_IO_KTOR)
-                            .artifactId(mavenArtifactFix(generatorContext.getBuildTool(), ARTIFACT_ID_KTOR_SERVER_NETTY))
+                            .artifactId(ARTIFACT_ID_KTOR_SERVER_NETTY)
                             .version(version)
                             .compile());
                 });
@@ -140,7 +139,7 @@ public class Ktor implements KotlinApplicationFeature, ThirdPartyServerFeature, 
                 .ifPresent(version -> {
                     generatorContext.addDependency(Dependency.builder()
                             .groupId(GROUP_ID_IO_KTOR)
-                            .artifactId(mavenArtifactFix(generatorContext.getBuildTool(), ARTIFACT_ID_KTOR_SERIALIZATION_JACKSON))
+                            .artifactId(ARTIFACT_ID_KTOR_SERIALIZATION_JACKSON)
                             .version(version)
                             .compile());
                 });
@@ -149,18 +148,10 @@ public class Ktor implements KotlinApplicationFeature, ThirdPartyServerFeature, 
                 .ifPresent(version -> {
                     generatorContext.addDependency(Dependency.builder()
                             .groupId(GROUP_ID_IO_KTOR)
-                            .artifactId(mavenArtifactFix(generatorContext.getBuildTool(), ARTIFACT_ID_KTOR_SERVER_CONTENT_NEGOTIATION))
+                            .artifactId(ARTIFACT_ID_KTOR_SERVER_CONTENT_NEGOTIATION)
                             .version(version)
                             .compile());
                 });
-    }
-
-    /**
-     * Maven dependencies require a platform suffix for maven.
-     * <a href="https://ktor.io/docs/server-dependencies.html#core-dependencies">As described here</a>.
-     */
-    private String mavenArtifactFix(BuildTool buildTool, String artifact) {
-        return buildTool == BuildTool.MAVEN ? artifact + "-jvm" : artifact;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/kotlin/templates/uppercaseTransformerKotlin.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/kotlin/templates/uppercaseTransformerKotlin.rocker.raw
@@ -14,6 +14,6 @@ import jakarta.inject.Singleton
 @@Singleton
 open class UppercaseTransformer : NameTransformer {
     override fun transform(@@NotBlank name: String): String {
-        return name.toUpperCase()
+        return name.uppercase()
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/kotlin/KtorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/kotlin/KtorSpec.groovy
@@ -26,7 +26,7 @@ class KtorSpec extends ApplicationContextSpec implements CommandOutputFixture {
     void 'test readme.md with feature ktor contains links to micronaut docs'() {
         when:
         Options options = new Options(Language.KOTLIN, TestFramework.JUNIT, BuildTool.GRADLE)
-        def output = generate(ApplicationType.DEFAULT, options, ['ktor'])
+        def output = generate(ApplicationType.DEFAULT, options, [Ktor.NAME])
         def readme = output["README.md"]
 
         then:
@@ -80,7 +80,7 @@ class KtorSpec extends ApplicationContextSpec implements CommandOutputFixture {
         when:
         String template = new BuildBuilder(beanContext, buildTool)
                 .language(language)
-                .features(['ktor'])
+                .features([Ktor.NAME])
                 .render()
 
         BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
@@ -105,7 +105,7 @@ class KtorSpec extends ApplicationContextSpec implements CommandOutputFixture {
         when:
         new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .language(language)
-                .features(['ktor'])
+                .features([Ktor.NAME])
                 .render()
 
         then:
@@ -120,7 +120,7 @@ class KtorSpec extends ApplicationContextSpec implements CommandOutputFixture {
     void 'dependency is included with gradle and feature ktor for language=#language'(Language language) {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .features(['ktor'])
+                .features([Ktor.NAME])
                 .language(language)
                 .render()
 
@@ -135,7 +135,7 @@ class KtorSpec extends ApplicationContextSpec implements CommandOutputFixture {
     void 'exception with gradle and feature ktor for language=#language'(Language language) {
         when:
         new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .features(['ktor'])
+                .features([Ktor.NAME])
                 .language(language)
                 .render()
 
@@ -153,7 +153,7 @@ class KtorSpec extends ApplicationContextSpec implements CommandOutputFixture {
         def output = generate(
                 ApplicationType.DEFAULT,
                 new Options(language, BuildTool.MAVEN),
-                ['ktor']
+                [Ktor.NAME]
         )
 
         then:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/kotlin/KtorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/kotlin/KtorSpec.groovy
@@ -77,6 +77,9 @@ class KtorSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Unroll
     void 'dependency is included with #buildTool and feature ktor for language=#language'(Language language, BuildTool buildTool) {
+        given:
+        def platformSuffix = buildTool == BuildTool.MAVEN ? '-jvm' : ''
+
         when:
         String template = new BuildBuilder(beanContext, buildTool)
                 .language(language)
@@ -87,9 +90,13 @@ class KtorSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
         then:
         verifier.hasDependency("io.micronaut.kotlin", "micronaut-ktor", Scope.COMPILE)
-        verifier.hasDependency("io.ktor", "ktor-server-netty", Scope.COMPILE)
-        verifier.hasDependency("io.ktor", "ktor-serialization-jackson", Scope.COMPILE)
         verifier.hasDependency("io.micronaut.kotlin", "micronaut-kotlin-runtime", Scope.COMPILE)
+        verifier.hasDependency("io.micronaut.validation", "micronaut-validation", Scope.COMPILE)
+
+        verifier.hasDependency("io.ktor", "ktor-server-netty" + platformSuffix, Scope.COMPILE)
+        verifier.hasDependency("io.ktor", "ktor-serialization-jackson" + platformSuffix, Scope.COMPILE)
+        verifier.hasDependency("io.ktor", "ktor-server-content-negotiation" + platformSuffix, Scope.COMPILE)
+
         !verifier.hasDependency("io.micronaut", "micronaut-http-server-netty", Scope.COMPILE)
 
         where:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/kotlin/KtorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/kotlin/KtorSpec.groovy
@@ -77,9 +77,6 @@ class KtorSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Unroll
     void 'dependency is included with #buildTool and feature ktor for language=#language'(Language language, BuildTool buildTool) {
-        given:
-        def platformSuffix = buildTool == BuildTool.MAVEN ? '-jvm' : ''
-
         when:
         String template = new BuildBuilder(beanContext, buildTool)
                 .language(language)
@@ -93,9 +90,9 @@ class KtorSpec extends ApplicationContextSpec implements CommandOutputFixture {
         verifier.hasDependency("io.micronaut.kotlin", "micronaut-kotlin-runtime", Scope.COMPILE)
         verifier.hasDependency("io.micronaut.validation", "micronaut-validation", Scope.COMPILE)
 
-        verifier.hasDependency("io.ktor", "ktor-server-netty" + platformSuffix, Scope.COMPILE)
-        verifier.hasDependency("io.ktor", "ktor-serialization-jackson" + platformSuffix, Scope.COMPILE)
-        verifier.hasDependency("io.ktor", "ktor-server-content-negotiation" + platformSuffix, Scope.COMPILE)
+        verifier.hasDependency("io.ktor", "ktor-server-netty-jvm", Scope.COMPILE)
+        verifier.hasDependency("io.ktor", "ktor-serialization-jackson-jvm", Scope.COMPILE)
+        verifier.hasDependency("io.ktor", "ktor-server-content-negotiation-jvm", Scope.COMPILE)
 
         !verifier.hasDependency("io.micronaut", "micronaut-http-server-netty", Scope.COMPILE)
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/server/MicronautServerDependentValidatorSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/server/MicronautServerDependentValidatorSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.starter.feature.server
 
 import io.micronaut.starter.BeanContextSpec
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.kotlin.Ktor
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
@@ -13,7 +14,7 @@ class MicronautServerDependentValidatorSpec extends BeanContextSpec  implements 
     void 'test third part server validation fails with micronaut server features'() {
         when:
         Options options = new Options(Language.KOTLIN, TestFramework.JUNIT, BuildTool.GRADLE)
-        generate(ApplicationType.DEFAULT, options, ['ktor', 'management', 'tracing-zipkin'])
+        generate(ApplicationType.DEFAULT, options, [Ktor.NAME, 'management', 'tracing-zipkin'])
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -23,7 +24,7 @@ class MicronautServerDependentValidatorSpec extends BeanContextSpec  implements 
     void 'test third part server validation fails with some micronaut server features'() {
         when:
         Options options = new Options(Language.KOTLIN, TestFramework.JUNIT, BuildTool.GRADLE)
-        generate(ApplicationType.DEFAULT, options, ['ktor', 'management', 'tracing-zipkin', 'kafka'])
+        generate(ApplicationType.DEFAULT, options, [Ktor.NAME, 'management', 'tracing-zipkin', 'kafka'])
 
         then:
         def e = thrown(IllegalArgumentException)

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/KtorSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/KtorSpec.groovy
@@ -5,11 +5,9 @@ import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.test.BuildToolCombinations
 import io.micronaut.starter.test.CommandSpec
-import spock.lang.Unroll
 
 class KtorSpec extends CommandSpec {
 
-    @Unroll
     void 'create-app with feature ktor for #lang and #buildTool starts successfully'(Language lang, BuildTool buildTool) {
         given:
         generateProject(lang, buildTool, ['ktor'] as List<String>, ApplicationType.DEFAULT)

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/KtorSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/KtorSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.starter.core.test.create
 
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.kotlin.Ktor
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.test.BuildToolCombinations
@@ -10,7 +11,7 @@ class KtorSpec extends CommandSpec {
 
     void 'create-app with feature ktor for #lang and #buildTool starts successfully'(Language lang, BuildTool buildTool) {
         given:
-        generateProject(lang, buildTool, ['ktor'] as List<String>, ApplicationType.DEFAULT)
+        generateProject(lang, buildTool, [Ktor.NAME] as List<String>, ApplicationType.DEFAULT)
 
         when:
         String output = executeBuild(buildTool, "test")

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/KtorSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/KtorSpec.groovy
@@ -5,10 +5,8 @@ import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.test.BuildToolCombinations
 import io.micronaut.starter.test.CommandSpec
-import spock.lang.Ignore
 import spock.lang.Unroll
 
-@Ignore
 class KtorSpec extends CommandSpec {
 
     @Unroll


### PR DESCRIPTION
Fails with :

```
e: org.jetbrains.kotlin.backend.common.BackendException: Backend Internal error: Exception during psi2ir
File being compiled: (19,53) in /private/var/folders/pb/dx1ms2_92_g54v9jvzv7k4hc0000gn/T/test-ktor11112501255394226473/src/main/kotlin/example/micronaut/HomeRoute.kt
The root cause org.jetbrains.kotlin.psi2ir.generators.ErrorExpressionException was thrown at: org.jetbrains.kotlin.psi2ir.generators.ErrorExpressionGenerator.generateErrorCall(ErrorExpressionGenerator.kt:100)
null: KtCallExpression:
joinToString(",") { c -> "${c.propertyPath.last().name} ${c.message}" }
	at org.jetbrains.kotlin.backend.common.CodegenUtil.reportBackendException(CodegenUtil.kt:253)
	at org.jetbrains.kotlin.backend.common.CodegenUtil.reportBackendException$default(CodegenUtil.kt:237)
	at org.jetbrains.kotlin.psi2ir.generators.DeclarationGenerator.generateMemberDeclaration(DeclarationGenerator.kt:75)
	at org.jetbrains.kotlin.psi2ir.generators.ModuleGenerator.generateSingleFile(ModuleGenerator.kt:73)
	at org.jetbrains.kotlin.psi2ir.generators.ModuleGenerator.generateModuleFragment(ModuleGenerator.kt:53)
	at org.jetbrains.kotlin.psi2ir.Psi2IrTranslator.generateModuleFragment(Psi2IrTranslator.kt:97)
	at org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.convertToIr(JvmIrCodegenFactory.kt:224)
	at org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.convertToIr(JvmIrCodegenFactory.kt:57)
	at org.jetbrains.kotlin.codegen.KotlinCodegenFacade.compileCorrectFiles(KotlinCodegenFacade.java:41)
	at org.jetbrains.kotlin.kapt3.AbstractKapt3Extension.contextForStubGeneration(Kapt3Extension.kt:280)
	at org.jetbrains.kotlin.kapt3.AbstractKapt3Extension.analysisCompleted(Kapt3Extension.kt:174)
	at org.jetbrains.kotlin.kapt3.ClasspathBasedKapt3Extension.analysisCompleted(Kapt3Extension.kt:104)
	at org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM$analyzeFilesWithJavaIntegration$2.invoke(TopDownAnalyzerFacadeForJVM.kt:115)
	at org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(TopDownAnalyzerFacadeForJVM.kt:125)
	at org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration$default(TopDownAnalyzerFacadeForJVM.kt:99)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler$analyze$1.invoke(KotlinToJVMBytecodeCompiler.kt:257)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler$analyze$1.invoke(KotlinToJVMBytecodeCompiler.kt:42)
	at org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport.analyzeAndReport(AnalyzerWithCompilerReport.kt:115)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.analyze(KotlinToJVMBytecodeCompiler.kt:248)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.compileModules$cli(KotlinToJVMBytecodeCompiler.kt:88)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.compileModules$cli$default(KotlinToJVMBytecodeCompiler.kt:47)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:168)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:53)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:100)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:46)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:101)
	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:495)
	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:133)
	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.doCompile(IncrementalCompilerRunner.kt:486)
	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileImpl(IncrementalCompilerRunner.kt:409)
	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileNonIncrementally(IncrementalCompilerRunner.kt:290)
	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile(IncrementalCompilerRunner.kt:112)
	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.execIncrementalCompiler(CompileServiceImpl.kt:627)
	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.access$execIncrementalCompiler(CompileServiceImpl.kt:101)
	at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1587)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:360)
	at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
	at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
	at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:587)
	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:828)
	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:705)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:704)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.ja
``