### PR TITLE
Drop Kotest 4 in favor of Kotest 5.

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/gru/template/helloWorldGruControllerTestKotest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/gru/template/helloWorldGruControllerTestKotest.rocker.raw
@@ -9,7 +9,7 @@ package @project.getPackageName()
 }
 
 import com.agorapulse.gru.Gru
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 import io.kotest.core.spec.style.StringSpec
 
 @@MicronautTest

--- a/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/permissions/template/messageServiceTestKotest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/permissions/template/messageServiceTestKotest.rocker.raw
@@ -16,7 +16,7 @@ import io.micronaut.security.authentication.Authentication
 import io.micronaut.security.utils.DefaultSecurityService
 import io.micronaut.security.utils.SecurityService
 import io.micronaut.test.annotation.MockBean
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 import io.mockk.every
 import io.mockk.mockk
 import java.util.Optional

--- a/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/slack/template/commandHandlerTestKotest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/slack/template/commandHandlerTestKotest.rocker.raw
@@ -15,7 +15,7 @@ import io.micronaut.context.annotation.Property
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 
 private const val TEST_SIGNING_SECRET = "s3cr3t"
 private val SIGNATURE_GENERATOR = SlackSignature.Generator(TEST_SIGNING_SECRET)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/slack/template/reactionHandlerGruTestKotest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/slack/template/reactionHandlerGruTestKotest.rocker.raw
@@ -12,7 +12,7 @@ import com.agorapulse.gru.Gru
 import com.agorapulse.gru.TestDefinitionBuilder
 import com.slack.api.methods.MethodsClient
 import com.slack.api.model.Message
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property

--- a/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/worker/template/emailDigestDistributedJobTestKotest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/worker/template/emailDigestDistributedJobTestKotest.rocker.raw
@@ -10,7 +10,7 @@ package @project.getPackageName()
 }
 
 import com.agorapulse.worker.JobManager
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 import io.kotest.core.spec.style.StringSpec
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.annotation.MockBean

--- a/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/worker/template/emailDigestSimpleJobTestKotest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/worker/template/emailDigestSimpleJobTestKotest.rocker.raw
@@ -10,7 +10,7 @@ package @project.getPackageName()
 }
 
 import com.agorapulse.worker.JobManager
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 import io.kotest.core.spec.style.StringSpec
 import io.micronaut.test.annotation.MockBean
 import io.mockk.*

