### PR TITLE
Remove java8/java11 requirement in tests

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
@@ -177,7 +177,7 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
         if (buildTool == BuildTool.MAVEN) {
             return "mvnw clean package azure-functions:run";
         } else {
-            return "gradlew clean azureFunctionsRun";
+            return "gradlew azureFunctionsRun";
         }
     }
 
@@ -186,7 +186,7 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
         if (buildTool == BuildTool.MAVEN) {
             return "mvnw clean package azure-functions:deploy";
         } else if (buildTool.isGradle()) {
-            return "gradlew clean azureFunctionsDeploy";
+            return "gradlew azureFunctionsDeploy";
         } else {
             throw new IllegalStateException("Unsupported build tool");
         }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
@@ -50,8 +50,6 @@ public class AzureHttpFunction extends AbstractAzureFunction implements Feature 
             .test()
             .build();
 
-    public static final String NAME = "azure-function-http";
-
     public AzureHttpFunction(CoordinateResolver coordinateResolver) {
         super(coordinateResolver);
     }
@@ -59,7 +57,7 @@ public class AzureHttpFunction extends AbstractAzureFunction implements Feature 
     @NonNull
     @Override
     public String getName() {
-        return NAME;
+        return "azure-function-http";
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureHttpFunction.java
@@ -50,6 +50,8 @@ public class AzureHttpFunction extends AbstractAzureFunction implements Feature 
             .test()
             .build();
 
+    public static final String NAME = "azure-function-http";
+
     public AzureHttpFunction(CoordinateResolver coordinateResolver) {
         super(coordinateResolver);
     }
@@ -57,7 +59,7 @@ public class AzureHttpFunction extends AbstractAzureFunction implements Feature 
     @NonNull
     @Override
     public String getName() {
-        return "azure-function-http";
+        return NAME;
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionGroovyJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionGroovyJunit.rocker.raw
@@ -9,6 +9,7 @@ package @project.getPackageName();
 }
 
 import com.microsoft.azure.functions.HttpStatus
+import com.microsoft.azure.functions.HttpResponseMessage
 import io.micronaut.azure.function.http.HttpRequestMessageBuilder
 import io.micronaut.http.HttpMethod
 import org.junit.jupiter.api.Test
@@ -20,8 +21,7 @@ class @project.getClassName()FunctionTest {
     @@Test
     void testFunction() {
         new Function().withCloseable { Function function ->
-            HttpRequestMessageBuilder.AzureHttpResponseMessage response =
-                function.request(HttpMethod.GET, "/@project.getPropertyName()")
+            HttpResponseMessage response = function.request(HttpMethod.GET, "/@project.getPropertyName()")
                         .invoke()
             assertEquals(HttpStatus.OK, response.status)
         }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionJavaJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionJavaJunit.rocker.raw
@@ -9,7 +9,7 @@ package @project.getPackageName();
 }
 
 import com.microsoft.azure.functions.HttpStatus;
-import io.micronaut.azure.function.http.HttpRequestMessageBuilder;
+import com.microsoft.azure.functions.HttpResponseMessage;
 import io.micronaut.http.HttpMethod;
 import org.junit.jupiter.api.Test;
 
@@ -20,8 +20,7 @@ public class @project.getClassName()FunctionTest {
     @@Test
     public void testFunction() throws Exception {
         try (Function function = new Function()) {
-            HttpRequestMessageBuilder.AzureHttpResponseMessage response =
-                function.request(HttpMethod.GET, "/@project.getPropertyName()")
+            HttpResponseMessage response = function.request(HttpMethod.GET, "/@project.getPropertyName()")
                         .invoke();
 
             assertEquals(HttpStatus.OK, response.getStatus());

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionKoTest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionKoTest.rocker.raw
@@ -9,7 +9,6 @@ package @project.getPackageName()
 }
 
 import com.microsoft.azure.functions.HttpStatus
-import io.micronaut.azure.function.http.HttpRequestMessageBuilder
 import io.micronaut.http.HttpMethod
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionKotlinJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionKotlinJunit.rocker.raw
@@ -9,7 +9,6 @@ package @project.getPackageName();
 }
 
 import com.microsoft.azure.functions.HttpStatus
-import io.micronaut.azure.function.http.HttpRequestMessageBuilder
 import io.micronaut.http.HttpMethod
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionSpock.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionSpock.rocker.raw
@@ -9,7 +9,7 @@ package @project.getPackageName();
 }
 
 import com.microsoft.azure.functions.HttpStatus
-import io.micronaut.azure.function.http.HttpRequestMessageBuilder
+import com.microsoft.azure.functions.HttpResponseMessage
 import io.micronaut.http.HttpMethod
 import spock.lang.*
 
@@ -20,8 +20,7 @@ class @project.getClassName()FunctionSpec extends Specification {
 
     void "test function"() {
         when:"The function is executed"
-        HttpRequestMessageBuilder.AzureHttpResponseMessage response =
-            function.request(HttpMethod.GET, "/@project.getPropertyName()")
+        HttpResponseMessage response = function.request(HttpMethod.GET, "/@project.getPropertyName()")
                     .invoke()
 
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/elasticsearch/ElasticsearchSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/elasticsearch/ElasticsearchSpec.groovy
@@ -7,7 +7,6 @@ import io.micronaut.starter.feature.graalvm.GraalVMFeatureValidator
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import spock.lang.Requires
 import spock.lang.Unroll
 
 class ElasticsearchSpec extends ApplicationContextSpec  implements CommandOutputFixture {
@@ -67,7 +66,6 @@ class ElasticsearchSpec extends ApplicationContextSpec  implements CommandOutput
     }
 
     @Unroll
-    @Requires({ jvm.isJava8() || jvm.isJava11() })
     void 'test gradle elasticsearch and graalvm features for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
@@ -85,7 +83,6 @@ class ElasticsearchSpec extends ApplicationContextSpec  implements CommandOutput
     }
 
     @Unroll
-    @Requires({ jvm.isJava8() || jvm.isJava11() })
     void 'test maven elasticsearch and graalvm features for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/docker/GraalVMDockerRegistryWorkflowSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/docker/GraalVMDockerRegistryWorkflowSpec.groovy
@@ -8,7 +8,6 @@ import io.micronaut.starter.util.VersionInfo
 import spock.lang.Requires
 import spock.lang.Unroll
 
-@Requires({ jvm.isJava8() || jvm.isJava11() })
 class GraalVMDockerRegistryWorkflowSpec extends BeanContextSpec implements CommandOutputFixture {
 
     void 'test github workflow readme'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/docker/GraalVMDockerRegistryWorkflowSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/docker/GraalVMDockerRegistryWorkflowSpec.groovy
@@ -5,7 +5,6 @@ import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.*
 import io.micronaut.starter.util.VersionInfo
-import spock.lang.Requires
 import spock.lang.Unroll
 
 class GraalVMDockerRegistryWorkflowSpec extends BeanContextSpec implements CommandOutputFixture {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/graalvm/GraalVMSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/graalvm/GraalVMSpec.groovy
@@ -10,7 +10,6 @@ import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
-@Requires({ jvm.isJava8() || jvm.isJava11() })
 class GraalVMSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     @Subject
@@ -63,7 +62,7 @@ class GraalVMSpec extends ApplicationContextSpec implements CommandOutputFixture
             <path>
               <groupId>io.micronaut</groupId>
               <artifactId>micronaut-graal</artifactId>
-              <version>\${micronaut.version}</version>
+              <version>\${micronaut.core.version}</version>
             </path>
 """)
         template.contains("""
@@ -91,7 +90,7 @@ class GraalVMSpec extends ApplicationContextSpec implements CommandOutputFixture
                <annotationProcessorPath>
                  <groupId>io.micronaut</groupId>
                  <artifactId>micronaut-graal</artifactId>
-                 <version>${micronaut.version}</version>
+                 <version>${micronaut.core.version}</version>
                </annotationProcessorPath>
 ''')
         template.contains("""

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/graalvm/GraalVMSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/graalvm/GraalVMSpec.groovy
@@ -5,7 +5,6 @@ import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.*
-import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll

--- a/test-aws/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaGraalvmSpec.groovy
+++ b/test-aws/src/test/groovy/io/micronaut/starter/core/test/aws/CreateAwsLambdaGraalvmSpec.groovy
@@ -7,15 +7,10 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.BuildToolCombinations
 import io.micronaut.starter.test.CommandSpec
-import spock.lang.Requires
-import spock.lang.Retry
 import spock.lang.Unroll
-import spock.util.environment.Jvm
 
-@Retry // can fail on CI due to port binding race condition, so retry
 class CreateAwsLambdaGraalvmSpec extends CommandSpec {
 
-    @Requires({ Jvm.current.java8 || Jvm.current.java11 })
     @Unroll
     void 'create-#applicationType with features aws-lambda, graalvm and lang #lang and build #build and test framework: #testFramework'(
             ApplicationType applicationType, Language lang, BuildTool build, TestFramework testFramework) {

--- a/test-buildtool/src/test/groovy/io/micronaut/starter/core/test/buildTool/MavenPackageSpec.groovy
+++ b/test-buildtool/src/test/groovy/io/micronaut/starter/core/test/buildTool/MavenPackageSpec.groovy
@@ -6,7 +6,6 @@ import io.micronaut.starter.test.BuildToolTest
 import io.micronaut.starter.test.CommandSpec
 import spock.lang.IgnoreIf
 import spock.lang.PendingFeature
-import spock.lang.Requires
 import spock.lang.Unroll
 
 class MavenPackageSpec extends CommandSpec {

--- a/test-buildtool/src/test/groovy/io/micronaut/starter/core/test/buildTool/MavenPackageSpec.groovy
+++ b/test-buildtool/src/test/groovy/io/micronaut/starter/core/test/buildTool/MavenPackageSpec.groovy
@@ -5,12 +5,10 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.test.BuildToolTest
 import io.micronaut.starter.test.CommandSpec
 import spock.lang.IgnoreIf
+import spock.lang.PendingFeature
 import spock.lang.Requires
-import spock.lang.Retry
 import spock.lang.Unroll
-import spock.util.environment.Jvm
 
-@Retry // sometimes CI gets connection failure/reset resolving dependencies from Maven central
 class MavenPackageSpec extends CommandSpec {
 
     @Override
@@ -54,7 +52,6 @@ class MavenPackageSpec extends CommandSpec {
 
     @IgnoreIf({ BuildToolTest.IGNORE_MAVEN })
     @Unroll
-    @Requires({ Jvm.current.java8 || Jvm.current.java11 })
     void 'test maven Docker Native packaging for #lang'(Language lang) {
         given:
         generateProject(lang, BuildTool.MAVEN, [])
@@ -63,7 +60,7 @@ class MavenPackageSpec extends CommandSpec {
         String output = executeMaven( "package -Dpackaging=docker-native -Pgraalvm", 30)
 
         then:
-        output.contains("Using BASE_IMAGE: ghcr.io/graalvm/native-image:ol7-java11-22.3.2")
+        output.contains("Using BASE_IMAGE: ghcr.io/graalvm/native-image:ol8-java17-22.3.0")
         
         where:
         lang << Language.values()
@@ -71,7 +68,7 @@ class MavenPackageSpec extends CommandSpec {
 
     @IgnoreIf({ BuildToolTest.IGNORE_MAVEN })
     @Unroll
-    @Requires({ Jvm.current.java8 || Jvm.current.java11 })
+    @PendingFeature
     void 'test maven Docker Native packaging GraalVM check for #lang'(Language lang) {
         given:
         generateProject(lang, BuildTool.MAVEN, [])

--- a/test-buildtool/src/test/groovy/io/micronaut/starter/core/test/buildTool/MavenPackageSpec.groovy
+++ b/test-buildtool/src/test/groovy/io/micronaut/starter/core/test/buildTool/MavenPackageSpec.groovy
@@ -1,11 +1,11 @@
 package io.micronaut.starter.core.test.buildTool
 
+import io.micronaut.starter.feature.graalvm.GraalVMFeatureValidator
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.test.BuildToolTest
 import io.micronaut.starter.test.CommandSpec
 import spock.lang.IgnoreIf
-import spock.lang.PendingFeature
 import spock.lang.Unroll
 
 class MavenPackageSpec extends CommandSpec {
@@ -56,30 +56,14 @@ class MavenPackageSpec extends CommandSpec {
         generateProject(lang, BuildTool.MAVEN, [])
 
         when:
-        String output = executeMaven( "package -Dpackaging=docker-native -Pgraalvm", 30)
+        String output = executeMaven( "package -Dpackaging=docker-native -Pgraalvm")
 
         then:
-        output.contains("Using BASE_IMAGE: ghcr.io/graalvm/native-image:ol8-java17-22.3.0")
-        
-        where:
-        lang << Language.values()
-    }
-
-    @IgnoreIf({ BuildToolTest.IGNORE_MAVEN })
-    @Unroll
-    @PendingFeature
-    void 'test maven Docker Native packaging GraalVM check for #lang'(Language lang) {
-        given:
-        generateProject(lang, BuildTool.MAVEN, [])
-
-        when:
-        String output = executeMaven( "package -Dpackaging=docker-native", 30)
-
-        then:
-        output.contains("The [graalvm] profile was not activated automatically because you are not using a GraalVM JDK. Activate the profile manually (-Pgraalvm) and try again")
+        output.contains("Successfully tagged foo:latest")
+        output.contains("BUILD SUCCESS")
 
         where:
-        lang << Language.values()
+        lang << Language.values().findAll { GraalVMFeatureValidator.supports(it) }
     }
 
     @IgnoreIf({ BuildToolTest.IGNORE_MAVEN })
@@ -92,10 +76,11 @@ class MavenPackageSpec extends CommandSpec {
         String output = executeMaven( "package -Dpackaging=native-image")
 
         then:
-        output.contains("org.graalvm.buildtools:native-maven-plugin")
+        output.contains("GraalVM Native Image: Generating 'foo' (executable)...")
+        output.contains("BUILD SUCCESS")
 
         where:
-        lang << Language.values()
+        lang << Language.values().findAll { GraalVMFeatureValidator.supports(it) }
     }
 
 }

--- a/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
+++ b/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.starter.core.test.cloud.azure
 
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.function.azure.AbstractAzureFunction
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
@@ -20,7 +21,7 @@ class CreateAzureFunctionSpec extends CommandSpec {
                                                                                                                 BuildTool build,
                                                                                                                 TestFramework testFramework) {
         given:
-        List<String> features = ['azure-function']
+        List<String> features = [AbstractAzureFunction.NAME]
         generateProject(lang, build, features, applicationType, testFramework)
 
         when:
@@ -40,7 +41,7 @@ class CreateAzureFunctionSpec extends CommandSpec {
             TestFramework testFramework
     ) {
         given:
-        List<String> features = ['azure-function'] + serializationFeature
+        List<String> features = [AbstractAzureFunction.NAME] + serializationFeature
         generateProject(lang, build, features, ApplicationType.DEFAULT, testFramework)
 
         when:

--- a/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
+++ b/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
@@ -7,12 +7,7 @@ import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.ApplicationTypeCombinations
 import io.micronaut.starter.test.BuildToolCombinations
 import io.micronaut.starter.test.CommandSpec
-import spock.lang.Requires
-import spock.lang.Retry
-import spock.util.environment.Jvm
 
-@Retry // can fail on CI due to port binding race condition, so retry
-@Requires({ Jvm.current.java8 || Jvm.current.java11 })
 class CreateAzureFunctionSpec extends CommandSpec {
 
     @Override

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/github/workflows/azure/AzureContainerInstanceWorkflowSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/github/workflows/azure/AzureContainerInstanceWorkflowSpec.groovy
@@ -31,10 +31,8 @@ import java.util.stream.Collectors
  * see {@link AzureContainerInstanceWorkflowSpec#envVariables()}
  */
 @Requires({
-    AzureContainerInstanceWorkflowSpec.envVariables().stream().allMatch { envVar -> System.getenv().containsKey(envVar) } &&  \
-    jvm.isJava11()
+    AzureContainerInstanceWorkflowSpec.envVariables().stream().allMatch { envVar -> System.getenv().containsKey(envVar) }
 })
-
 class AzureContainerInstanceWorkflowSpec extends WorkflowSpec {
 
     static List<String> envVariables() {

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/github/workflows/docker/DockerRegistryWorkflowSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/github/workflows/docker/DockerRegistryWorkflowSpec.groovy
@@ -26,8 +26,8 @@ import java.util.stream.Collectors
  * </ul>
  */
 @Requires({
-    DockerRegistryWorkflowSpec.envVariables().stream().allMatch { envVar -> System.getenv().containsKey(envVar) } \
-    && jvm.isJava11()})
+    DockerRegistryWorkflowSpec.envVariables().stream().allMatch { envVar -> System.getenv().containsKey(envVar) }
+})
 class DockerRegistryWorkflowSpec extends WorkflowSpec {
 
     @Shared

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/github/workflows/gcloud/GoogleCloudRunWorkflowSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/github/workflows/gcloud/GoogleCloudRunWorkflowSpec.groovy
@@ -32,8 +32,7 @@ import java.util.stream.Collectors
  * created as GitHub Secrets. For required variables see see {@link GoogleCloudRunWorkflowSpec#envVariables()}
  */
 @Requires({
-    GoogleCloudRunWorkflowSpec.envVariables().stream().allMatch { envVar -> System.getenv().containsKey(envVar) } &&  \
-    jvm.isJava11()
+    GoogleCloudRunWorkflowSpec.envVariables().stream().allMatch { envVar -> System.getenv().containsKey(envVar) }
 })
 
 class GoogleCloudRunWorkflowSpec extends WorkflowSpec {

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/github/workflows/oci/OracleFunctionsWorkflowSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/github/workflows/oci/OracleFunctionsWorkflowSpec.groovy
@@ -57,8 +57,7 @@ import static com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider.SimpleAuth
  * as GitHub Secrets, see {@link OracleFunctionsWorkflowSpec#envVariables()}
  */
 @Requires({
-    OracleFunctionsWorkflowSpec.envVariables().stream().allMatch { envVar -> System.getenv().containsKey(envVar) } &&  \
-      jvm.isJava11()
+    OracleFunctionsWorkflowSpec.envVariables().stream().allMatch { envVar -> System.getenv().containsKey(envVar) }
 })
 @Slf4j
 class OracleFunctionsWorkflowSpec extends WorkflowSpec {


### PR DESCRIPTION
I think a lot of this is due to the cloud providers (at the time) not having java 17 support. This is no longer the case, so we should be able to remove the java8/java11 requirement so that the tests run again.

Queued up after https://github.com/micronaut-projects/micronaut-starter/pull/1917 as there are azure tests that will fail without it