### PR TITLE
Deploy native image to cloudrun

### DIFF
--- a/.github/workflows/gcr-snapshot.yml
+++ b/.github/workflows/gcr-snapshot.yml
@@ -24,7 +24,7 @@ jobs:
           PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
       - name: Build Docker image
         run: |
-          ./gradlew starter-web-netty:dockerBuild -PdockerImageName="gcr.io/${{ secrets.GCLOUD_PROJECT }}/${{ secrets.GCLOUD_SNAPSHOT_APP_NAME }}:snapshot"
+          ./gradlew starter-web-netty:dockerBuildNative -PdockerImageName="gcr.io/${{ secrets.GCLOUD_PROJECT }}/${{ secrets.GCLOUD_SNAPSHOT_APP_NAME }}:snapshot"
       - name: Authenticate into Google Cloud Platform
         uses: google-github-actions/setup-gcloud@v0.2.1
         with:
@@ -34,7 +34,7 @@ jobs:
         run: "gcloud auth configure-docker --quiet"
       - name: Push image to Google Cloud Container Registry
         run: |
-          ./gradlew starter-web-netty:dockerPush -PdockerImageName="gcr.io/${{ secrets.GCLOUD_PROJECT }}/${{ secrets.GCLOUD_SNAPSHOT_APP_NAME }}:snapshot"
+          ./gradlew starter-web-netty:dockerPushNative -PdockerImageName="gcr.io/${{ secrets.GCLOUD_PROJECT }}/${{ secrets.GCLOUD_SNAPSHOT_APP_NAME }}:snapshot"
       - name: Deploy to Cloud Run
         run: |
           gcloud components install beta --quiet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
       - name: Build Docker image
         run: |
-          ./gradlew starter-web-netty:dockerBuild -PdockerImageName="gcr.io/${{ secrets.GCLOUD_PROJECT }}/micronaut-starter:${{ steps.release_version.outputs.release_version }}"
+          ./gradlew starter-web-netty:dockerBuildNative -PdockerImageName="gcr.io/${{ secrets.GCLOUD_PROJECT }}/micronaut-starter:${{ steps.release_version.outputs.release_version }}"
       - name: Authenticate into Google Cloud Platform
         uses: google-github-actions/setup-gcloud@v0.2.1
         with:
@@ -301,7 +301,7 @@ jobs:
         run: "gcloud auth configure-docker --quiet"
       - name: Push image to Google Cloud Container Registry
         run: |
-          ./gradlew starter-web-netty:dockerPush -PdockerImageName="gcr.io/${{ secrets.GCLOUD_PROJECT }}/micronaut-starter:${{ steps.release_version.outputs.release_version }}"
+          ./gradlew starter-web-netty:dockerPushNative -PdockerImageName="gcr.io/${{ secrets.GCLOUD_PROJECT }}/micronaut-starter:${{ steps.release_version.outputs.release_version }}"
       - name: Deploy to Cloud Run
         env:
           release_version: ${{ steps.release_version.outputs.release_version }}

--- a/starter-web-netty/build.gradle
+++ b/starter-web-netty/build.gradle
@@ -22,10 +22,12 @@ dependencies {
 application {
     mainClass = "io.micronaut.starter.netty.Application"
 }
-
+tasks.named('dockerfileNative') {
+    // https://www.graalvm.org/latest/docs/getting-started/container-images/
+    baseImage("ghcr.io/graalvm/jdk:ol8-java17-22.3.2")
+}
 
 tasks.named("dockerBuildNative") {
-    
     images = [project.hasProperty("dockerImageName") ? project.getProperty("dockerImageName") : "micronaut-starter"]
 }
 


### PR DESCRIPTION
We had to change to `dockerBuild` instead of `dockerBuildNative` because the ZIP file was corrupt. 

We faced this already in https://github.com/micronaut-projects/micronaut-starter/issues/1270 and fixed it via https://github.com/micronaut-projects/micronaut-starter/pull/1271

I removed the fix, the snippet : 

```
tasks.named('dockerfileNative') {
    baseImage("ghcr.io/graalvm/native-image:ol7-java11-22.1.0")
}
```

because it was using a java11 image.  

## Steps to reproduce

Clone this PR branch

Run `./gradlew :starter-web-netty:dockerBuildNative `

Run the docker via `docker run -p 8080:8080  micronaut-starter:latest`

in a different terminal, download a zip file: 

```
 curl localhost:8080/test.zip -O -J
```

```
unzip test.zip                    
Archive:  test.zip
  inflating: test/micronaut-cli.yml   bad CRC d7933ffd  (should be 0b0e88f6)
  inflating: test/src/main/resources/logback.xml  
  inflating: test/src/main/java/test/Application.java  
  inflating: test/src/test/java/test/TestTest.java   bad CRC eead523a  (should be 2c8c7beb)
  inflating: test/gradle/wrapper/gradle-wrapper.jar  
  inflating: test/gradle/wrapper/gradle-wrapper.properties  
  inflating: test/gradlew            
  inflating: test/gradlew.bat        
  inflating: test/build.gradle        bad CRC abb91d90  (should be 6f21756c)
  inflating: test/.gitignore         
  inflating: test/gradle.properties   bad CRC bf827ece  (should be 899b0fab)
  inflating: test/settings.gradle     bad CRC 1f803243  (should be 1f3e14ae)
  inflating: test/README.md           bad CRC e8156e4b  (should be 5d2d4f9a)
```

We should something without `bad CRC`. eg.: 


```
unzip demo-294.zip 
Archive:  demo-294.zip
  inflating: demo/micronaut-cli.yml  
  inflating: demo/src/main/resources/logback.xml  
  inflating: demo/src/main/java/com/example/Application.java  
  inflating: demo/src/test/java/com/example/DemoTest.java  
  inflating: demo/gradle/wrapper/gradle-wrapper.jar  
  inflating: demo/gradle/wrapper/gradle-wrapper.properties  
  inflating: demo/gradlew            
  inflating: demo/gradlew.bat        
  inflating: demo/build.gradle       
  inflating: demo/.gitignore         
  inflating: demo/gradle.properties  
  inflating: demo/settings.gradle    
  inflating: demo/README.md          
  inflating: demo/src/main/resources/application.properties  
```