### PR TITLE
Generated apps should not include hard-coded version for `jakarta.validation-api` dependency

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/validator/MicronautValidationFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/validator/MicronautValidationFeature.java
@@ -17,8 +17,6 @@ package io.micronaut.starter.feature.validator;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.generator.GeneratorContext;
-import io.micronaut.starter.build.dependencies.Coordinate;
-import io.micronaut.starter.build.dependencies.CoordinateResolver;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.options.BuildTool;
@@ -40,16 +38,10 @@ public class MicronautValidationFeature implements ValidationFeature {
 
     private static final String ARTIFACT_ID_VALIDATION_API = "jakarta.validation-api";
     private static final String VALIDATION_VERSION_MAVEN_PROPERTY = "micronaut.validation.version";
-    private static final Dependency.Builder DEPENDENCY_VALIDATON_API = Dependency.builder()
+    private static final Dependency.Builder DEPENDENCY_VALIDATION_API = Dependency.builder()
             .groupId("jakarta.validation")
             .artifactId(ARTIFACT_ID_VALIDATION_API)
             .compile();
-
-    private final CoordinateResolver coordinateResolver;
-
-    public MicronautValidationFeature(CoordinateResolver coordinateResolver) {
-        this.coordinateResolver = coordinateResolver;
-    }
 
     @Override
     @NonNull
@@ -81,9 +73,7 @@ public class MicronautValidationFeature implements ValidationFeature {
     protected void addDependencies(GeneratorContext generatorContext) {
         generatorContext.addDependency(MICRONAUT_VALIDATION_COMPILE);
         generatorContext.addDependency(micronautValidationProcessor(generatorContext).build());
-        coordinateResolver.resolve(ARTIFACT_ID_VALIDATION_API)
-                .map(Coordinate::getVersion)
-                .ifPresent(version -> generatorContext.addDependency(DEPENDENCY_VALIDATON_API.version(version)));
+        generatorContext.addDependency(DEPENDENCY_VALIDATION_API);
     }
 
     public static Dependency.Builder micronautValidationProcessor(GeneratorContext generatorContext) {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/validator/MicronautValidationFeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/validator/MicronautValidationFeatureSpec.groovy
@@ -10,6 +10,8 @@ import io.micronaut.starter.feature.Category
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Subject
 
@@ -26,6 +28,33 @@ class MicronautValidationFeatureSpec extends ApplicationContextSpec implements C
         then:
         readme
         readme.contains("https://micronaut-projects.github.io/micronaut-validation/latest/guide/")
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-starter/issues/1914")
+    void 'jakarta.validation:jakarta.validation-api for gradle should not include version'() {
+        when:
+        Map<String, String> output = generate(['validation'])
+        String build = output["build.gradle"]
+
+        then:
+        build
+        build.contains('implementation("jakarta.validation:jakarta.validation-api")')
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-starter/issues/1914")
+    void 'jakarta.validation:jakarta.validation-api for maven should not include version'() {
+        when:
+        Map<String, String> output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, BuildTool.MAVEN),['validation'])
+        String pom = output["pom.xml"]
+
+        then:
+        pom
+        pom.contains('''
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+      <scope>compile</scope>
+    </dependency>''')
     }
 
     void "test Micronaut Validation belongs to Validation category"() {


### PR DESCRIPTION
closes #1914