### PR TITLE
Stop testResources config in Gradle when testcontainers used instead

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautBuildPlugin.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautBuildPlugin.java
@@ -39,6 +39,7 @@ import io.micronaut.starter.feature.function.awslambda.AwsLambda;
 import io.micronaut.starter.feature.graalvm.GraalVMFeatureValidator;
 import io.micronaut.starter.feature.messaging.SharedTestResourceFeature;
 import io.micronaut.starter.feature.testresources.DbType;
+import io.micronaut.starter.feature.testresources.TestResources;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -151,6 +152,9 @@ public class MicronautBuildPlugin implements BuildPluginFeature {
             databaseDriverFeature.flatMap(DatabaseDriverFeature::getDbType)
                     .map(dbType -> getModuleName(generatorContext, dbType))
                     .ifPresent(builder::addAdditionalTestResourceModules);
+        }
+        if (generatorContext.hasFeature(TestResources.class)) {
+            builder = builder.hasTestResources();
         }
         if (generatorContext.getFeatures().isFeaturePresent(SharedTestResourceFeature.class)) {
             builder = builder.withSharedTestResources();

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/MicronautApplicationGradlePlugin.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/MicronautApplicationGradlePlugin.java
@@ -51,6 +51,7 @@ public class MicronautApplicationGradlePlugin {
         private boolean incremental;
         private  String packageName;
         private boolean sharedTestResources;
+        private boolean hasTestResources;
 
         public Builder buildTool(BuildTool buildTool) {
             this.buildTool = buildTool;
@@ -134,7 +135,20 @@ public class MicronautApplicationGradlePlugin {
             return GradlePlugin.builder()
                     .id(id)
                     .lookupArtifactId(ARTIFACT_ID)
-                    .extension(new RockerWritable(micronautGradle.template(dsl, buildTool, dockerfile, dockerfileNative, dockerBuildImages, dockerBuildNativeImages, runtime, testRuntime, aotVersion, incremental, packageName, additionalTestResourceModules, sharedTestResources)));
+                    .extension(new RockerWritable(micronautGradle.template(
+                            dsl,
+                            buildTool,
+                            dockerfile,
+                            dockerfileNative,
+                            dockerBuildImages,
+                            dockerBuildNativeImages,
+                            runtime,
+                            testRuntime,
+                            aotVersion,
+                            incremental,
+                            packageName,
+                            hasTestResources, additionalTestResourceModules, sharedTestResources
+                    )));
         }
 
         public Builder dsl(GradleDsl gradleDsl) {
@@ -144,6 +158,11 @@ public class MicronautApplicationGradlePlugin {
 
         public Builder withSharedTestResources() {
             this.sharedTestResources = true;
+            return this;
+        }
+
+        public Builder hasTestResources() {
+            this.hasTestResources = true;
             return this;
         }
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/micronautGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/micronautGradle.rocker.raw
@@ -7,7 +7,7 @@
     List<String> dockerBuilderImages, List<String> dockerBuilderNativeImages,
     String runtime, String testRuntime,
     String aotVersion, boolean incremental, String packageName,
-    List<String> additionalTestResourceModules, boolean sharedTestResources
+    boolean hasTestResources, List<String> additionalTestResourceModules, boolean sharedTestResources
 )
 micronaut {
 @if(runtime != null) {
@@ -22,7 +22,7 @@ micronaut {
         annotations("@(packageName).*")
     }
 }
-@if (additionalTestResourceModules != null || sharedTestResources) {
+@if (hasTestResources && (additionalTestResourceModules != null || sharedTestResources)) {
     testResources {
         @if(additionalTestResourceModules != null) {
             @for (String module : additionalTestResourceModules) {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MySQLSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/MySQLSpec.groovy
@@ -4,11 +4,9 @@ import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import spock.lang.Unroll
 
 class MySQLSpec extends ApplicationContextSpec {
 
-    @Unroll
     void 'test gradle mysql feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
@@ -29,7 +27,26 @@ class MySQLSpec extends ApplicationContextSpec {
         language << Language.values().toList()
     }
 
-    @Unroll
+    void 'testresources not configured for Gradle with testContainers feature and language=#language'() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['mysql', 'testcontainers'])
+                .language(language)
+                .render()
+
+        then:
+        template.contains('runtimeOnly("mysql:mysql-connector-java")')
+
+        and:
+        !template.contains("""
+    testResources {
+        additionalModules.add("jdbc-mysql")
+    }""")
+
+        where:
+        language << Language.values().toList()
+    }
+
     void 'test maven mysql feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/kafka/KafkaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/messaging/kafka/KafkaSpec.groovy
@@ -26,7 +26,24 @@ class KafkaSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
         then:
         template.contains('implementation("io.micronaut.kafka:micronaut-kafka")')
-        template.contains('sharedServer = true')
+        template.contains("""
+    testResources {
+        sharedServer = true
+    }""")
+    }
+
+    void "test resources config is not present if testContainers feature is added"() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(['kafka', 'testcontainers'])
+                .render()
+
+        then:
+        template.contains('implementation("io.micronaut.kafka:micronaut-kafka")')
+        !template.contains("""
+    testResources {
+        sharedServer = true
+    }""")
     }
 
     void "test dependencies are present for maven"() {


### PR DESCRIPTION
Prior to this fix, using a feature that added an additional module, or shared server would write the Micronaut TestResources config to the build file even if TestContainers was used instead of TestResources.

Fixes #1943