### PR TITLE
build: workaround gradle #17559 to be able to do dockerPush

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,7 @@
 plugins {
     id "io.micronaut.internal.starter.aggregator"
     id "io.micronaut.build.internal.dependency-updates"
+    // https://github.com/bmuschko/gradle-docker-plugin/issues/1123
+    // https://github.com/gradle/gradle/issues/17559
+    id("com.bmuschko.docker-remote-api") version "9.0.1" apply false
 }


### PR DESCRIPTION
Without this fix:

./gradlew :starter-analytics-postgres:dockerBuild

fails with    > Cannot set the value of task ':starter-analytics-postgres:dockerPush' property 'dockerClientService' of type com.bmuschko.gradle.docker.internal.services.DockerClientService using a provider of type com.bmuschko.gradle.docker.internal.services.DockerClientService.