--- a/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/templates/cancelIntentHandlerKoTest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/templates/cancelIntentHandlerKoTest.rocker.raw
@@ -17,7 +17,7 @@ import com.amazon.ask.model.ui.SsmlOutputSpeech
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.StringSpec
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 
 @@MicronautTest
 class CancelIntentHandlerTest(private val handler: CancelIntentHandler): StringSpec({

--- a/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/templates/fallbackIntentHandlerKoTest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/templates/fallbackIntentHandlerKoTest.rocker.raw
@@ -19,7 +19,7 @@ import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.StringSpec
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 
 @@MicronautTest
 class FallbackIntentHandlerTest(private val handler: FallbackIntentHandler): StringSpec({

--- a/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/templates/helpIntentHandlerKoTest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/templates/helpIntentHandlerKoTest.rocker.raw
@@ -20,7 +20,7 @@ import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.StringSpec
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 
 @@MicronautTest
 class HelpIntentHandlerTest(private val handler: HelpIntentHandler): StringSpec({

--- a/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/templates/launchRequestIntentHandlerKoTest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/templates/launchRequestIntentHandlerKoTest.rocker.raw
@@ -18,7 +18,7 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 
 @@MicronautTest
 class LaunchRequestIntentHandlerTest(private val handler: LaunchRequestIntentHandler): StringSpec({

--- a/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/templates/sessionEndedRequestIntentHandlerKoTest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/templates/sessionEndedRequestIntentHandlerKoTest.rocker.raw
@@ -13,7 +13,7 @@ import com.amazon.ask.model.RequestEnvelope
 import com.amazon.ask.model.SessionEndedRequest
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.booleans.shouldBeTrue
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 
 @@MicronautTest
 class SessionEndedRequestIntentHandlerTest(private val handler: SessionEndedRequestIntentHandler): StringSpec({

--- a/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/templates/stopIntentHandlerKoTest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/templates/stopIntentHandlerKoTest.rocker.raw
@@ -18,7 +18,7 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.StringSpec
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 
 @@MicronautTest
 class StopIntentHandlerTest(private val handler: StopIntentHandler): StringSpec({

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautBuildPlugin.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautBuildPlugin.java
@@ -194,7 +194,7 @@ public class MicronautBuildPlugin implements BuildPluginFeature {
         if (generatorContext.getFeatures().testFramework().isJunit()) {
             return Optional.of("junit5");
         } else if (generatorContext.getFeatures().testFramework().isKotlinTestFramework()) {
-            return Optional.of("kotest");
+            return Optional.of("kotest5");
         } else if (generatorContext.getFeatures().testFramework().isSpock()) {
             return Optional.of("spock2");
         }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/server/template/koTest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/server/template/koTest.rocker.raw
@@ -11,7 +11,7 @@ import io.micronaut.http.HttpStatus
 import io.micronaut.context.ApplicationContext
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.http.client.HttpClient
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/KoTest.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/KoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,10 +53,6 @@ public class KoTest implements TestFeature {
 
         // Only for Maven, these dependencies are applied by the Micronaut Gradle Plugin
         if (generatorContext.getBuildTool() == MAVEN) {
-            generatorContext.addDependency(new Dependency.Builder()
-                    .groupId("io.mockk")
-                    .artifactId("mockk")
-                    .test());
             generatorContext.addDependency(DEPENDENCY_MICRONAUT_TEST_KOTEST5);
             generatorContext.addDependency(Dependency.builder()
                     .lookupArtifactId(ARTIFACT_ID_KOTEST_RUNNER_JUNIT_5_JVM)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/KoTest.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/KoTest.java
@@ -19,21 +19,21 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
-import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.TestFramework;
 import io.micronaut.starter.template.URLTemplate;
-
 import jakarta.inject.Singleton;
+
+import static io.micronaut.starter.options.BuildTool.MAVEN;
 
 @Singleton
 public class KoTest implements TestFeature {
-    protected static final String ARTIFACT_ID_MICRONAUT_TEST_KOTEST = "micronaut-test-kotest";
 
-    protected static final Dependency DEPENDENCY_MICRONAUT_TEST_KOTEST = MicronautDependencyUtils
+    protected static final Dependency DEPENDENCY_MICRONAUT_TEST_KOTEST5 = MicronautDependencyUtils
             .testDependency()
-            .artifactId(ARTIFACT_ID_MICRONAUT_TEST_KOTEST)
+            .artifactId("micronaut-test-kotest5")
             .test()
             .build();
+
     protected static final String ARTIFACT_ID_KOTEST_RUNNER_JUNIT_5_JVM = "kotest-runner-junit5-jvm";
 
     protected static final String ARTIFACT_ID_KOTEST_ASSERTIONS_CORE_JVM = "kotest-assertions-core-jvm";
@@ -52,8 +52,12 @@ public class KoTest implements TestFeature {
                         classLoader.getResource("kotest/ProjectConfig.kt")));
 
         // Only for Maven, these dependencies are applied by the Micronaut Gradle Plugin
-        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
-            generatorContext.addDependency(DEPENDENCY_MICRONAUT_TEST_KOTEST);
+        if (generatorContext.getBuildTool() == MAVEN) {
+            generatorContext.addDependency(new Dependency.Builder()
+                    .groupId("io.mockk")
+                    .artifactId("mockk")
+                    .test());
+            generatorContext.addDependency(DEPENDENCY_MICRONAUT_TEST_KOTEST5);
             generatorContext.addDependency(Dependency.builder()
                     .lookupArtifactId(ARTIFACT_ID_KOTEST_RUNNER_JUNIT_5_JVM)
                     .test());
@@ -68,4 +72,18 @@ public class KoTest implements TestFeature {
         return TestFramework.KOTEST;
     }
 
+    @Override
+    public String getTitle() {
+        return "Micronaut Test Kotest5";
+    }
+
+    @Override
+    public String getMicronautDocumentation() {
+        return "https://micronaut-projects.github.io/micronaut-test/latest/guide/#kotest5";
+    }
+
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://kotest.io/";
+    }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/test/template/koTest.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/test/template/koTest.rocker.raw
@@ -7,7 +7,7 @@ package @project.getPackageName()
 }
 
 import io.micronaut.runtime.EmbeddedApplication
-import io.micronaut.test.extensions.kotest.annotation.MicronautTest
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 import io.kotest.core.spec.style.StringSpec
 
 @if(transactional) {

--- a/starter-core/src/main/resources/kotest/ProjectConfig.kt
+++ b/starter-core/src/main/resources/kotest/ProjectConfig.kt
@@ -1,9 +1,8 @@
 package io.kotest.provided
 
 import io.kotest.core.config.AbstractProjectConfig
-import io.micronaut.test.extensions.kotest.MicronautKotestExtension
+import io.micronaut.test.extensions.kotest5.MicronautKotest5Extension
 
 object ProjectConfig : AbstractProjectConfig() {
-    override fun listeners() = listOf(MicronautKotestExtension)
-    override fun extensions() = listOf(MicronautKotestExtension)
+    override fun extensions() = listOf(MicronautKotest5Extension)
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/KoTestSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/KoTestSpec.groovy
@@ -2,6 +2,9 @@ package io.micronaut.starter.feature.test
 
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.TestFramework
 
@@ -33,6 +36,29 @@ class KoTestSpec extends ApplicationContextSpec {
         </dependencies>
       </plugin>
 ''')
+    }
 
+    void 'test maven configure unit tests for Kotest5'() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .testFramework(TestFramework.KOTEST)
+                .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(BuildTool.MAVEN, template)
+
+        then:
+        verifier.hasDependency("io.kotest", "kotest-assertions-core-jvm", Scope.TEST)
+        verifier.hasDependency("io.kotest", "kotest-runner-junit5-jvm", Scope.TEST)
+        verifier.hasDependency("io.micronaut.test", "micronaut-test-kotest5", Scope.TEST)
+        verifier.hasDependency("io.mockk", "mockk", Scope.TEST)
+    }
+
+    void 'test gradle configure unit tests for Kotest5'() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .testFramework(TestFramework.KOTEST)
+                .render()
+
+        then:
+        template.contains('testRuntime("kotest5")')
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/KoTestSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/KoTestSpec.groovy
@@ -49,7 +49,6 @@ class KoTestSpec extends ApplicationContextSpec {
         verifier.hasDependency("io.kotest", "kotest-assertions-core-jvm", Scope.TEST)
         verifier.hasDependency("io.kotest", "kotest-runner-junit5-jvm", Scope.TEST)
         verifier.hasDependency("io.micronaut.test", "micronaut-test-kotest5", Scope.TEST)
-        verifier.hasDependency("io.mockk", "mockk", Scope.TEST)
     }
 
     void 'test gradle configure unit tests for Kotest5'() {


### PR DESCRIPTION
closes #1614

This is a back port to Micronaut 3.10.x from changes I made on #1296 for Micronaut 4.