### PR TITLE
Support only jdk17

### DIFF
--- a/starter-analytics-postgres/src/test/groovy/io/micronaut/starter/analytics/postgres/StoreGeneratedProjectStatsSpec.groovy
+++ b/starter-analytics-postgres/src/test/groovy/io/micronaut/starter/analytics/postgres/StoreGeneratedProjectStatsSpec.groovy
@@ -15,6 +15,7 @@ import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.util.VersionInfo
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
@@ -58,7 +59,7 @@ class StoreGeneratedProjectStatsSpec extends Specification implements TestProper
                 Language.KOTLIN,
                 BuildTool.MAVEN,
                 TestFramework.SPOCK,
-                JdkVersion.JDK_11
+                MicronautJdkVersionConfiguration.DEFAULT_OPTION
         )
         generated.setSelectedFeatures([new SelectedFeature("google-cloud-function")])
 

--- a/starter-api/src/main/java/io/micronaut/starter/api/SelectOptionsDTO.java
+++ b/starter-api/src/main/java/io/micronaut/starter/api/SelectOptionsDTO.java
@@ -25,7 +25,7 @@ import io.micronaut.starter.api.options.LanguageSelectOptions;
 import io.micronaut.starter.api.options.TestFrameworkSelectOptions;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.options.BuildTool;
