### PR TITLE
Stop hardcoding a version of micronaut-security-aot

### DIFF
--- a/gradle/templates.versions.toml
+++ b/gradle/templates.versions.toml
@@ -63,13 +63,11 @@ jakarta-validation-api = "3.0.2"
 spring-boot-gradle-plugin = "3.1.1"
 spring-dependency-management-plugin = "1.1.3"
 micronaut-starter-aws-cdk = "4.0.0"
-micronaut-security-aot = "4.0.1"
 spring-boot-starter-parent="3.1.1"
 [libraries]
 spring-boot-starter-parent = { module = "org.springframework.boot:spring-boot-starter-parent", version.ref = "spring-boot-starter-parent" }
 spring-dependency-management-plugin = { module = "io.spring.gradle:dependency-management-plugin", version.ref = "spring-dependency-management-plugin" }
 spring-boot-gradle-plugin = { module = "org.springframework.boot:spring-boot-gradle-plugin", version.ref = "spring-boot-gradle-plugin" }
-micronaut-security-aot = { module = "io.micronaut.security:micronaut-security-aot", version.ref = "micronaut-security-aot" }
 micronaut-starter-aws-cdk = { module = "io.micronaut.starter:micronaut-starter-aws-cdk", version.ref = "micronaut-starter-aws-cdk" }
 jakarta-validation-api = { module = "jakarta.validation:jakarta.validation-api", version.ref = "jakarta-validation-api" }
 agorapulse-gru = { module = "com.agorapulse:gru-micronaut", version.ref = "agorapulse-gru" }

--- a/starter-core/src/main/java/io/micronaut/starter/build/maven/GroovyMavenPlusPlugin.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/maven/GroovyMavenPlusPlugin.java
@@ -26,6 +26,7 @@ public class GroovyMavenPlusPlugin implements MavenSpecificFeature {
 
     private static final String GROUP_ID_GMAVEN = "org.codehaus.gmavenplus";
     private static final String ARTIFACT_ID_GMAVEN = "gmavenplus-plugin";
+
     @Override
     public String getName() {
         return "groovy-maven-plus-plugin";

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAot.java
@@ -22,6 +22,7 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.BuildProperties;
+import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.build.dependencies.Scope;
 import io.micronaut.starter.build.gradle.GradlePlugin;
@@ -120,6 +121,10 @@ public class MicronautAot implements DefaultFeature {
 
     protected void addAotPluginsDependencies(GeneratorContext generatorContext) {
         if (generatorContext.hasFeature(SecurityJWT.class) || generatorContext.hasFeature(SecurityOAuth2.class)) {
+            Dependency.Builder securityAotPluginDependency = MicronautDependencyUtils.securityDependency()
+                    .artifactId("micronaut-security-aot")
+                    .scope(Scope.AOT_PLUGIN);
+
             if (generatorContext.getBuildTool().isGradle()) {
                 generatorContext.addDependency(MicronautDependencyUtils.platformDependency()
                         .artifactId("micronaut-platform")
@@ -127,10 +132,10 @@ public class MicronautAot implements DefaultFeature {
                         .pom()
                         .scope(Scope.AOT_PLUGIN)
                 );
+                generatorContext.addDependency(securityAotPluginDependency);
+            } else {
+                generatorContext.addDependency(securityAotPluginDependency.version("${micronaut.security.version}"));
             }
-            generatorContext.addDependency(MicronautDependencyUtils.securityDependency()
-                    .artifactId("micronaut-security-aot")
-                    .scope(Scope.AOT_PLUGIN));
         }
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAot.java
@@ -32,8 +32,10 @@ import io.micronaut.starter.feature.build.maven.templates.aot;
 import io.micronaut.starter.feature.graalvm.GraalVM;
 import io.micronaut.starter.feature.security.SecurityJWT;
 import io.micronaut.starter.feature.security.SecurityOAuth2;
+import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.Options;
 import io.micronaut.starter.template.RockerTemplate;
+import io.micronaut.starter.util.VersionInfo;
 import jakarta.inject.Singleton;
 
 import java.util.ArrayList;
@@ -119,8 +121,16 @@ public class MicronautAot implements DefaultFeature {
 
     protected void addAotPluginsDependencies(GeneratorContext generatorContext) {
         if (generatorContext.hasFeature(SecurityJWT.class) || generatorContext.hasFeature(SecurityOAuth2.class)) {
+            if (generatorContext.getBuildTool().isGradle()) {
+                generatorContext.addDependency(MicronautDependencyUtils.platformDependency()
+                        .artifactId("micronaut-platform")
+                        .version(VersionInfo.getMicronautVersion())
+                        .pom()
+                        .scope(Scope.AOT_PLUGIN)
+                );
+            }
             generatorContext.addDependency(MicronautDependencyUtils.securityDependency()
-                    .lookupArtifactId("micronaut-security-aot")
+                    .artifactId("micronaut-security-aot")
                     .scope(Scope.AOT_PLUGIN));
         }
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAot.java
@@ -32,7 +32,6 @@ import io.micronaut.starter.feature.build.maven.templates.aot;
 import io.micronaut.starter.feature.graalvm.GraalVM;
 import io.micronaut.starter.feature.security.SecurityJWT;
 import io.micronaut.starter.feature.security.SecurityOAuth2;
-import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.Options;
 import io.micronaut.starter.template.RockerTemplate;
 import io.micronaut.starter.util.VersionInfo;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/aotDependencies.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/aotDependencies.rocker.raw
@@ -6,7 +6,7 @@
                   <dependency>
                       <groupId>@(aotDependency.getGroupId())</groupId>
                       <artifactId>@(aotDependency.getArtifactId())</artifactId>
-                      <version>${micronaut.security.version}</version>
+                      <version>@(aotDependency.getVersion())</version>
                   </dependency>
 }
               </aotDependencies>

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/aotDependencies.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/aotDependencies.rocker.raw
@@ -6,7 +6,6 @@
                   <dependency>
                       <groupId>@(aotDependency.getGroupId())</groupId>
                       <artifactId>@(aotDependency.getArtifactId())</artifactId>
-                      <version>@(aotDependency.getVersion())</version>
                   </dependency>
 }
               </aotDependencies>

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/aotDependencies.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/aotDependencies.rocker.raw
@@ -6,6 +6,7 @@
                   <dependency>
                       <groupId>@(aotDependency.getGroupId())</groupId>
                       <artifactId>@(aotDependency.getArtifactId())</artifactId>
+                      <version>${micronaut.security.version}</version>
                   </dependency>
 }
               </aotDependencies>


### PR DESCRIPTION
We were hardcoding a version of micronaut-security-aot, which meant that we ended up with two versions of a core library when trying to run the AOT analysis.

This led to multiple beans being in the context as seen in

https://github.com/micronaut-projects/micronaut-security/issues/1420

The fix here imports the micronaut-platform for the aotPlugin configuration

I don't believe we need this for the maven dependency.