### PR TITLE
ci: do sdkMinorRelease not sdkMajorRelease [ci skip]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
-        run: ./gradlew sdkMajorRelease --no-daemon
+        run: ./gradlew sdkMinorRelease --no-daemon
   gcr:
     name: Deploy to Cloud Run
     runs-on: ubuntu-latest


### PR DESCRIPTION
Close #1989 

https://github.com/sdkman/sdkman-vendor-gradle-plugin

> sdkMinorRelease - Convenience task performs a Minor Release consisting of Release and Announce combined.