### PR TITLE
Stop adding microstream annotations as compile as well as provided

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/microstream/MicroStream.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/microstream/MicroStream.java
@@ -21,6 +21,8 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.Category;
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.options.Language;
 import jakarta.inject.Singleton;
 
 @Singleton
@@ -63,12 +65,16 @@ public class MicroStream implements MicroStreamFeature {
                 .artifactId("micronaut-microstream")
                 .build()
         );
-        generatorContext.addDependency(Dependency.builder()
-                .compile()
-                .groupId(MICRONAUT_MICROSTREAM_GROUP_ID)
-                .artifactId("micronaut-microstream-annotations")
-                .build()
-        );
+        // For Groovy and Maven we only require the annotation in provided scope (from the processor below)
+        // Adding it in both compile, and provided via the processor results in a build failure
+        if (generatorContext.getBuildTool() != BuildTool.MAVEN || generatorContext.getLanguage() != Language.GROOVY) {
+            generatorContext.addDependency(Dependency.builder()
+                    .compile()
+                    .groupId(MICRONAUT_MICROSTREAM_GROUP_ID)
+                    .artifactId("micronaut-microstream-annotations")
+                    .build()
+            );
+        }
         generatorContext.addDependency(Dependency.builder()
                 .annotationProcessor()
                 .groupId(MICRONAUT_MICROSTREAM_GROUP_ID)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/microstream/MicroStreamSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/microstream/MicroStreamSpec.groovy
@@ -122,11 +122,18 @@ class MicroStreamSpec extends BeanContextSpec implements CommandOutputFixture {
       <scope>compile</scope>
     </dependency>
     """)
-        template.contains("""
+        (language != Language.GROOVY) == template.contains("""
     <dependency>
       <groupId>io.micronaut.microstream</groupId>
       <artifactId>micronaut-microstream-annotations</artifactId>
       <scope>compile</scope>
+    </dependency>
+""")
+        (language == Language.GROOVY) == template.contains("""
+    <dependency>
+      <groupId>io.micronaut.microstream</groupId>
+      <artifactId>micronaut-microstream-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
 """)
         if (language == Language.KOTLIN) {
@@ -164,11 +171,18 @@ class MicroStreamSpec extends BeanContextSpec implements CommandOutputFixture {
       <scope>compile</scope>
     </dependency>
     """)
-        template.contains("""
+        (language != Language.GROOVY) == template.contains("""
     <dependency>
       <groupId>io.micronaut.microstream</groupId>
       <artifactId>micronaut-microstream-annotations</artifactId>
       <scope>compile</scope>
+    </dependency>
+""")
+        (language == Language.GROOVY) == template.contains("""
+    <dependency>
+      <groupId>io.micronaut.microstream</groupId>
+      <artifactId>micronaut-microstream-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
 """)
         template.contains("""


### PR DESCRIPTION
For Groovy Maven builds, annotation processors end up as being provided dependencies. However, we add microstream-annotation as a compile dependency.

For Groovy compilation to succeed, we need to only have the provided dependency.

This was discovered as part of getting the MicroStream guide working for 4.0.0

See: https://github.com/micronaut-projects/micronaut-guides/pull/1269\#issuecomment-1620402381