-import io.micronaut.starter.options.JdkVersion;
+import io.micronaut.starter.options.JdkVersionConfiguration;
 import io.micronaut.starter.options.Language;
 import io.micronaut.starter.options.TestFramework;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -93,7 +93,9 @@ public class SelectOptionsDTO {
      * Build the options
      * @return the supported options
      */
-    public static SelectOptionsDTO make(MessageSource messageSource, MessageSource.MessageContext messageContext) {
+    public static SelectOptionsDTO make(MessageSource messageSource,
+                                        MessageSource.MessageContext messageContext,
+                                        JdkVersionConfiguration jdkVersionConfiguration) {
 
         List<ApplicationTypeDTO> applications = Arrays.stream(ApplicationType.values())
                 .map(it -> new ApplicationTypeDTO(it, null, messageSource, messageContext))
@@ -104,13 +106,13 @@ public class SelectOptionsDTO {
                 new ApplicationTypeDTO(ApplicationType.DEFAULT_OPTION, null, messageSource, messageContext)
         );
 
-        List<JdkVersionDTO> jdkVersions = Arrays.stream(JdkVersion.values())
+        List<JdkVersionDTO> jdkVersions = jdkVersionConfiguration.getSupportedJdkVersions().stream()
                 .map(it -> new JdkVersionDTO(it, messageSource, messageContext))
                 .collect(Collectors.toList());
 
         JdkVersionSelectOptions jdkVersionOpts = new JdkVersionSelectOptions(
                 jdkVersions,
-                new JdkVersionDTO(JdkVersion.DEFAULT_OPTION, messageSource, messageContext)
+                new JdkVersionDTO(jdkVersionConfiguration.getDefaultJdkVersion(), messageSource, messageContext)
         );
 
         List<LanguageDTO> languages = Arrays.stream(Language.values())

--- a/starter-api/src/main/java/io/micronaut/starter/api/create/AbstractCreateController.java
+++ b/starter-api/src/main/java/io/micronaut/starter/api/create/AbstractCreateController.java
@@ -33,6 +33,7 @@ import io.micronaut.starter.io.ConsoleOutput;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.JdkVersion;
 import io.micronaut.starter.options.Language;
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration;
 import io.micronaut.starter.options.Options;
 import io.micronaut.starter.util.NameUtils;
 import org.slf4j.Logger;
@@ -90,7 +91,7 @@ public abstract class AbstractCreateController {
                     new Options(lang,
                             testFramework != null ? testFramework.toTestFramework() : language.getDefaults().getTest(),
                             buildTool == null ? language.getDefaults().getBuild() : buildTool,
-                            javaVersion == null ? JdkVersion.DEFAULT_OPTION : javaVersion),
+                            javaVersion == null ? MicronautJdkVersionConfiguration.DEFAULT_OPTION : javaVersion),
                     getOperatingSystem(userAgent),
                     features != null ? features : Collections.emptyList(),
                     ConsoleOutput.NOOP

--- a/starter-api/src/main/java/io/micronaut/starter/api/diff/DiffController.java
+++ b/starter-api/src/main/java/io/micronaut/starter/api/diff/DiffController.java
@@ -33,6 +33,7 @@ import io.micronaut.starter.io.ConsoleOutput;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.JdkVersion;
 import io.micronaut.starter.options.Language;
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration;
 import io.micronaut.starter.options.Options;
 import io.micronaut.starter.options.TestFramework;
 import io.micronaut.starter.util.NameUtils;
@@ -111,7 +112,7 @@ public class DiffController implements DiffOperations {
                     language,
                     test != null ? test : language.getDefaults().getTest(),
                     build != null ? build : language.getDefaults().getBuild(),
-                    javaVersion != null ? javaVersion : JdkVersion.DEFAULT_OPTION
+                    javaVersion != null ? javaVersion : MicronautJdkVersionConfiguration.DEFAULT_OPTION
             );
             projectGenerator = this.projectGenerator;
             generatorContext = projectGenerator.createGeneratorContext(
@@ -163,7 +164,7 @@ public class DiffController implements DiffOperations {
                     language,
                     test != null ? test : language.getDefaults().getTest(),
                     build != null ? build : language.getDefaults().getBuild(),
-                    javaVersion != null ? javaVersion : JdkVersion.DEFAULT_OPTION
+                    javaVersion != null ? javaVersion : MicronautJdkVersionConfiguration.DEFAULT_OPTION
             );
             projectGenerator = this.projectGenerator;
             generatorContext = projectGenerator.createGeneratorContext(

--- a/starter-api/src/main/java/io/micronaut/starter/api/options/SelectOptionsController.java
+++ b/starter-api/src/main/java/io/micronaut/starter/api/options/SelectOptionsController.java
@@ -23,7 +23,7 @@ import io.micronaut.http.annotation.Get;
 import io.micronaut.starter.api.RequestInfo;
 import io.micronaut.starter.api.SelectOptionsDTO;
 
-import jakarta.inject.Inject;
+import io.micronaut.starter.options.JdkVersionConfiguration;
 import jakarta.inject.Singleton;
 
 /**
@@ -34,8 +34,13 @@ import jakarta.inject.Singleton;
 @Controller("/select-options")
 public class SelectOptionsController implements SelectOptionsOperations {
 
-    @Inject
-    MessageSource messageSource;
+    private final MessageSource messageSource;
+    private final JdkVersionConfiguration jdkVersionConfiguration;
+
+    public SelectOptionsController(MessageSource messageSource, JdkVersionConfiguration jdkVersionConfiguration) {
+        this.messageSource = messageSource;
+        this.jdkVersionConfiguration = jdkVersionConfiguration;
+    }
 
     /**
      * Gets select options for the starter
@@ -46,7 +51,7 @@ public class SelectOptionsController implements SelectOptionsOperations {
     @Get(uri = "/", produces = MediaType.APPLICATION_JSON)
     public SelectOptionsDTO selectOptions(RequestInfo requestInfo) {
         MessageSource.MessageContext context = MessageSource.MessageContext.of(requestInfo.getLocale());
-        return SelectOptionsDTO.make(messageSource, context);
+        return SelectOptionsDTO.make(messageSource, context, jdkVersionConfiguration);
     }
 
     @Singleton

--- a/starter-api/src/main/java/io/micronaut/starter/api/preview/PreviewController.java
+++ b/starter-api/src/main/java/io/micronaut/starter/api/preview/PreviewController.java
@@ -34,6 +34,7 @@ import io.micronaut.starter.io.MapOutputHandler;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.JdkVersion;
 import io.micronaut.starter.options.Language;
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration;
 import io.micronaut.starter.options.Options;
 import io.micronaut.starter.util.NameUtils;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -96,7 +97,7 @@ public class PreviewController extends AbstractCreateController implements Previ
                             lang,
                             test != null ? test.toTestFramework() : null,
                             build == null ? BuildTool.DEFAULT_OPTION : build,
-                            javaVersion == null ? JdkVersion.DEFAULT_OPTION : javaVersion),
+                            javaVersion == null ? MicronautJdkVersionConfiguration.DEFAULT_OPTION : javaVersion),
                     getOperatingSystem(requestInfo.getUserAgent()),
                     features == null ? Collections.emptyList() : features,
                     outputHandler,

--- a/starter-api/src/test/groovy/io/micronaut/starter/api/features/GoogleCloudFunctionSpec.groovy
+++ b/starter-api/src/test/groovy/io/micronaut/starter/api/features/GoogleCloudFunctionSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.function.gcp.GoogleCloudEventsFunction
 import io.micronaut.starter.feature.function.gcp.GoogleCloudRawFunction
 import io.micronaut.starter.options.JdkVersion
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Requires
 import spock.lang.Specification
@@ -27,7 +28,7 @@ class GoogleCloudFunctionSpec extends Specification {
                 null,
                 null,
                 null,
-                JdkVersion.JDK_11,
+                MicronautJdkVersionConfiguration.DEFAULT_OPTION,
                 new RequestInfo("http://localhost", "", null, Locale.ENGLISH, "")
         )
 
@@ -46,7 +47,7 @@ class GoogleCloudFunctionSpec extends Specification {
                 null,
                 null,
                 null,
-                JdkVersion.JDK_11,
+                MicronautJdkVersionConfiguration.DEFAULT_OPTION,
                 new RequestInfo("http://localhost", "", null, Locale.ENGLISH, "")
         )
 

--- a/starter-api/src/test/groovy/io/micronaut/starter/api/options/SelectOptionsControllerTest.groovy
+++ b/starter-api/src/test/groovy/io/micronaut/starter/api/options/SelectOptionsControllerTest.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.starter.api.options
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.starter.api.JdkVersionDTO
+import io.micronaut.starter.api.SelectOptionsDTO
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class SelectOptionsControllerTest extends Specification {
+
+    @Inject
+    @Client("/")
+    HttpClient httpClient
+
+    void "Only JDK 17 is supported"() {
+        BlockingHttpClient client = httpClient.toBlocking()
+
+        HttpRequest<?> request = HttpRequest.GET("/select-options")
+        when:
+        SelectOptionsDTO selectOptionsDTO = client.retrieve(request, SelectOptionsDTO)
+
+        then:
+        noExceptionThrown()
+        ['JDK_17'] == selectOptionsDTO.jdkVersion.options.stream().map(JdkVersionDTO::getName).toList()
+    }
+}

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/BuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/BuilderCommand.java
@@ -25,6 +25,7 @@ import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.JdkVersion;
 import io.micronaut.starter.options.Language;
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration;
 import io.micronaut.starter.options.TestFramework;
 import io.micronaut.starter.util.NameUtils;
 import org.jline.reader.EndOfFileException;
@@ -97,13 +98,18 @@ public abstract class BuilderCommand extends BaseCommand implements Callable<Int
     }
 
     protected JdkVersion getJdkVersion(LineReader reader) {
+        List<String> candidates = new JdkVersionCandidates();
+        JdkVersion defaultOption = MicronautJdkVersionConfiguration.DEFAULT_OPTION;
+        if (candidates.size() == 1) {
+            return defaultOption;
+        }
         out("Choose the target JDK. (enter for default)");
-        return getEnumOption(
-                JdkVersion.class,
-                jdkVersion -> Integer.toString(jdkVersion.majorVersion()),
-                JdkVersion.DEFAULT_OPTION,
+        return JdkVersion.valueOf(Integer.parseInt(getListOption(
+                candidates,
+                s -> s,
+                String.valueOf(defaultOption.majorVersion()),
                 reader
-        );
+        )));
     }
 
     protected int getOption(LineReader reader, int max) throws UserInterruptException, EndOfFileException {

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
@@ -161,8 +161,7 @@ public class CreateLambdaBuilderCommand extends BuilderCommand {
         switch (deployment) {
             case NATIVE_EXECUTABLE:
                 return new JdkVersion[] {
-                        JdkVersion.JDK_17,
-                        JdkVersion.JDK_11,
+                        JdkVersion.JDK_17
                 };
             default:
             case FAT_JAR:

--- a/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/CreateBuilderCommandSpec.groovy
+++ b/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/CreateBuilderCommandSpec.groovy
@@ -39,9 +39,7 @@ Choose your preferred build tool. (enter for default)
  3) Maven
 
 Choose the target JDK. (enter for default)
- 1) 8
-*2) 11
- 3) 17
+ 1) 17
      */
     @Unroll
     void "test prompt"(List<String> answers,
@@ -78,91 +76,77 @@ Choose the target JDK. (enter for default)
                 "1", // Java
                 "1", // JUnit
                 "1", // Gradle
-                "1", // JDK 8
-        ]       | ApplicationType.DEFAULT | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_8
+                "1", // JDK 17
+        ]       | ApplicationType.DEFAULT | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_17
         [
                 "2", // CLI
                 "1", // Java
                 "1", // JUnit
                 "1", // Gradle
-                "1", // JDK 8
-        ]       | ApplicationType.CLI | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_8
+                "1", // JDK 17
+        ]       | ApplicationType.CLI | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_17
         [
                 "3", // FUNCTION
                 "1", // Java
                 "1", // JUnit
                 "1", // Gradle
-                "1", // JDK 8
-        ]       | ApplicationType.FUNCTION | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_8
+                "1", // JDK 17
+        ]       | ApplicationType.FUNCTION | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_17
         [
                 "4", // GRPC
                 "1", // Java
                 "1", // JUnit
                 "1", // Gradle
-                "1", // JDK 8
-        ]       | ApplicationType.GRPC | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_8
+                "1", // JDK 17
+        ]       | ApplicationType.GRPC | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_17
         [
                 "5", // MESSAGING
                 "1", // Java
                 "1", // JUnit
                 "1", // Gradle
-                "1", // JDK 8
-        ]       | ApplicationType.MESSAGING | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_8
+                "1", // JDK 17
+        ]       | ApplicationType.MESSAGING | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_17
         [
                 "1", // Default
                 "2", // Groovy
                 "1", // JUnit
                 "1", // Gradle
-                "1", // JDK 8
-        ]       | ApplicationType.DEFAULT | Language.GROOVY | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_8
+                "1", // JDK 17
+        ]       | ApplicationType.DEFAULT | Language.GROOVY | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_17
         [
                 "1", // Default
                 "3", // Kotlin
                 "1", // JUnit
                 "1", // Gradle
-                "1", // JDK 8
-        ]       | ApplicationType.DEFAULT | Language.KOTLIN | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_8
+                "1", // JDK 17
+        ]       | ApplicationType.DEFAULT | Language.KOTLIN | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_17
         [
                 "1", // Default
                 "1", // Java
                 "2", // Spock
                 "1", // Gradle
-                "1", // JDK 8
-        ]       | ApplicationType.DEFAULT | Language.JAVA | TestFramework.SPOCK | BuildTool.GRADLE | JdkVersion.JDK_8
+                "1", // JDK 17
+        ]       | ApplicationType.DEFAULT | Language.JAVA | TestFramework.SPOCK | BuildTool.GRADLE | JdkVersion.JDK_17
         [
                 "1", // Default
                 "1", // Java
                 "3", // KoTest
                 "1", // Gradle
-                "1", // JDK 8
-        ]       | ApplicationType.DEFAULT | Language.JAVA | TestFramework.KOTEST | BuildTool.GRADLE | JdkVersion.JDK_8
+                "1", // JDK 17
+        ]       | ApplicationType.DEFAULT | Language.JAVA | TestFramework.KOTEST | BuildTool.GRADLE | JdkVersion.JDK_17
         [
                 "1", // Default
                 "1", // Java
                 "1", // JUnit
                 "2", // Gradle Kotlin
-                "1", // JDK 8
-        ]       | ApplicationType.DEFAULT | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE_KOTLIN | JdkVersion.JDK_8
+                "1", // JDK 17
+        ]       | ApplicationType.DEFAULT | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE_KOTLIN | JdkVersion.JDK_17
         [
                 "1", // Default
                 "1", // Java
                 "1", // JUnit
                 "3", // Maven
-                "1", // JDK 8
-        ]       | ApplicationType.DEFAULT | Language.JAVA | TestFramework.JUNIT | BuildTool.MAVEN | JdkVersion.JDK_8
-        [
-                "1", // Default
-                "1", // Java
-                "1", // JUnit
-                "1", // Gradle
-                "2", // JDK 11
-        ]       | ApplicationType.DEFAULT | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_11
-        [
-                "1", // Default
-                "1", // Java
-                "1", // JUnit
-                "1", // Gradle
-                "3", // JDK 17
-        ]       | ApplicationType.DEFAULT | Language.JAVA | TestFramework.JUNIT | BuildTool.GRADLE | JdkVersion.JDK_17
+                "1", // JDK 17
+        ]       | ApplicationType.DEFAULT | Language.JAVA | TestFramework.JUNIT | BuildTool.MAVEN | JdkVersion.JDK_17
     }
 }

