### PR TITLE
Re-enable serialization-jackson with GCP function

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GoogleCloudFunctionFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GoogleCloudFunctionFeatureValidator.java
@@ -18,7 +18,6 @@ package io.micronaut.starter.feature.function.gcp;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.graalvm.GraalVM;
-import io.micronaut.starter.feature.json.SerializationFeature;
 import io.micronaut.starter.feature.validation.FeatureValidator;
 import io.micronaut.starter.options.JdkVersion;
 import io.micronaut.starter.options.Options;
@@ -35,9 +34,6 @@ public class GoogleCloudFunctionFeatureValidator implements FeatureValidator {
             if (features.stream().anyMatch(GraalVM.class::isInstance)) {
                 throw new IllegalArgumentException("Google Cloud Function is not supported for GraalVM. " +
                     "Consider Google Cloud Run for deploying GraalVM native images as docker containers.");
-            }
-            if (features.stream().anyMatch(SerializationFeature.class::isInstance)) {
-                throw new IllegalArgumentException("Google Cloud Function does not currently support micronaut-serialization.");
             }
         }
     }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/gcp/GoogleCloudFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/gcp/GoogleCloudFunctionSpec.groovy
@@ -9,7 +9,12 @@ import io.micronaut.starter.build.dependencies.Scope
 import io.micronaut.starter.feature.json.JacksonDatabindFeature
 import io.micronaut.starter.feature.other.ShadePlugin
 import io.micronaut.starter.fixture.CommandOutputFixture
-import io.micronaut.starter.options.*
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
+import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
 import spock.lang.Issue
 import spock.lang.Requires
 import spock.lang.Shared
@@ -183,22 +188,6 @@ class GoogleCloudFunctionSpec extends BeanContextSpec  implements CommandOutputF
 
         where:
         jdkVersion << [JdkVersion.JDK_8]
-    }
-
-    void 'test Google Cloud Function with #serialization is unsupported'() {
-        when:
-        generate(
-                ApplicationType.DEFAULT,
-                new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
-                ['google-cloud-function',serialization]
-        )
-
-        then:
-        def e = thrown(IllegalArgumentException)
-        e.message == 'Google Cloud Function does not currently support micronaut-serialization.'
-
-        where:
-        serialization << ['serialization-jackson', 'serialization-bson', 'serialization-jsonp']
     }
 
     void 'test Google Cloud Function with graalvm is unsupported'() {


### PR DESCRIPTION
We previously had an issue whereby micronaut-serialization and GCP functions didn't work together

https://github.com/micronaut-projects/micronaut-gcp/issues/724

This has been fixed for Micronaut 4.0.0, so this PR re-enables this combination