### PR TITLE
Fix generated Azure projects in starter [skip ci]

### DIFF
--- a/starter-azure-function/src/test/groovy/io/micronaut/starter/azure/FunctionSpec.groovy
+++ b/starter-azure-function/src/test/groovy/io/micronaut/starter/azure/FunctionSpec.groovy
@@ -2,8 +2,6 @@ package io.micronaut.starter.azure
 
 import com.microsoft.azure.functions.HttpResponseMessage
 import io.micronaut.azure.function.http.AzureHttpFunction
-import io.micronaut.azure.function.http.AzureHttpResponseMessage
-import io.micronaut.azure.function.http.AzureHttpResponseMessageAdapter
 import io.micronaut.azure.function.http.DefaultExecutionContext
 import io.micronaut.azure.function.http.HttpRequestMessageBuilder
 import io.micronaut.http.HttpHeaders
@@ -19,7 +17,7 @@ class FunctionSpec extends Specification {
         Function function = new Function()
 
         when:
-        AzureHttpResponseMessage responseMessage = invoke(function, function.request(HttpMethod.GET, '/application-types/default/features'))
+        HttpResponseMessage responseMessage = invoke(function, function.request(HttpMethod.GET, '/application-types/default/features'))
 
         then:
         responseMessage.status.value() == HttpStatus.OK.code
@@ -30,7 +28,7 @@ class FunctionSpec extends Specification {
         Function function = new Function()
 
         when:
-        AzureHttpResponseMessage response = invoke(function, function.request(HttpMethod.GET, "/create/default/test"))
+        HttpResponseMessage response = invoke(function, function.request(HttpMethod.GET, "/create/default/test"))
 
         then:
         response.status.value() == HttpStatus.CREATED.code
@@ -38,11 +36,10 @@ class FunctionSpec extends Specification {
         ZipUtil.isZip(response.body as byte[])
     }
 
-    static AzureHttpResponseMessage invoke(AzureHttpFunction function, HttpRequestMessageBuilder<?> builder) {
-        HttpResponseMessage result = function.route(
+    static HttpResponseMessage invoke(AzureHttpFunction function, HttpRequestMessageBuilder<?> builder) {
+        function.route(
                 builder.buildEncoded(),
                 new DefaultExecutionContext()
         );
-        return new AzureHttpResponseMessageAdapter(result);
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
@@ -177,7 +177,7 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
         if (buildTool == BuildTool.MAVEN) {
             return "mvnw clean package azure-functions:run";
         } else {
-            return "gradlew clean azureFunctionsRun";
+            return "gradlew azureFunctionsRun";
         }
     }
 
@@ -186,7 +186,7 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
         if (buildTool == BuildTool.MAVEN) {
             return "mvnw clean package azure-functions:deploy";
         } else if (buildTool.isGradle()) {
-            return "gradlew clean azureFunctionsDeploy";
+            return "gradlew azureFunctionsDeploy";
         } else {
             throw new IllegalStateException("Unsupported build tool");
         }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
@@ -38,6 +38,8 @@ import jakarta.inject.Singleton;
 @Singleton
 public class AzureHttpFunction extends AbstractAzureFunction implements Feature {
 
+    public static final String NAME = "azure-function-http";
+
     private static final Dependency MICRONAUT_AZURE_FUNCTION_HTTP = MicronautDependencyUtils
             .azureDependency()
             .artifactId("micronaut-azure-function-http")
@@ -49,8 +51,6 @@ public class AzureHttpFunction extends AbstractAzureFunction implements Feature 
             .artifactId("micronaut-azure-function-http-test")
             .test()
             .build();
-
-    public static final String NAME = "azure-function-http";
 
     public AzureHttpFunction(CoordinateResolver coordinateResolver) {
         super(coordinateResolver);

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
@@ -50,6 +50,8 @@ public class AzureHttpFunction extends AbstractAzureFunction implements Feature 
             .test()
             .build();
 
+    public static final String NAME = "azure-function-http";
+
     public AzureHttpFunction(CoordinateResolver coordinateResolver) {
         super(coordinateResolver);
     }
@@ -57,7 +59,7 @@ public class AzureHttpFunction extends AbstractAzureFunction implements Feature 
     @NonNull
     @Override
     public String getName() {
-        return "azure-function-http";
+        return NAME;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionGroovyJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionGroovyJunit.rocker.raw
@@ -9,6 +9,7 @@ package @project.getPackageName();
 }
 
 import com.microsoft.azure.functions.HttpStatus
+import com.microsoft.azure.functions.HttpResponseMessage
 import io.micronaut.azure.function.http.HttpRequestMessageBuilder
 import io.micronaut.http.HttpMethod
 import org.junit.jupiter.api.Test
@@ -20,8 +21,7 @@ class @project.getClassName()FunctionTest {
     @@Test
     void testFunction() {
         new Function().withCloseable { Function function ->
-            HttpRequestMessageBuilder.AzureHttpResponseMessage response =
-                function.request(HttpMethod.GET, "/@project.getPropertyName()")
+            HttpResponseMessage response = function.request(HttpMethod.GET, "/@project.getPropertyName()")
                         .invoke()
             assertEquals(HttpStatus.OK, response.status)
         }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionJavaJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionJavaJunit.rocker.raw
@@ -9,7 +9,7 @@ package @project.getPackageName();
 }
 
 import com.microsoft.azure.functions.HttpStatus;
-import io.micronaut.azure.function.http.HttpRequestMessageBuilder;
+import com.microsoft.azure.functions.HttpResponseMessage;
 import io.micronaut.http.HttpMethod;
 import org.junit.jupiter.api.Test;
 
@@ -20,8 +20,7 @@ public class @project.getClassName()FunctionTest {
     @@Test
     public void testFunction() throws Exception {
         try (Function function = new Function()) {
-            HttpRequestMessageBuilder.AzureHttpResponseMessage response =
-                function.request(HttpMethod.GET, "/@project.getPropertyName()")
+            HttpResponseMessage response = function.request(HttpMethod.GET, "/@project.getPropertyName()")
                         .invoke();
 
             assertEquals(HttpStatus.OK, response.getStatus());

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionKoTest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionKoTest.rocker.raw
@@ -9,7 +9,6 @@ package @project.getPackageName()
 }
 
 import com.microsoft.azure.functions.HttpStatus
-import io.micronaut.azure.function.http.HttpRequestMessageBuilder
 import io.micronaut.http.HttpMethod
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionKotlinJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionKotlinJunit.rocker.raw
@@ -9,7 +9,6 @@ package @project.getPackageName();
 }
 
 import com.microsoft.azure.functions.HttpStatus
-import io.micronaut.azure.function.http.HttpRequestMessageBuilder
 import io.micronaut.http.HttpMethod
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionSpock.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionSpock.rocker.raw
@@ -9,7 +9,7 @@ package @project.getPackageName();
 }
 
 import com.microsoft.azure.functions.HttpStatus
-import io.micronaut.azure.function.http.HttpRequestMessageBuilder
+import com.microsoft.azure.functions.HttpResponseMessage
 import io.micronaut.http.HttpMethod
 import spock.lang.*
 
@@ -20,8 +20,7 @@ class @project.getClassName()FunctionSpec extends Specification {
 
     void "test function"() {
         when:"The function is executed"
-        HttpRequestMessageBuilder.AzureHttpResponseMessage response =
-            function.request(HttpMethod.GET, "/@project.getPropertyName()")
+        HttpResponseMessage response = function.request(HttpMethod.GET, "/@project.getPropertyName()")
                     .invoke()
 
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/json/SerializationFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/json/SerializationFeature.java
@@ -21,7 +21,6 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.feature.testresources.TestResources;
 import io.micronaut.starter.options.BuildTool;
 
 import java.util.ArrayList;

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
@@ -144,7 +144,7 @@ class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOu
         output.containsKey("$language.srcDir/example/micronaut/Function.$language.extension".toString())
         output.containsKey("$language.testSrcDir/example/micronaut/FooFunctionTest.$language.extension".toString())
         output.get("$language.testSrcDir/example/micronaut/FooFunctionTest.$language.extension".toString())
-                .contains("HttpRequestMessageBuilder")
+                .contains("response = function.request")
 
         where:
         [language, useSerde] << [Language.values().toList(), [true, false]].combinations()
@@ -178,7 +178,7 @@ class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOu
         output.containsKey("$language.srcDir/example/micronaut/Function.$language.extension".toString())
         output.containsKey("$language.testSrcDir/example/micronaut/FooFunctionTest.$language.extension".toString())
         output.get("$language.testSrcDir/example/micronaut/FooFunctionTest.$language.extension".toString())
-              .contains("HttpRequestMessageBuilder")
+              .contains("response = function.request")
 
         where:
         [language, useSerde] << [Language.values().toList(), [true, false]].combinations()

--- a/starter-gcp-function/build.gradle
+++ b/starter-gcp-function/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     testCompileOnly "io.micronaut:micronaut-inject-groovy"
     testImplementation("com.google.cloud.functions:functions-framework-api")
     testImplementation "io.micronaut.test:micronaut-test-spock"
+    testRuntimeOnly("io.micronaut.serde:micronaut-serde-jackson")
     invoker 'com.google.cloud.functions.invoker:java-function-invoker:1.3.0'
 }
 

--- a/starter-web-netty/build.gradle
+++ b/starter-web-netty/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     testCompileOnly "io.micronaut:micronaut-inject-groovy"
     testImplementation "io.micronaut.test:micronaut-test-spock"
     testImplementation "io.micronaut:micronaut-http-client"
+    testRuntimeOnly("io.micronaut.serde:micronaut-serde-jackson")
 }
 
 application {

--- a/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
+++ b/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.starter.core.test.cloud.azure
 
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.function.azure.AbstractAzureFunction
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
@@ -20,7 +21,7 @@ class CreateAzureFunctionSpec extends CommandSpec {
                                                                                                                 BuildTool build,
                                                                                                                 TestFramework testFramework) {
         given:
-        List<String> features = ['azure-function']
+        List<String> features = [AbstractAzureFunction.NAME]
         generateProject(lang, build, features, applicationType, testFramework)
 
         when:
@@ -40,7 +41,7 @@ class CreateAzureFunctionSpec extends CommandSpec {
             TestFramework testFramework
     ) {
         given:
-        List<String> features = ['azure-function'] + serializationFeature
+        List<String> features = [AbstractAzureFunction.NAME] + serializationFeature
         generateProject(lang, build, features, ApplicationType.DEFAULT, testFramework)
 
         when:

--- a/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
+++ b/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
@@ -7,12 +7,7 @@ import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.ApplicationTypeCombinations
 import io.micronaut.starter.test.BuildToolCombinations
 import io.micronaut.starter.test.CommandSpec
-import spock.lang.Requires
-import spock.lang.Retry
-import spock.util.environment.Jvm
 
-@Retry // can fail on CI due to port binding race condition, so retry
-@Requires({ Jvm.current.java8 || Jvm.current.java11 })
 class CreateAzureFunctionSpec extends CommandSpec {
 
     @Override


### PR DESCRIPTION
For Azure 5.0.0 things have moved, and we need to change the generated test

This PR also removes the instructions to `clean` all the time with Gradle in the README

It will not pass until https://github.com/micronaut-projects/micronaut-azure/pull/509 is merged and released to platform.