### PR TITLE
security AOT optimizations for maven

### DIFF
--- a/gradle/templates.versions.toml
+++ b/gradle/templates.versions.toml
@@ -61,8 +61,10 @@ zeebe-micronaut-client = "1.14.0"
 ktor = "2.2.4"
 jakarta-validation-api = "3.0.2"
 micronaut-starter-aws-cdk = "4.0.0-M4"
+micronaut-security-aot = "4.0.0-M8"
 
 [libraries]
+micronaut-security-aot = { module = "io.micronaut.security:micronaut-security-aot", version.ref = "micronaut-security-aot" }
 micronaut-starter-aws-cdk = { module = "io.micronaut.starter:micronaut-starter-aws-cdk", version.ref = "micronaut-starter-aws-cdk" }
 jakarta-validation-api = { module = "jakarta.validation:jakarta.validation-api", version.ref = "jakarta-validation-api" }
 agorapulse-gru = { module = "com.agorapulse:gru-micronaut", version.ref = "agorapulse-gru" }

--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Scope.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Scope.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 public class Scope {
     public static final Scope ANNOTATION_PROCESSOR = new Scope(Source.MAIN, Collections.singletonList(Phase.ANNOTATION_PROCESSING));
+    public static final Scope AOT_PLUGIN = new Scope(Source.MAIN, Collections.singletonList(Phase.AOT_PLUGIN));
     public static final Scope API = new Scope(Source.MAIN, Arrays.asList(Phase.COMPILATION, Phase.PUBLIC_API, Phase.RUNTIME));
     public static final Scope COMPILE = new Scope(Source.MAIN, Arrays.asList(Phase.COMPILATION, Phase.RUNTIME));
     public static final Scope DEVELOPMENT_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.DEVELOPMENT));

--- a/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleConfiguration.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleConfiguration.java
@@ -44,7 +44,8 @@ public enum GradleConfiguration implements Ordered {
     TEST_RUNTIME_ONLY("testRuntimeOnly", 13),
     DEVELOPMENT_ONLY("developmentOnly", 14),
     OPENREWRITE("rewrite", 15),
-    TEST_RESOURCES_SERVICE("testResourcesService", 16);
+    TEST_RESOURCES_SERVICE("testResourcesService", 16),
+    AOT_PLUGIN("aotPlugins", 17);
 
     private final String configurationName;
     private final int order;
@@ -112,6 +113,9 @@ public enum GradleConfiguration implements Ordered {
                 }
                 if (scope.getPhases().contains(Phase.TEST_RESOURCES_SERVICE)) {
                     return Optional.of(GradleConfiguration.TEST_RESOURCES_SERVICE);
+                }
+                if (scope.getPhases().contains(Phase.AOT_PLUGIN)) {
+                    return Optional.of(GradleConfiguration.AOT_PLUGIN);
                 }
                 break;
             case TEST:

--- a/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuild.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuild.java
@@ -55,6 +55,8 @@ public class MavenBuild {
 
     private final List<MavenRepository> repositories;
 
+    private final List<DependencyCoordinate> aotDependencies;
+
     @NonNull
     private final String artifactId;
 
@@ -68,6 +70,7 @@ public class MavenBuild {
                 Collections.emptyList(),
                 MavenCombineAttribute.APPEND,
                 MavenCombineAttribute.APPEND,
+                Collections.emptyList(),
                 Collections.emptyList());
     }
 
@@ -84,6 +87,7 @@ public class MavenBuild {
                 repositories,
                 MavenCombineAttribute.APPEND,
                 MavenCombineAttribute.APPEND,
+                Collections.emptyList(),
                 Collections.emptyList());
     }
 