--- a/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/JdkVersionCandidatesSpec.groovy
+++ b/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/JdkVersionCandidatesSpec.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.starter.cli.command
+
+import spock.lang.Specification
+
+class JdkVersionCandidatesSpec extends Specification {
+
+    void "ony 17 is valid candidate"() {
+        expect:
+        ['17'] == new JdkVersionCandidates()
+    }
+}

--- a/starter-cli/src/test/groovy/io/micronaut/starter/cli/feature/database/CreateRepositorySpec.groovy
+++ b/starter-cli/src/test/groovy/io/micronaut/starter/cli/feature/database/CreateRepositorySpec.groovy
@@ -9,6 +9,7 @@ import io.micronaut.starter.io.ConsoleOutput
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.util.VersionInfo
 import spock.lang.AutoCleanup
@@ -69,7 +70,7 @@ class CreateRepositorySpec extends CommandSpec implements CommandFixture {
     void "test creating a repository for #language and #driverFeature.name"(Language language, DatabaseDriverFeature driverFeature) {
         boolean forceJava11 = driverFeature.name == "oracle-cloud-atp" && VersionInfo.getJavaVersion() == JdkVersion.JDK_8
         if (forceJava11) {
-            generateProject(new Options(language, null, BuildTool.GRADLE, JdkVersion.JDK_11),
+            generateProject(new Options(language, null, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                     ['data-jdbc', driverFeature.getName()])
         } else {
             generateProject(language, BuildTool.GRADLE, ['data-jdbc', driverFeature.getName()])

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/AwsLambdaFeatureValidator.java
@@ -21,16 +21,17 @@ import io.micronaut.starter.feature.function.awslambda.AwsLambda;
 import io.micronaut.starter.feature.graalvm.GraalVM;
 import io.micronaut.starter.feature.validation.FeatureValidator;
 import io.micronaut.starter.options.JdkVersion;
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration;
 import io.micronaut.starter.options.Options;
 import jakarta.inject.Singleton;
 
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Singleton
 public class AwsLambdaFeatureValidator implements FeatureValidator {
+
     @Override
     public void validatePreProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
         if (features.stream().anyMatch(f -> f instanceof AwsLambda) && features.stream().noneMatch(f -> f instanceof GraalVM)) {
@@ -47,19 +48,19 @@ public class AwsLambdaFeatureValidator implements FeatureValidator {
     }
 
     public static List<JdkVersion> supportedJdks() {
-        return Stream.of(JdkVersion.values())
+        return MicronautJdkVersionConfiguration.SUPPORTED_JDKS.stream()
                 .filter(AwsLambdaFeatureValidator::supports)
                 .collect(Collectors.toList());
     }
 
     public static JdkVersion firstSupportedJdk() {
-        return Stream.of(JdkVersion.values())
+        return MicronautJdkVersionConfiguration.SUPPORTED_JDKS.stream()
                 .filter(AwsLambdaFeatureValidator::supports)
                 .findFirst()
                 .orElse(JdkVersion.JDK_17);
     }
     
     public static boolean supports(JdkVersion jdkVersion) {
-        return jdkVersion == JdkVersion.JDK_8 || jdkVersion == JdkVersion.JDK_11 || jdkVersion == JdkVersion.JDK_17;
+        return jdkVersion == JdkVersion.JDK_17;
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/template/cdkappstack.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/template/cdkappstack.rocker.raw
@@ -153,11 +153,7 @@ public class AppStack extends Stack {
                 this,
                 "@(functionId)")
 @if (!nativeImage) {
-@if (jdkVersion == JdkVersion.JDK_8) {
-                .runtime(Runtime.JAVA_8)
-} else if (jdkVersion == JdkVersion.JDK_11) {
-                .runtime(Runtime.JAVA_11)
-} else if (jdkVersion == JdkVersion.JDK_17) {
+@if (jdkVersion == JdkVersion.JDK_17) {
                 .runtime(Runtime.JAVA_17)
 }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -51,18 +51,12 @@ MavenBuild mavenBuild
     <artifactId>micronaut-parent</artifactId>
     <version>@VersionInfo.getMicronautVersion()</version>
   </parent>
-
 }
 
   <properties>
     <packaging>jar</packaging>
     <jdk.version>@features.getTargetJdk()</jdk.version>
-@if (features.javaVersion() == JdkVersion.JDK_8) {
-    <!-- If you are building with JDK 9 or higher, you can uncomment the lines below to set the release version -->
-    <!-- <release.version>@features.javaVersion().majorVersion()</release.version> -->
-} else {
     <release.version>@features.javaVersion().majorVersion()</release.version>
-}
 @for (Property prop : mavenBuild.getProperties()) {
 @if (prop.isComment()) {
     <!--@prop.getComment()-->

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
@@ -123,10 +123,6 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
     private Optional<String> javaVersionValue(GeneratorContext generatorContext) {
         if (generatorContext.getBuildTool().isGradle()) {
             switch (generatorContext.getJdkVersion()) {
-                case JDK_8:
-                    return Optional.of("Java 8");
-                case JDK_11:
-                    return Optional.of("Java 11");
                 case JDK_17:
                     return Optional.of("Java 17");
                 default:
@@ -134,10 +130,6 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
             }
         }
         switch (generatorContext.getJdkVersion()) {
-            case JDK_8:
-                return Optional.of("8");
-            case JDK_11:
-                return Optional.of("11");
             case JDK_17:
                 return Optional.of("17");
             default:

--- a/starter-core/src/main/java/io/micronaut/starter/options/JdkVersion.java
+++ b/starter-core/src/main/java/io/micronaut/starter/options/JdkVersion.java
@@ -17,27 +17,35 @@ package io.micronaut.starter.options;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * JDK versions.
- *
+ * <a href="https://www.java.com/releases/">Releases</a>
  * @author graemerocher
  * @since 1.0.0
  */
 public enum JdkVersion {
-    JDK_8(8),
-    JDK_11(11),
-    JDK_17(17);
+    JDK_8(8, true),
+    JDK_9(9, false),
+    JDK_10(9, false),
+    JDK_11(11, true),
+    JDK_12(12, false),
+    JDK_13(13, false),
+    JDK_14(14, false),
+    JDK_15(15, false),
+    JDK_16(16, false),
+    JDK_17(17, true),
+    JDK_19(19, false),
+    JDK_20(20, false);
 
-    public static final JdkVersion DEFAULT_OPTION = JDK_17;
-
-    private static final List<Integer> SUPPORTED_JDKS = Arrays.stream(JdkVersion.values()).map(JdkVersion::majorVersion).collect(Collectors.toList());
+    private static final List<Integer> SUPPORTED_JDKS = Arrays.stream(JdkVersion.values()).map(JdkVersion::majorVersion).toList();
 
     private final int majorVersion;
+    private final boolean lts;
 
-    JdkVersion(int majorVersion) {
+    JdkVersion(int majorVersion, boolean lts) {
         this.majorVersion = majorVersion;
+        this.lts = lts;
     }
 
     public static JdkVersion valueOf(int majorVersion) {
@@ -50,6 +58,10 @@ public enum JdkVersion {
 
     public int majorVersion() {
         return majorVersion;
+    }
+
+    public boolean isLts() {
+        return lts;
     }
 
     public boolean greaterThanEqual(JdkVersion jdk) {

--- a/starter-core/src/main/java/io/micronaut/starter/options/JdkVersion.java
+++ b/starter-core/src/main/java/io/micronaut/starter/options/JdkVersion.java
@@ -25,27 +25,26 @@ import java.util.List;
  * @since 1.0.0
  */
 public enum JdkVersion {
-    JDK_8(8, true),
-    JDK_9(9, false),
-    JDK_10(9, false),
-    JDK_11(11, true),
-    JDK_12(12, false),
-    JDK_13(13, false),
-    JDK_14(14, false),
-    JDK_15(15, false),
-    JDK_16(16, false),
-    JDK_17(17, true),
-    JDK_19(19, false),
-    JDK_20(20, false);
+    JDK_8(8),
+    JDK_9(9),
+    JDK_10(10),
+    JDK_11(11),
+    JDK_12(12),
+    JDK_13(13),
+    JDK_14(14),
+    JDK_15(15),
+    JDK_16(16),
+    JDK_17(17),
+    JDK_18(18),
+    JDK_19(19),
+    JDK_20(20);
 
     private static final List<Integer> SUPPORTED_JDKS = Arrays.stream(JdkVersion.values()).map(JdkVersion::majorVersion).toList();
 
     private final int majorVersion;
-    private final boolean lts;
 
-    JdkVersion(int majorVersion, boolean lts) {
+    JdkVersion(int majorVersion) {
         this.majorVersion = majorVersion;
-        this.lts = lts;
     }
 
     public static JdkVersion valueOf(int majorVersion) {
@@ -58,10 +57,6 @@ public enum JdkVersion {
 
     public int majorVersion() {
         return majorVersion;
-    }
-
-    public boolean isLts() {
-        return lts;
     }
 
     public boolean greaterThanEqual(JdkVersion jdk) {

--- a/starter-core/src/main/java/io/micronaut/starter/options/JdkVersionConfiguration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/options/JdkVersionConfiguration.java
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.cli.command;
+package io.micronaut.starter.options;
 
-import io.micronaut.starter.options.JdkVersion;
-import io.micronaut.starter.options.MicronautJdkVersionConfiguration;
+import io.micronaut.context.annotation.DefaultImplementation;
+import io.micronaut.core.annotation.NonNull;
 
-import java.util.ArrayList;
-import java.util.stream.Collectors;
+import java.util.List;
 
-public class JdkVersionCandidates extends ArrayList<String> {
+@DefaultImplementation(MicronautJdkVersionConfiguration.class)
+public interface JdkVersionConfiguration {
 
-    public JdkVersionCandidates() {
-        super(MicronautJdkVersionConfiguration.SUPPORTED_JDKS.stream().map(JdkVersion::majorVersion).map(Object::toString).collect(Collectors.toList()));
-    }
+    @NonNull
+    List<JdkVersion> getSupportedJdkVersions();
+
+    @NonNull
+    JdkVersion getDefaultJdkVersion();
 }

--- a/starter-core/src/main/java/io/micronaut/starter/options/MicronautJdkVersionConfiguration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/options/MicronautJdkVersionConfiguration.java
@@ -13,17 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.cli.command;
+package io.micronaut.starter.options;
 
-import io.micronaut.starter.options.JdkVersion;
-import io.micronaut.starter.options.MicronautJdkVersionConfiguration;
+import jakarta.inject.Singleton;
+import java.util.Collections;
+import java.util.List;
 
-import java.util.ArrayList;
-import java.util.stream.Collectors;
+@Singleton
+public class MicronautJdkVersionConfiguration implements JdkVersionConfiguration {
+    public static final List<JdkVersion> SUPPORTED_JDKS = Collections.singletonList(JdkVersion.JDK_17);
 
-public class JdkVersionCandidates extends ArrayList<String> {
+    public static final JdkVersion DEFAULT_OPTION = JdkVersion.JDK_17;
 
-    public JdkVersionCandidates() {
-        super(MicronautJdkVersionConfiguration.SUPPORTED_JDKS.stream().map(JdkVersion::majorVersion).map(Object::toString).collect(Collectors.toList()));
+    @Override
+    public List<JdkVersion> getSupportedJdkVersions() {
+        return SUPPORTED_JDKS;
+    }
+
+    @Override
+    public JdkVersion getDefaultJdkVersion() {
+        return DEFAULT_OPTION;
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/BuildBuilder.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/BuildBuilder.groovy
@@ -81,7 +81,7 @@ class BuildBuilder implements ProjectFixture, ContextFixture {
         TestFramework testFramework = this.testFramework ?: language.defaults.test
         ApplicationType type = this.applicationType ?: ApplicationType.DEFAULT
         Project project = getProject()
-        JdkVersion jdkVersion = this.jdkVersion ?: JdkVersion.JDK_8
+        JdkVersion jdkVersion = this.jdkVersion ?: MicronautJdkVersionConfiguration.DEFAULT_OPTION
         Options options = new Options(language, testFramework, buildTool, jdkVersion)
         Features features = getFeatures(featureNames, options, type)
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/FeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/FeatureSpec.groovy
@@ -90,7 +90,7 @@ class FeatureSpec extends BeanContextSpec {
     }
 
     private static JdkVersion javaVersionForFeature(String feature) {
-        feature == 'azure-function' ? JdkVersion.JDK_8 : JdkVersion.JDK_11
+        MicronautJdkVersionConfiguration.DEFAULT_OPTION
     }
 
     private static ApplicationType applicationTypeForFeature(Feature feature) {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/ArmSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/architecture/ArmSpec.groovy
@@ -10,6 +10,7 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Subject
@@ -42,7 +43,7 @@ class ArmSpec extends ApplicationContextSpec implements CommandOutputFixture {
     void 'arm plus cdk feature sets lambda function architecture'() {
         when:
 
-        Map<String, String> output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+        Map<String, String> output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [Cdk.NAME, AwsLambda.FEATURE_NAME_AWS_LAMBDA, Arm.NAME])
 
         then:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/awslambdacustomruntime/AwsLambdaCustomRuntimeSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/awslambdacustomruntime/AwsLambdaCustomRuntimeSpec.groovy
@@ -35,7 +35,7 @@ class AwsLambdaCustomRuntimeSpec extends ApplicationContextSpec  implements Comm
         when:
         def output = generate(
                 ApplicationType.DEFAULT,
-                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 ['aws-lambda-custom-runtime', 'graalvm']
         )
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
@@ -9,6 +9,7 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.util.VersionInfo
@@ -176,7 +177,7 @@ class MavenSpec extends ApplicationContextSpec implements CommandOutputFixture {
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .features(chosenFeatures)
                 .language(Language.JAVA)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .render()
         then:
         template.contains("<micronaut.runtime>${runtime}</micronaut.runtime>")

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/ci/workflows/aws/AWSWorkflowCISpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/ci/workflows/aws/AWSWorkflowCISpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Unroll
@@ -15,7 +16,7 @@ class AWSWorkflowCISpec extends BeanContextSpec implements CommandOutputFixture 
     void 'test aws-workflow-ci wrapper validation and upload is created for Gradle'() {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.DEFAULT_OPTION),
+                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [AWSCiWorkflowFeature.NAME])
         def workflow = output["buildspec.yml"]
 
@@ -29,7 +30,7 @@ class AWSWorkflowCISpec extends BeanContextSpec implements CommandOutputFixture 
     void 'test gcp-workflow-ci wrapper validation and upload is created for Maven'() {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.MAVEN, JdkVersion.DEFAULT_OPTION),
+                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [AWSCiWorkflowFeature.NAME])
         def workflow = output["buildspec.yml"]
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/ci/workflows/gcp/GoogleCloudWorkflowCISpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/ci/workflows/gcp/GoogleCloudWorkflowCISpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Unroll
@@ -15,7 +16,7 @@ class GoogleCloudWorkflowCISpec extends BeanContextSpec implements CommandOutput
     void 'test gcp-workflow-ci wrapper validation and upload is created for Gradle'() {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.DEFAULT_OPTION),
+                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [GoogleCloudCiWorkflowFeature.NAME])
         def workflow = output["cloudbuild.yaml"]
 
@@ -29,7 +30,7 @@ class GoogleCloudWorkflowCISpec extends BeanContextSpec implements CommandOutput
     void 'test gcp-workflow-ci wrapper validation and upload is created for Maven'() {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.MAVEN, JdkVersion.DEFAULT_OPTION),
+                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [GoogleCloudCiWorkflowFeature.NAME])
         def workflow = output["cloudbuild.yaml"]
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/ci/workflows/github/GithubWorkflowCISpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/ci/workflows/github/GithubWorkflowCISpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Unroll
@@ -14,10 +15,10 @@ class GithubWorkflowCISpec extends BeanContextSpec implements CommandOutputFixtu
     @Unroll
     void 'test github-workflow-ci is created for #buildTool and #jdkVersion'(BuildTool buildTool, int jdkVersion, String workflowName) {
         when:
-        def output = generate(ApplicationType.DEFAULT,
+        Map<String, String> output = generate(ApplicationType.DEFAULT,
                 new Options(Language.JAVA, TestFramework.JUNIT, buildTool, JdkVersion.valueOf(jdkVersion)),
                 [GithubCiWorkflowFeature.NAME])
-        def workflow = output[".github/workflows/${workflowName}"]
+        String workflow = output[".github/workflows/${workflowName}"]
 
         then:
         workflow
@@ -28,14 +29,8 @@ class GithubWorkflowCISpec extends BeanContextSpec implements CommandOutputFixtu
 
         where:
         buildTool               | jdkVersion | workflowName
-        BuildTool.GRADLE        | 8          | "gradle.yml"
-        BuildTool.GRADLE        | 11         | "gradle.yml"
         BuildTool.GRADLE        | 17         | "gradle.yml"
-        BuildTool.GRADLE_KOTLIN | 8          | "gradle.yml"
-        BuildTool.GRADLE_KOTLIN | 11         | "gradle.yml"
         BuildTool.GRADLE_KOTLIN | 17         | "gradle.yml"
-        BuildTool.MAVEN         | 8          | "maven.yml"
-        BuildTool.MAVEN         | 11         | "maven.yml"
         BuildTool.MAVEN         | 17         | "maven.yml"
     }
 
@@ -43,7 +38,7 @@ class GithubWorkflowCISpec extends BeanContextSpec implements CommandOutputFixtu
     void 'test github-workflow-ci wrapper validation and upload is created for #buildTool'(BuildTool buildTool) {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, JdkVersion.DEFAULT_OPTION),
+                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [GithubCiWorkflowFeature.NAME])
         def workflow = output[".github/workflows/gradle.yml"]
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/ci/workflows/oci/OCIWorkflowCISpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/ci/workflows/oci/OCIWorkflowCISpec.groovy
@@ -7,6 +7,7 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Unroll
@@ -17,7 +18,7 @@ class OCIWorkflowCISpec extends BeanContextSpec implements CommandOutputFixture 
     void 'test oci-devops-build-ci is created for #buildTool and #jdkVersion'(BuildTool buildTool, JdkVersion jdkVersion) {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, JdkVersion.valueOf(jdkVersion.majorVersion())),
+                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, jdkVersion),
                 [OCICiWorkflowFeature.NAME])
         def workflow = output["build_spec.yml"]
 
@@ -49,7 +50,7 @@ class OCIWorkflowCISpec extends BeanContextSpec implements CommandOutputFixture 
         workflow.contains("location: foo")
 
         where:
-        [buildTool, jdkVersion] << [BuildTool.values(), JdkVersion.values()].combinations()
+        [buildTool, jdkVersion] << [BuildTool.values(), MicronautJdkVersionConfiguration.SUPPORTED_JDKS].combinations()
     }
 
     @Unroll
@@ -89,6 +90,6 @@ class OCIWorkflowCISpec extends BeanContextSpec implements CommandOutputFixture 
         workflow.contains("location: foo")
 
         where:
-        [buildTool, jdkVersion] << [BuildTool.values(), JdkVersion.values()].combinations()
+        [buildTool, jdkVersion] << [BuildTool.values(), MicronautJdkVersionConfiguration.SUPPORTED_JDKS].combinations()
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataHibernateReactiveSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/DataHibernateReactiveSpec.groovy
@@ -14,6 +14,7 @@ import io.micronaut.starter.feature.testresources.DbType
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import spock.lang.Issue
 import spock.lang.Requires
 
@@ -76,7 +77,7 @@ class DataHibernateReactiveSpec extends BaseHibernateReactiveSpec {
 
         when:
         new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .features([DataHibernateReactive.NAME, MySQL.NAME])
                 .render()
 
@@ -96,7 +97,7 @@ class DataHibernateReactiveSpec extends BaseHibernateReactiveSpec {
     void "test dependencies are present for gradle with #db (#client)"() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .features([DataHibernateReactive.NAME, db])
                 .render()
 
@@ -131,7 +132,7 @@ class DataHibernateReactiveSpec extends BaseHibernateReactiveSpec {
     void "test dependencies are present for gradle with #db (#client) and #migration"() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .features([DataHibernateReactive.NAME, db, migration])
                 .render()
 
@@ -173,7 +174,7 @@ class DataHibernateReactiveSpec extends BaseHibernateReactiveSpec {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
                 .features([DataHibernateReactive.NAME, MySQL.NAME])
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .language(Language.KOTLIN)
                 .render()
 
@@ -185,7 +186,7 @@ class DataHibernateReactiveSpec extends BaseHibernateReactiveSpec {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .features([DataHibernateReactive.NAME, db])
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .render()
         BuildTestVerifier verifier = BuildTestUtil.verifier(BuildTool.MAVEN, template)
 
@@ -225,7 +226,7 @@ class DataHibernateReactiveSpec extends BaseHibernateReactiveSpec {
         BuildTool buildTool = BuildTool.MAVEN
         String template = new BuildBuilder(beanContext, buildTool)
                 .features([DataHibernateReactive.NAME, db, migration])
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .render()
         BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
 
@@ -270,7 +271,7 @@ class DataHibernateReactiveSpec extends BaseHibernateReactiveSpec {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .features([DataHibernateReactive.NAME, MySQL.NAME])
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .language(Language.KOTLIN)
                 .render()
         def xml = new XmlSlurper().parseText(template)
@@ -346,7 +347,7 @@ class DataHibernateReactiveSpec extends BaseHibernateReactiveSpec {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .language(Language.GROOVY)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .features([DataHibernateReactive.NAME, MySQL.NAME])
                 .render()
         BuildTestVerifier verifier = BuildTestUtil.verifier(BuildTool.MAVEN, template)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateReactiveJpaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/HibernateReactiveJpaSpec.groovy
@@ -12,6 +12,7 @@ import io.micronaut.starter.feature.testresources.DbType
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import spock.lang.Requires
 
 @Requires({ jvm.current.isJava11Compatible() })
@@ -72,7 +73,7 @@ class HibernateReactiveJpaSpec extends BaseHibernateReactiveSpec {
 
         when:
         new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .features([DataHibernateReactive.NAME, MySQL.NAME])
                 .render()
 
@@ -93,7 +94,7 @@ class HibernateReactiveJpaSpec extends BaseHibernateReactiveSpec {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
                 .features([HibernateReactiveJpa.NAME, db])
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .render()
 
         then:
@@ -128,7 +129,7 @@ class HibernateReactiveJpaSpec extends BaseHibernateReactiveSpec {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
                 .features([HibernateReactiveJpa.NAME, db, migration])
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .render()
 
         then:
@@ -168,7 +169,7 @@ class HibernateReactiveJpaSpec extends BaseHibernateReactiveSpec {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
                 .features([HibernateReactiveJpa.NAME, MySQL.NAME])
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .language(Language.KOTLIN)
                 .render()
 
@@ -180,7 +181,7 @@ class HibernateReactiveJpaSpec extends BaseHibernateReactiveSpec {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .features([HibernateReactiveJpa.NAME, db])
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .render()
         BuildTestVerifier verifier = BuildTestUtil.verifier(BuildTool.MAVEN, template)
 
@@ -221,7 +222,7 @@ class HibernateReactiveJpaSpec extends BaseHibernateReactiveSpec {
         BuildTool buildTool = BuildTool.MAVEN
         String template = new BuildBuilder(beanContext, buildTool)
                 .features([HibernateReactiveJpa.NAME, db, migration])
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .render()
         BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
 
@@ -267,7 +268,7 @@ class HibernateReactiveJpaSpec extends BaseHibernateReactiveSpec {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .features([HibernateReactiveJpa.NAME, MySQL.NAME])
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .language(Language.KOTLIN)
                 .render()
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/JooqSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/JooqSpec.groovy
@@ -7,13 +7,14 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.Options
 
 class JooqSpec extends ApplicationContextSpec  implements CommandOutputFixture {
 
     void 'test readme.md with feature jooq contains links to micronaut docs'() {
         when:
-        def output = generate(ApplicationType.DEFAULT, new Options().withJavaVersion(JdkVersion.JDK_11), ['jooq'])
+        def output = generate(ApplicationType.DEFAULT, new Options().withJavaVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION), ['jooq'])
         def readme = output["README.md"]
 
         then:
@@ -26,7 +27,7 @@ class JooqSpec extends ApplicationContextSpec  implements CommandOutputFixture {
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
                 .features(['jooq'])
                 .language(language)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .render()
 
         then:
@@ -41,7 +42,7 @@ class JooqSpec extends ApplicationContextSpec  implements CommandOutputFixture {
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .features(['jooq'])
                 .language(language)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .render()
 
         then:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/TestContainersSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/TestContainersSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.starter.feature.Features
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.TestFramework
 
 import java.util.stream.Collectors
@@ -385,12 +386,12 @@ class TestContainersSpec extends ApplicationContextSpec {
     void "test there is a dependency for every non embedded driver feature"() {
         when:
         String mavenTemplate = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .features([TestContainers.NAME, driverFeature.getName()])
                 .render()
 
         String gradleTemplate = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .features([TestContainers.NAME, driverFeature.getName()])
                 .render()
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/awslambda/AwsLambdaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/awslambda/AwsLambdaSpec.groovy
@@ -12,6 +12,7 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Shared
@@ -366,7 +367,7 @@ tasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>("dockerfileNative"
         when:
         def output = generate(
                 ApplicationType.DEFAULT,
-                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 ['aws-lambda', 'graalvm']
         )
 
@@ -383,7 +384,7 @@ tasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>("dockerfileNative"
         when:
         def output = generate(
                 ApplicationType.DEFAULT,
-                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 ['aws-lambda', 'aws-lambda-custom-runtime']
         )
 
@@ -463,7 +464,7 @@ tasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>("dockerfileNative"
         when:
         def output = generate(
                 applicationType,
-                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 ['aws-lambda', 'graalvm']
         )
         String build = output['build.gradle']
@@ -510,7 +511,7 @@ tasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>("dockerfileNative"
         when:
         def output = generate(
                 ApplicationType.DEFAULT,
-                new Options(language, TestFramework.JUNIT, BuildTool.MAVEN, JdkVersion.JDK_11),
+                new Options(language, TestFramework.JUNIT, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 ['aws-lambda', 'graalvm']
         )
         String build = output['pom.xml']

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
@@ -8,6 +8,7 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Unroll
@@ -28,7 +29,7 @@ class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOu
         where:
         [applicationType, jdkVersion, feature] << [
                 [ApplicationType.FUNCTION, ApplicationType.DEFAULT],
-                JdkVersion.values(),
+                MicronautJdkVersionConfiguration.SUPPORTED_JDKS,
                 ['azure-function']
         ].combinations()
     }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/gcp/GoogleCloudFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/gcp/GoogleCloudFunctionSpec.groovy
@@ -26,7 +26,7 @@ class GoogleCloudFunctionSpec extends BeanContextSpec  implements CommandOutputF
         when:
         def output = generate(
                 ApplicationType.DEFAULT,
-                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 ['google-cloud-function']
         )
         def readme = output["README.md"]
@@ -79,7 +79,7 @@ class GoogleCloudFunctionSpec extends BeanContextSpec  implements CommandOutputF
         when:
         def output = generate(
                 ApplicationType.DEFAULT,
-                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 ['google-cloud-function']
         )
         def readme = output["README.md"]
@@ -121,7 +121,7 @@ class GoogleCloudFunctionSpec extends BeanContextSpec  implements CommandOutputF
         String build = new BuildBuilder(beanContext, buildTool)
                 .features(['google-cloud-function'])
                 .testFramework(TestFramework.JUNIT)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .render()
 
         BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, build)
@@ -186,7 +186,7 @@ class GoogleCloudFunctionSpec extends BeanContextSpec  implements CommandOutputF
         when:
         generate(
                 ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 ['google-cloud-function',serialization]
         )
 
@@ -202,7 +202,7 @@ class GoogleCloudFunctionSpec extends BeanContextSpec  implements CommandOutputF
         when:
         generate(
             ApplicationType.DEFAULT,
-            new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+            new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
             ['google-cloud-function','graalvm']
         )
 
@@ -218,7 +218,7 @@ class GoogleCloudFunctionSpec extends BeanContextSpec  implements CommandOutputF
                 .applicationType(ApplicationType.DEFAULT)
                 .features(['google-cloud-function'])
                 .language(language)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .render()
         BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
 
@@ -244,7 +244,7 @@ class GoogleCloudFunctionSpec extends BeanContextSpec  implements CommandOutputF
                 .applicationType(ApplicationType.FUNCTION)
                 .features(['google-cloud-function'])
                 .language(language)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .render()
         BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/oraclefunction/OracleFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/oraclefunction/OracleFunctionSpec.groovy
@@ -39,7 +39,7 @@ class OracleFunctionSpec extends BeanContextSpec  implements CommandOutputFixtur
         when:
         def output = generate(
                 ApplicationType.DEFAULT,
-                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 ['oracle-function'] + (useSerde ? ['serialization-jackson'] : [])
         )
         def readme = output["README.md"]
@@ -67,7 +67,7 @@ class OracleFunctionSpec extends BeanContextSpec  implements CommandOutputFixtur
         String build = new BuildBuilder(beanContext, BuildTool.GRADLE)
                 .features(['oracle-function'])
                 .testFramework(TestFramework.JUNIT)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .render()
 
         then:
@@ -81,7 +81,7 @@ class OracleFunctionSpec extends BeanContextSpec  implements CommandOutputFixtur
         when:
         def output = generate(
                 ApplicationType.DEFAULT,
-                new Options(language, TestFramework.JUNIT, BuildTool.MAVEN, JdkVersion.JDK_11),
+                new Options(language, TestFramework.JUNIT, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 ['oracle-function'] + (useSerde ? ['serialization-jackson'] : [])
         )
         String build = output['pom.xml']
@@ -111,7 +111,7 @@ class OracleFunctionSpec extends BeanContextSpec  implements CommandOutputFixtur
         when:
         def output = generate(
                 ApplicationType.FUNCTION,
-                new Options(language, TestFramework.JUNIT, BuildTool.MAVEN, JdkVersion.JDK_11),
+                new Options(language, TestFramework.JUNIT, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 ['oracle-function'] + (useSerde ? ['serialization-jackson'] : [])
         )
         String build = output['pom.xml']

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/azure/AzureContainerInstanceWorkflowSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/azure/AzureContainerInstanceWorkflowSpec.groovy
@@ -33,7 +33,7 @@ class AzureContainerInstanceWorkflowSpec extends BeanContextSpec implements Comm
     void 'test java github workflow is created for #buildTool'(BuildTool buildTool) {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [AzureContainerInstanceJavaWorkflow.NAME])
         def workflow = output[".github/workflows/azure-container-instance.yml"]
 
@@ -87,8 +87,6 @@ class AzureContainerInstanceWorkflowSpec extends BeanContextSpec implements Comm
 
         where:
         jdkVersion | graalVersion
-        JdkVersion.JDK_8  | JdkVersion.JDK_8
-        JdkVersion.JDK_11 | JdkVersion.JDK_11
         JdkVersion.JDK_17 | JdkVersion.JDK_17
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/docker/DockerRegistryWorkflowSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/docker/DockerRegistryWorkflowSpec.groovy
@@ -31,7 +31,7 @@ Add the following GitHub secrets:
     void 'test github workflow is created for #buildTool'(BuildTool buildTool, String workflowName) {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [DockerRegistryWorkflow.NAME])
         def workflow = output[".github/workflows/${workflowName}"]
 
@@ -48,7 +48,7 @@ Add the following GitHub secrets:
     void 'test push to docker workflow for maven'() {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.MAVEN, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [DockerRegistryWorkflow.NAME])
         def maven = output['.github/workflows/maven.yml']
 
@@ -83,6 +83,6 @@ Add the following GitHub secrets:
         workflow.contains("java-version: ${version.majorVersion()}")
 
         where:
-        version << JdkVersion.values()
+        version << MicronautJdkVersionConfiguration.SUPPORTED_JDKS
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/docker/GraalVMDockerRegistryWorkflowSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/docker/GraalVMDockerRegistryWorkflowSpec.groovy
@@ -34,7 +34,7 @@ Add the following GitHub secrets:
     void 'test github workflow is created for #buildTool'(BuildTool buildTool) {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [GraalVMDockerRegistryWorkflow.NAME])
         def workflow = output[".github/workflows/graalvm.yml"]
 
@@ -61,7 +61,7 @@ Add the following GitHub secrets:
     void 'test push to docker workflow for maven'() {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.MAVEN, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [GraalVMDockerRegistryWorkflow.NAME])
         def maven = output['.github/workflows/graalvm.yml']
 
@@ -89,7 +89,6 @@ Add the following GitHub secrets:
 
         where:
         jdkVersion        | graalVersion
-        JdkVersion.JDK_8  | JdkVersion.JDK_8
-        JdkVersion.JDK_11 | JdkVersion.JDK_11
+        JdkVersion.JDK_17 | JdkVersion.JDK_17
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/gcloud/GoogleCloudRunWorkflowSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/gcloud/GoogleCloudRunWorkflowSpec.groovy
@@ -24,7 +24,7 @@ class GoogleCloudRunWorkflowSpec extends BeanContextSpec implements CommandOutpu
     void 'test graalvm github workflow is created for #buildTool'(BuildTool buildTool) {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [GoogleCloudRunGraalWorkflow.NAME])
         def workflow = output[".github/workflows/google-cloud-run-graalvm.yml"]
 
@@ -40,7 +40,7 @@ class GoogleCloudRunWorkflowSpec extends BeanContextSpec implements CommandOutpu
     void 'test github workflow is created for #buildTool'(BuildTool buildTool) {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [GoogleCloudRunJavaWorkflow.NAME])
         println(output)
         def workflow = output[".github/workflows/google-cloud-run.yml"]
@@ -90,8 +90,6 @@ class GoogleCloudRunWorkflowSpec extends BeanContextSpec implements CommandOutpu
 
         where:
         jdkVersion | graalVersion
-        JdkVersion.JDK_8  | JdkVersion.JDK_8
-        JdkVersion.JDK_11 | JdkVersion.JDK_11
         JdkVersion.JDK_17 | JdkVersion.JDK_17
     }
 
@@ -110,7 +108,7 @@ class GoogleCloudRunWorkflowSpec extends BeanContextSpec implements CommandOutpu
         where:
         [buildTool, jdkVersion] << [
                 [BuildTool.GRADLE, BuildTool.MAVEN],
-                JdkVersion.values()
+                MicronautJdkVersionConfiguration.SUPPORTED_JDKS
         ].combinations()
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/oci/OracleFunctionsWorkflowSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/oci/OracleFunctionsWorkflowSpec.groovy
@@ -48,7 +48,7 @@ class OracleFunctionsWorkflowSpec extends BeanContextSpec implements CommandOutp
         where:
         [buildTool, jdkVersion] << [
                 [BuildTool.GRADLE, BuildTool.MAVEN],
-                JdkVersion.values()
+                MicronautJdkVersionConfiguration.SUPPORTED_JDKS
         ].combinations()
     }
 
@@ -56,7 +56,7 @@ class OracleFunctionsWorkflowSpec extends BeanContextSpec implements CommandOutp
     void 'test github graalvm workflow is created for #buildTool'(BuildTool buildTool) {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.JUNIT, buildTool, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [OracleFunctionsGraalWorkflow.NAME])
         def workflow = output[".github/workflows/oracle-cloud-functions-graalvm.yml"]
 
@@ -73,7 +73,7 @@ class OracleFunctionsWorkflowSpec extends BeanContextSpec implements CommandOutp
     void 'test http function pom.xml configuration for #feature'(String feature) {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.MAVEN, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [OracleFunctionsJavaWorkflow.NAME])
         def pom = output["pom.xml"]
 
@@ -98,7 +98,7 @@ class OracleFunctionsWorkflowSpec extends BeanContextSpec implements CommandOutp
     void 'test graalvm http function pom.xml configuration'() {
         when:
         def output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.MAVEN, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [OracleFunctionsGraalWorkflow.NAME])
         def pom = output["pom.xml"]
 
@@ -158,7 +158,6 @@ class OracleFunctionsWorkflowSpec extends BeanContextSpec implements CommandOutp
 
         where:
         jdkVersion        | graalVersion
-        JdkVersion.JDK_8  | JdkVersion.JDK_8
-        JdkVersion.JDK_11 | JdkVersion.JDK_11
+        JdkVersion.JDK_17 | JdkVersion.JDK_17
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/graalvm/GraalVMSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/graalvm/GraalVMSpec.groovy
@@ -119,7 +119,7 @@ class GraalVMSpec extends ApplicationContextSpec implements CommandOutputFixture
         when:
         def output = generate(
                 ApplicationType.DEFAULT,
-                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, JdkVersion.JDK_11),
+                new Options(language, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 ['graalvm', 'aws-lambda']
         )
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/oracecloud/OracleCloudAutonomousDatabaseSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/oracecloud/OracleCloudAutonomousDatabaseSpec.groovy
@@ -8,6 +8,7 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import spock.lang.Issue
@@ -19,7 +20,7 @@ class OracleCloudAutonomousDatabaseSpec extends ApplicationContextSpec implement
     void 'test ATP feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .features(['oracle-cloud-atp'])
                 .language(language)
                 .render()
@@ -34,7 +35,7 @@ class OracleCloudAutonomousDatabaseSpec extends ApplicationContextSpec implement
     void 'test ATP feature for maven and language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .features(['oracle-cloud-atp'])
                 .language(language)
                 .render()
@@ -54,7 +55,7 @@ class OracleCloudAutonomousDatabaseSpec extends ApplicationContextSpec implement
     void 'test ATP config file'() {
         when:
         Map<String, String> output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.SPOCK, BuildTool.MAVEN, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.SPOCK, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [Yaml.NAME, 'oracle-cloud-atp'])
         String config = output["src/main/resources/application.yml"]
 
@@ -73,7 +74,7 @@ class OracleCloudAutonomousDatabaseSpec extends ApplicationContextSpec implement
     void 'test ATP config file no jdbc config'() {
         when:
         Map<String, String> output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.SPOCK, BuildTool.GRADLE, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.SPOCK, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [Yaml.NAME, 'jdbc-hikari', 'oracle-cloud-atp'])
         String config = output["src/main/resources/application.yml"]
 
@@ -85,7 +86,7 @@ class OracleCloudAutonomousDatabaseSpec extends ApplicationContextSpec implement
     void 'test default database driver not present in config'() {
         when:
         Map<String, String> output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.SPOCK, BuildTool.MAVEN, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.SPOCK, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [Yaml.NAME, 'oracle-cloud-atp', "data-jdbc"])
         String config = output["src/main/resources/application.yml"]
 
@@ -96,7 +97,7 @@ class OracleCloudAutonomousDatabaseSpec extends ApplicationContextSpec implement
     void 'test config with a driver config feature'() {
         when:
         Map<String, String> output = generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.SPOCK, BuildTool.MAVEN, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.SPOCK, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [Yaml.NAME, 'oracle-cloud-atp', "data-jdbc"])
         String config = output["src/main/resources/application.yml"]
 
@@ -128,7 +129,7 @@ class OracleCloudAutonomousDatabaseSpec extends ApplicationContextSpec implement
 
         when:
         generate(ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.SPOCK, BuildTool.MAVEN, JdkVersion.JDK_11),
+                new Options(Language.JAVA, TestFramework.SPOCK, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 ['oracle-cloud-atp'])
         then:
         noExceptionThrown()

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/MockkSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/MockkSpec.groovy
@@ -10,6 +10,7 @@ import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.util.VersionInfo
@@ -24,7 +25,7 @@ class MockkSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void 'test readme.md with feature mockk contains links to 3rd party docs'() {
         when:
-        Options options = new Options(Language.KOTLIN, TestFramework.JUNIT, BuildTool.MAVEN, JdkVersion.JDK_11, Collections.emptyMap())
+        Options options = new Options(Language.KOTLIN, TestFramework.JUNIT, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION, Collections.emptyMap())
         Map<String, String> output = generate(ApplicationType.DEFAULT, options, ['mockk'])
         String readme = output["README.md"]
 
@@ -53,7 +54,7 @@ class MockkSpec extends ApplicationContextSpec implements CommandOutputFixture {
     void 'test mockk feature is added automatically for Maven and Kotest for language=#language'(Language language) {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .jdkVersion(JdkVersion.JDK_11)
+                .jdkVersion(MicronautJdkVersionConfiguration.DEFAULT_OPTION)
                 .language(language)
                 .features([])
                 .testFramework(TestFramework.KOTEST)

--- a/starter-core/src/test/groovy/io/micronaut/starter/options/JdkVersionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/options/JdkVersionSpec.groovy
@@ -15,7 +15,7 @@ class JdkVersionSpec extends Specification {
 
         then:
         IllegalArgumentException ex = thrown()
-        ex.message == "Unsupported JDK version: 3. Supported values are [8, 11, 17]"
+        ex.message.startsWith("Unsupported JDK version: 3. Supported values are ")
     }
 
     void "greaterThanOrEqual"() {

--- a/starter-web-netty/src/test/groovy/io/micronaut/starter/netty/SelectOptionsTest.groovy
+++ b/starter-web-netty/src/test/groovy/io/micronaut/starter/netty/SelectOptionsTest.groovy
@@ -9,6 +9,7 @@ import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -52,12 +53,12 @@ class SelectOptionsTest extends Specification {
 
         then: "We get all the jdk version options"
         def jdkVersionOpts = selectOptions.jdkVersion.options
-        jdkVersionOpts.size() == JdkVersion.values().size()
+        jdkVersionOpts.size() == MicronautJdkVersionConfiguration.SUPPORTED_JDKS.size()
 
         then: "We get the correct JdkVersion default"
-        selectOptions.jdkVersion.defaultOption.value == JdkVersion.DEFAULT_OPTION
+        selectOptions.jdkVersion.defaultOption.value == MicronautJdkVersionConfiguration.DEFAULT_OPTION
 
-        JdkVersion.values().each { jdkVer ->
+        MicronautJdkVersionConfiguration.SUPPORTED_JDKS.each { jdkVer ->
             then: "We can find the ${jdkVer.name()} jdk version"
             jdkVersionOpts.find {so -> jdkVer == so.value} != null
         }


### PR DESCRIPTION
We are using the `JdkVersion` to map into a database entity for `starter-analytics`. Thus, we should not delete items from the enum if we want to keep using it for analytics mapping since the database contains entries such as JDK_11 

This PR sets `JdkVersion` as a representation of Java releases. It creates an API , `JdkVersionConfiguration` to manage which versions are supported. This allows downstream consumers of the API, such as grails, to support different JDKs. 

