### PR TITLE
AWS Lambda and CDK configuration with Java 17 shouldn't set JAVA_TOOL_OPTIONS variable

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/template/cdkappstack.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/template/cdkappstack.rocker.raw
@@ -138,10 +138,6 @@ public class AppStack extends Stack {
                 .build());
 }
 @if (functionId != null) {
-@if (!nativeImage) {
-        // https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
-        environmentVariables.put("JAVA_TOOL_OPTIONS", "-XX:+TieredCompilation -XX:TieredStopAtLevel=1");
-}
 @if (applicationType == ApplicationType.DEFAULT) {
         Function function = MicronautFunction.create(ApplicationType.DEFAULT,
 }


### PR DESCRIPTION
fixes #2043