@@ -96,7 +100,8 @@ public class MavenBuild {
                       @NonNull List<MavenRepository> repositories,
                       @NonNull MavenCombineAttribute annotationProcessorCombineAttribute,
                       @NonNull MavenCombineAttribute testAnnotationProcessorCombineAttribute,
-                      @NonNull Collection<Profile> profiles) {
+                      @NonNull Collection<Profile> profiles,
+                      @NonNull List<DependencyCoordinate> aotDependencies) {
         this.artifactId = artifactId;
         this.annotationProcessors = annotationProcessors;
         this.testAnnotationProcessors = testAnnotationProcessors;
@@ -107,6 +112,7 @@ public class MavenBuild {
         this.annotationProcessorCombineAttribute = annotationProcessorCombineAttribute;
         this.testAnnotationProcessorCombineAttribute = testAnnotationProcessorCombineAttribute;
         this.profiles = profiles;
+        this.aotDependencies = aotDependencies;
     }
 
     @NonNull
@@ -174,5 +180,9 @@ public class MavenBuild {
     @NonNull
     public MavenCombineAttribute getTestAnnotationProcessorCombineAttribute() {
         return testAnnotationProcessorCombineAttribute;
+    }
+
+    public List<DependencyCoordinate> getAotDependencies() {
+        return aotDependencies;
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
@@ -26,6 +26,7 @@ import io.micronaut.starter.build.dependencies.DependencyCoordinate;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.build.dependencies.Phase;
 import io.micronaut.starter.build.dependencies.Priority;
+import io.micronaut.starter.build.dependencies.Scope;
 import io.micronaut.starter.build.dependencies.Source;
 import io.micronaut.starter.feature.graalvm.GraalVM;
 import io.micronaut.starter.options.Language;
@@ -102,6 +103,7 @@ public class MavenBuildCreator {
                 MavenRepository.listOf(repositories),
                 combineAttribute,
                 testCombineAttribute,
-                generatorContext.getProfiles());
+                generatorContext.getProfiles(),
+                generatorContext.getDependencies().stream().filter(dep -> dep.getScope() == Scope.AOT_PLUGIN).map(DependencyCoordinate::new).toList());
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenDependency.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenDependency.java
@@ -89,7 +89,7 @@ public class MavenDependency extends DependencyCoordinate {
     public static List<MavenDependency> listOf(@NonNull DependencyContext dependencyContext, Language language) {
         return dependencyContext.getDependencies()
                 .stream()
-                .filter(dep -> dep.getScope() != null && !dep.getScope().getPhases().contains(Phase.ANNOTATION_PROCESSING))
+                .filter(dep -> dep.getScope() != null && !dep.getScope().getPhases().contains(Phase.ANNOTATION_PROCESSING) && !dep.getScope().getPhases().contains(Phase.AOT_PLUGIN))
                 .map(dep -> new MavenDependency(dep, language))
                 .sorted(MavenDependency.COMPARATOR)
                 .collect(Collectors.toList());

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
@@ -252,6 +252,7 @@ public class Cdk implements MultiProjectFeature, InfrastructureAsCodeFeature {
                 MavenRepository.listOf(repositoryResolver.resolveRepositories(generatorContext)),
                 MavenCombineAttribute.APPEND,
                 MavenCombineAttribute.APPEND,
+                Collections.emptyList(),
                 Collections.emptyList());
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAot.java
@@ -15,23 +15,30 @@
  */
 package io.micronaut.starter.feature.build;
 
+import com.fizzed.rocker.RockerModel;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.BuildProperties;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
+import io.micronaut.starter.build.dependencies.Scope;
 import io.micronaut.starter.build.gradle.GradlePlugin;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.build.maven.templates.aot;
 import io.micronaut.starter.feature.graalvm.GraalVM;
+import io.micronaut.starter.feature.security.SecurityJWT;
+import io.micronaut.starter.feature.security.SecurityOAuth2;
 import io.micronaut.starter.template.RockerTemplate;
 import jakarta.inject.Singleton;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Singleton
 public class MicronautAot implements Feature {
-
     public static final String FEATURE_NAME_AOT = "micronaut-aot";
 
     private static final String GRADLE_PLUGIN_ID = "io.micronaut.aot";
@@ -73,21 +80,75 @@ public class MicronautAot implements Feature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
+        addAotPluginsDependencies(generatorContext);
         if (generatorContext.getBuildTool().isGradle()) {
-            generatorContext.addBuildPlugin(GradlePlugin.builder()
-                    .id(GRADLE_PLUGIN_ID)
-                    .lookupArtifactId(GRADLE_PLUGIN_ARTIFACT_ID)
-                    .order(GRADLE_PLUGIN_ORDER)
-                    .build());
+            addAotGradlePlugin(generatorContext);
         } else {
-            BuildProperties buildProperties = generatorContext.getBuildProperties();
-            buildProperties.put("micronaut.aot.enabled", StringUtils.TRUE);
-            buildProperties.put("micronaut.aot.packageName", generatorContext.getProject().getPackageName() + ".aot.generated");
-
-            generatorContext.addTemplate("aotJitProperties", new RockerTemplate("aot-jar.properties", aot.template("jar")));
-            if (generatorContext.isFeaturePresent(GraalVM.class)) {
-                generatorContext.addTemplate("aotNativeProperties", new RockerTemplate("aot-native-image.properties", aot.template("native-image")));
-            }
+            addAotBuildProperties(generatorContext);
+            addAotConfigurationPropertiesFiles(generatorContext);
         }
+    }
+
+    protected void addAotBuildProperties(GeneratorContext generatorContext) {
+        BuildProperties buildProperties = generatorContext.getBuildProperties();
+        buildProperties.put("micronaut.aot.enabled", StringUtils.TRUE);
+        buildProperties.put("micronaut.aot.packageName", generatorContext.getProject().getPackageName() + ".aot.generated");
+    }
+
+    protected void addAotGradlePlugin(GeneratorContext generatorContext) {
+        generatorContext.addBuildPlugin(GradlePlugin.builder()
+                .id(GRADLE_PLUGIN_ID)
+                .lookupArtifactId(GRADLE_PLUGIN_ARTIFACT_ID)
+                .order(GRADLE_PLUGIN_ORDER)
+                .build());
+    }
+
+    protected void addAotConfigurationPropertiesFiles(GeneratorContext generatorContext) {
+        List<MicronautAotOptimization> optimizations = optimizations(false, generatorContext);
+        RockerModel rockerModel = aot.template("jar", optimizations);
+        generatorContext.addTemplate("aotJitProperties", new RockerTemplate("aot-jar.properties", rockerModel));
+        if (generatorContext.isFeaturePresent(GraalVM.class)) {
+            optimizations = optimizations(true, generatorContext);
+            rockerModel = aot.template("native-image", optimizations);
+            generatorContext.addTemplate("aotNativeProperties", new RockerTemplate("aot-native-image.properties", rockerModel));
+        }
+    }
+
+    protected void addAotPluginsDependencies(GeneratorContext generatorContext) {
+        if (generatorContext.hasFeature(SecurityJWT.class) || generatorContext.hasFeature(SecurityOAuth2.class)) {
+            generatorContext.addDependency(MicronautDependencyUtils.securityDependency()
+                    .lookupArtifactId("micronaut-security-aot")
+                    .scope(Scope.AOT_PLUGIN));
+        }
+    }
+
+    protected List<MicronautAotOptimization> optimizations(boolean graalvm, GeneratorContext generatorContext) {
+        final List<MicronautAotOptimization> optimizations = new ArrayList<>();
+        optimizations.add(new MicronautAotOptimization("cached.environment.enabled", true, "Caches environment property values: environment properties will be deemed immutable after application startup."));
+        optimizations.add(new MicronautAotOptimization("precompute.environment.properties.enabled", true, "Precomputes Micronaut configuration property keys from the current environment variables"));
+        if (graalvm) {
+            optimizations.add(new MicronautAotOptimization("yaml.to.java.config.enabled", false, "Converts YAML configuration files to Java configuration"));
+            optimizations.add(new MicronautAotOptimization("graalvm.config.enabled", true, "Generates GraalVM configuration files required to load the AOT optimizations"));
+            optimizations.add(new MicronautAotOptimization("serviceloading.native.enabled", false, "Scans for service types ahead-of-time, avoiding classpath scanning at startup"));
+        } else {
+            optimizations.add(new MicronautAotOptimization("yaml.to.java.config.enabled", true, "Converts YAML configuration files to Java configuration"));
+            optimizations.add(new MicronautAotOptimization("serviceloading.jit.enabled", true, "Scans for service types ahead-of-time, avoiding classpath scanning at startup"));
+        }
+        optimizations.add(new MicronautAotOptimization("scan.reactive.types.enabled", true, "Scans reactive types at build time instead of runtime"));
+        optimizations.add(new MicronautAotOptimization("deduce.environment.enabled", true, "Deduces the environment at build time instead of runtime"));
+        optimizations.add(new MicronautAotOptimization("known.missing.types.enabled", true, "Checks of existence of some types at build time instead of runtime"));
+        optimizations.add(new MicronautAotOptimization("sealed.property.source.enabled", true, "Precomputes property sources at build time"));
+
+        optimizations.add(new MicronautAotOptimization("service.types", "io.micronaut.context.env.PropertySourceLoader,io.micronaut.inject.BeanConfiguration,io.micronaut.inject.BeanDefinitionReference,io.micronaut.http.HttpRequestFactory,io.micronaut.http.HttpResponseFactory,io.micronaut.core.beans.BeanIntrospectionReference", "The list of service types to be scanned (comma separated)"));
+
+        optimizations.add(new MicronautAotOptimization("known.missing.types.list", "io.reactivex.Observable,reactor.core.publisher.Flux,kotlinx.coroutines.flow.Flow,io.reactivex.rxjava3.core.Flowable,io.reactivex.rxjava3.core.Observable,io.reactivex.Single,reactor.core.publisher.Mono,io.reactivex.Maybe,io.reactivex.rxjava3.core.Single,io.reactivex.rxjava3.core.Maybe,io.reactivex.Completable,io.reactivex.rxjava3.core.Completable,io.methvin.watchservice.MacOSXListeningWatchService,io.micronaut.core.async.publisher.CompletableFuturePublisher,io.micronaut.core.async.publisher.Publishers.JustPublisher,io.micronaut.core.async.subscriber.Completable", "A list of types that the AOT analyzer needs to check for existence (comma separated)"));
+
+        if (generatorContext.hasFeature(SecurityJWT.class) || generatorContext.hasFeature(SecurityOAuth2.class)) {
+            optimizations.add(new MicronautAotOptimization("micronaut.security.jwks.enabled", false, "It fetches remote Json Web Key Set at Build Time. https://micronaut-projects.github.io/micronaut-security/latest/guide/index.html#aotJwks"));
+        }
+        if (generatorContext.hasFeature(SecurityOAuth2.class)) {
+            optimizations.add(new MicronautAotOptimization("micronaut.security.openid-configuration.enabled", false, "It fetches OpenID Connect metadata at Build time. https://micronaut-projects.github.io/micronaut-security/latest/guide/index.html#aotOpenidConfiguration"));
+        }
+        return optimizations;
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAotOptimization.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAotOptimization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.build.dependencies;
+package io.micronaut.starter.feature.build;
 
-public enum Phase {
-    ANNOTATION_PROCESSING,
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 
-    AOT_PLUGIN,
-    PUBLIC_API,
-    COMPILATION,
-    NATIVE_IMAGE_COMPILATION,
-    DEVELOPMENT,
-    RUNTIME,
-    OPENREWRITE,
-    TEST_RESOURCES_SERVICE,
+public record MicronautAotOptimization(@NonNull String key, Object value, @Nullable String comment) {
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/aotExtension.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/aotExtension.rocker.raw
@@ -1,0 +1,30 @@
+@import io.micronaut.starter.build.gradle.GradleDsl
+@import java.util.Map
+@args(GradleDsl dsl, Map<String, String> aotKeys)
+aot {
+   // Please review carefully the optimizations enabled below
+  // Check https://micronaut-projects.github.io/micronaut-aot/latest/guide/ for more details
+@if (dsl == GradleDsl.KOTLIN) {
+        optimizeServiceLoading.set(false)
+        convertYamlToJava.set(false)
+        precomputeOperations.set(true)
+        cacheEnvironment.set(true)
+        optimizeClassLoading.set(true)
+        deduceEnvironment.set(true)
+        optimizeNetty.set(true)
+}
+@if (dsl == GradleDsl.GROOVY) {
+        optimizeServiceLoading = false
+        convertYamlToJava = false
+        precomputeOperations = true
+        cacheEnvironment = true
+        optimizeClassLoading = true
+        deduceEnvironment = true
+        optimizeNetty = true
+}
+@if(aotKeys != null) {
+@for (String keyName : aotKeys.keySet()) {
+        configurationProperties.put("@(keyName)","@(aotKeys.get(keyName))")
+}
+}
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/micronautGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/micronautGradle.rocker.raw
@@ -43,33 +43,7 @@ micronaut {
     }
 }
 @if(aotVersion != null) {
-    aot {
-        // Please review carefully the optimizations enabled below
-        // Check https://micronaut-projects.github.io/micronaut-aot/latest/guide/ for more details
-@if (dsl == GradleDsl.KOTLIN) {
-        optimizeServiceLoading.set(true)
-        convertYamlToJava.set(true)
-        precomputeOperations.set(true)
-        cacheEnvironment.set(true)
-        optimizeClassLoading.set(true)
-        deduceEnvironment.set(true)
-        optimizeNetty.set(true)
-}
-@if (dsl == GradleDsl.GROOVY) {
-        optimizeServiceLoading = true
-        convertYamlToJava = true
-        precomputeOperations = true
-        cacheEnvironment = true
-        optimizeClassLoading = true
-        deduceEnvironment = true
-        optimizeNetty = true
-}
-@if(aotKeys != null) {
-@for (String keyName : aotKeys.keySet()) {
-        configurationProperties.put("@(keyName)","@(aotKeys.get(keyName))")
-}
-}
-    }
+@io.micronaut.starter.feature.build.gradle.templates.aotExtension.template(dsl, aotKeys)
 }
 }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/aot.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/aot.rocker.raw
@@ -1,47 +1,17 @@
+@import java.util.List
+@import io.micronaut.starter.feature.build.MicronautAotOptimization
 @args (
-String packaging
+String packaging,
+List<MicronautAotOptimization> optimizations
 )
-
 # AOT configuration properties for @packaging packaging
 # Please review carefully the optimizations enabled below
 # Check https://micronaut-projects.github.io/micronaut-aot/latest/guide/ for more details
 
-# Caches environment property values: environment properties will be deemed immutable after application startup.
-cached.environment.enabled=true
-
-# Precomputes Micronaut configuration property keys from the current environment variables
-precompute.environment.properties.enabled=true
-
-# Converts YAML configuration files to Java configuration
-yaml.to.java.config.enabled=true
-
-@if ("native-image".equals(packaging)) {
-# Generates GraalVM configuration files required to load the AOT optimizations
-graalvm.config.enabled=true
-
-# Scans for service types ahead-of-time, avoiding classpath scanning at startup
-serviceloading.native.enabled=true
-
-} else {
-# Scans for service types ahead-of-time, avoiding classpath scanning at startup
-serviceloading.jit.enabled = true
+@for (MicronautAotOptimization optimization : optimizations) {
+@if (optimization.comment() != null) {
+# @(optimization.comment())
+@(optimization.key())=@(optimization.value())
 
 }
-
-# Scans reactive types at build time instead of runtime
-scan.reactive.types.enabled=true
-
-# Deduces the environment at build time instead of runtime
-deduce.environment.enabled=true
-
-# Checks of existence of some types at build time instead of runtime
-known.missing.types.enabled=true
-
-# Precomputes property sources at build time
-sealed.property.source.enabled=true
-
-# The list of service types to be scanned (comma separated)
-service.types=io.micronaut.context.env.PropertySourceLoader,io.micronaut.inject.BeanConfiguration,io.micronaut.inject.BeanDefinitionReference,io.micronaut.http.HttpRequestFactory,io.micronaut.http.HttpResponseFactory,io.micronaut.core.beans.BeanIntrospectionReference
-
-# A list of types that the AOT analyzer needs to check for existence (comma separated)
-known.missing.types.list=io.reactivex.Observable,reactor.core.publisher.Flux,kotlinx.coroutines.flow.Flow,io.reactivex.rxjava3.core.Flowable,io.reactivex.rxjava3.core.Observable,io.reactivex.Single,reactor.core.publisher.Mono,io.reactivex.Maybe,io.reactivex.rxjava3.core.Single,io.reactivex.rxjava3.core.Maybe,io.reactivex.Completable,io.reactivex.rxjava3.core.Completable,io.methvin.watchservice.MacOSXListeningWatchService,io.micronaut.core.async.publisher.CompletableFuturePublisher,io.micronaut.core.async.publisher.Publishers.JustPublisher,io.micronaut.core.async.subscriber.Completable
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/aotDependencies.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/aotDependencies.rocker.raw
@@ -1,0 +1,12 @@
+@import java.util.List
+@import io.micronaut.starter.build.dependencies.DependencyCoordinate
+@args(List<DependencyCoordinate> aotDependencies)
+              <aotDependencies>
+@for (DependencyCoordinate aotDependency : aotDependencies) {
+                  <dependency>
+                      <groupId>@(aotDependency.getGroupId())</groupId>
+                      <artifactId>@(aotDependency.getArtifactId())</artifactId>
+                      <version>@(aotDependency.getVersion())</version>
+                  </dependency>
+}
+              </aotDependencies>

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -98,7 +98,8 @@ MavenBuild mavenBuild
       <plugin>
         <groupId>io.micronaut.maven</groupId>
         <artifactId>micronaut-maven-plugin</artifactId>
-@if (features.contains("springloaded")
+@if (!mavenBuild.getAotDependencies().isEmpty()
+     || features.contains("springloaded")
      || features.contains("jrebel")
      || features.contains("oracle-function")
      || features.contains("micronaut-aot")
@@ -110,6 +111,9 @@ MavenBuild mavenBuild
                || features.isFeaturePresent(R2dbc.class)))
 ) {
           <configuration>
+@if (!mavenBuild.getAotDependencies().isEmpty()) {
+@io.micronaut.starter.feature.build.maven.templates.aotDependencies.template(mavenBuild.getAotDependencies())
+}
 @if (features.isFeaturePresent(SharedTestResourceFeature.class)) {
             <shared>true</shared>
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/json/SerializationFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/json/SerializationFeature.java
@@ -21,7 +21,6 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.feature.testresources.TestResources;
 import io.micronaut.starter.options.BuildTool;
 
 import java.util.ArrayList;

--- a/starter-core/src/test/resources/expected-aot-jar.properties
+++ b/starter-core/src/test/resources/expected-aot-jar.properties
@@ -12,7 +12,7 @@ precompute.environment.properties.enabled=true
 yaml.to.java.config.enabled=true
 
 # Scans for service types ahead-of-time, avoiding classpath scanning at startup
-serviceloading.jit.enabled = true
+serviceloading.jit.enabled=true
 
 # Scans reactive types at build time instead of runtime
 scan.reactive.types.enabled=true

--- a/starter-core/src/test/resources/expected-aot-native-image.properties
+++ b/starter-core/src/test/resources/expected-aot-native-image.properties
@@ -9,13 +9,13 @@ cached.environment.enabled=true
 precompute.environment.properties.enabled=true
 
 # Converts YAML configuration files to Java configuration
-yaml.to.java.config.enabled=true
+yaml.to.java.config.enabled=false
 
 # Generates GraalVM configuration files required to load the AOT optimizations
 graalvm.config.enabled=true
 
 # Scans for service types ahead-of-time, avoiding classpath scanning at startup
-serviceloading.native.enabled=true
+serviceloading.native.enabled=false
 
 # Scans reactive types at build time instead of runtime
 scan.reactive.types.enabled=true

--- a/starter-gcp-function/build.gradle
+++ b/starter-gcp-function/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     testImplementation("com.google.cloud.functions:functions-framework-api")
     testImplementation "io.micronaut.test:micronaut-test-spock"
     invoker 'com.google.cloud.functions.invoker:java-function-invoker:1.3.0'
+
+    annotationProcessor("io.micronaut.serde:micronaut-serde-processor")
+    implementation("io.micronaut.serde:micronaut-serde-jackson")
 }
 
 tasks.named("test", Test) {

--- a/starter-web-netty/build.gradle
+++ b/starter-web-netty/build.gradle
@@ -14,6 +14,10 @@ dependencies {
     implementation project(":starter-api")
     implementation "io.micronaut.gcp:micronaut-gcp-http-client"
     runtimeOnly "ch.qos.logback:logback-classic"
+
+    annotationProcessor("io.micronaut.serde:micronaut-serde-processor")
+    implementation("io.micronaut.serde:micronaut-serde-jackson")
+
     testCompileOnly "io.micronaut:micronaut-inject-groovy"
     testImplementation "io.micronaut.test:micronaut-test-spock"
     testImplementation "io.micronaut:micronaut-http-client"

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/AotSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/AotSpec.groovy
@@ -1,0 +1,45 @@
+package io.micronaut.starter.core.test.create
+
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.build.MicronautAot
+import io.micronaut.starter.feature.security.SecurityOAuth2
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.test.CommandSpec
+import io.micronaut.starter.test.LanguageBuildCombinations
+
+class AotSpec extends CommandSpec {
+
+    void 'create-app with feature micronaut-aot for #lang and #buildTool starts successfully'(Language lang, BuildTool buildTool) {
+        given:
+        generateProject(lang, buildTool, [MicronautAot.FEATURE_NAME_AOT] as List<String>, ApplicationType.DEFAULT)
+
+        when:
+        String output = executeBuild(buildTool, "test")
+
+        then:
+        output.contains("BUILD SUCCESS")
+
+        where:
+        [lang, buildTool] << LanguageBuildCombinations.combinations()
+    }
+
+    void 'create-app with feature micronaut-aot and security-oauth2 for #lang and #buildTool starts successfully'(Language lang, BuildTool buildTool) {
+        given:
+        generateProject(lang, buildTool, [MicronautAot.FEATURE_NAME_AOT, SecurityOAuth2.NAME] as List<String>, ApplicationType.DEFAULT)
+
+        when:
+        String output = executeBuild(buildTool, "test")
+
+        then:
+        output.contains("BUILD SUCCESS")
+
+        where:
+        [lang, buildTool] << LanguageBuildCombinations.combinations()
+    }
+
+    @Override
+    String getTempDirectoryPrefix() {
+        'test-aot'
+    }
+}


### PR DESCRIPTION
Close #1907

This PR

- Adds security AOT optimizations for Maven builds
- Correctly adds the security AOT plugin as a dependency with aotPlugins Gradle Configuration in Gradle and as a aotDependency for micronaut Maven plugin configuration.
- It disables service loading and yaml AOT optimizations which fail due to a bug in GraalVM
- Moves Optimizations to Java code outside of rocker