### PR TITLE
Exclude inject from Jax-rs processor in maven

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/jaxrs/JaxRs.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/jaxrs/JaxRs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.micronaut.starter.feature.jaxrs;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeatureContext;
@@ -29,6 +30,9 @@ import jakarta.inject.Singleton;
 public class JaxRs implements Feature, MicronautServerDependent {
 
     public static final String MICRONAUT_JAX_RS_GROUP = "io.micronaut.jaxrs";
+    public static final String MICRONAUT_JAXRS_VERSION = "micronaut.jaxrs.version";
+    public static final String MICRONAUT_JAXRS_PROCESSOR = "micronaut-jaxrs-processor";
+    public static final String NAME = "jax-rs";
 
     private final JaxRsSecurity jaxRsSecurity;
 
@@ -38,7 +42,7 @@ public class JaxRs implements Feature, MicronautServerDependent {
 
     @Override
     public String getName() {
-        return "jax-rs";
+        return NAME;
     }
 
     @Override
@@ -62,11 +66,18 @@ public class JaxRs implements Feature, MicronautServerDependent {
     public void apply(GeneratorContext generatorContext) {
         Dependency.Builder jaxrs = Dependency.builder()
                 .groupId(MICRONAUT_JAX_RS_GROUP)
-                .artifactId("micronaut-jaxrs-processor")
-                .versionProperty("micronaut.jaxrs.version")
+                .artifactId(MICRONAUT_JAXRS_PROCESSOR)
+                .versionProperty(MICRONAUT_JAXRS_VERSION)
                 .template();
 
-        generatorContext.addDependency(jaxrs.annotationProcessor());
+        if (generatorContext.getBuildTool().isGradle()) {
+            generatorContext.addDependency(jaxrs.annotationProcessor());
+        } else {
+            generatorContext.addDependency(MicronautDependencyUtils
+                    .moduleMavenAnnotationProcessor(MICRONAUT_JAX_RS_GROUP, MICRONAUT_JAXRS_PROCESSOR, MICRONAUT_JAXRS_VERSION, false)
+            );
+        }
+
         generatorContext.addDependency(jaxrs.testAnnotationProcessor());
         generatorContext.addDependency(Dependency.builder()
                 .groupId(MICRONAUT_JAX_RS_GROUP)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/jaxrs/JaxRsSecuritySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/jaxrs/JaxRsSecuritySpec.groovy
@@ -11,7 +11,7 @@ class JaxRsSecuritySpec extends ApplicationContextSpec implements CommandOutputF
 
     void 'test readme.md with feature jax-rs-security contains links to micronaut docs'() {
         when:
-        def output = generate(['security', 'jax-rs'])
+        def output = generate(['security', JaxRs.NAME])
         def readme = output["README.md"]
 
         then:
@@ -23,7 +23,7 @@ class JaxRsSecuritySpec extends ApplicationContextSpec implements CommandOutputF
     void 'test jax-rs-security with Gradle for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .features(['security', 'jax-rs', 'kapt'])
+                .features(['security', JaxRs.NAME, 'kapt'])
                 .language(language)
                 .render()
 
@@ -42,7 +42,7 @@ class JaxRsSecuritySpec extends ApplicationContextSpec implements CommandOutputF
     void 'test jax-rs-security is not with Gradle if none SecurityFeature selected'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .features(['jax-rs'])
+                .features([JaxRs.NAME])
                 .language(Language.JAVA)
                 .render()
 
@@ -53,7 +53,7 @@ class JaxRsSecuritySpec extends ApplicationContextSpec implements CommandOutputF
     void 'test maven jax-rs-security feature'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .features(['security', 'jax-rs'])
+                .features(['security', JaxRs.NAME])
                 .render()
 
         then:
@@ -77,13 +77,19 @@ class JaxRsSecuritySpec extends ApplicationContextSpec implements CommandOutputF
               <groupId>io.micronaut.jaxrs</groupId>
               <artifactId>micronaut-jaxrs-processor</artifactId>
               <version>\${micronaut.jaxrs.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-inject</artifactId>
+                </exclusion>
+              </exclusions>
             </path>
 """)
 
         when:
         template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .language(Language.KOTLIN)
-                .features(['security', 'jax-rs'])
+                .features(['security', JaxRs.NAME])
                 .render()
 
         then:
@@ -113,7 +119,7 @@ class JaxRsSecuritySpec extends ApplicationContextSpec implements CommandOutputF
         when:
         template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .language(Language.GROOVY)
-                .features(['security', 'jax-rs'])
+                .features(['security', JaxRs.NAME])
                 .render()
 
         then:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/jaxrs/JaxRsSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/jaxrs/JaxRsSpec.groovy
@@ -11,7 +11,7 @@ class JaxRsSpec extends ApplicationContextSpec  implements CommandOutputFixture 
 
     void 'test readme.md with feature jax-rs contains links to micronaut docs'() {
         when:
-        def output = generate(['jax-rs'])
+        def output = generate([JaxRs.NAME])
         def readme = output["README.md"]
 
         then:
@@ -23,7 +23,7 @@ class JaxRsSpec extends ApplicationContextSpec  implements CommandOutputFixture 
     void 'test jax-rs with Gradle for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
-                .features(['jax-rs', 'kapt'])
+                .features([JaxRs.NAME, 'kapt'])
                 .language(language)
                 .render()
 
@@ -41,7 +41,7 @@ class JaxRsSpec extends ApplicationContextSpec  implements CommandOutputFixture 
     void 'test maven jax-rs feature'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .features(['jax-rs'])
+                .features([JaxRs.NAME])
                 .render()
 
         then:
@@ -57,13 +57,19 @@ class JaxRsSpec extends ApplicationContextSpec  implements CommandOutputFixture 
               <groupId>io.micronaut.jaxrs</groupId>
               <artifactId>micronaut-jaxrs-processor</artifactId>
               <version>\${micronaut.jaxrs.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-inject</artifactId>
+                </exclusion>
+              </exclusions>
             </path>
 """)
 
         when:
         template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .language(Language.KOTLIN)
-                .features(['jax-rs'])
+                .features([JaxRs.NAME])
                 .render()
 
         then:
@@ -85,7 +91,7 @@ class JaxRsSpec extends ApplicationContextSpec  implements CommandOutputFixture 
         when:
         template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .language(Language.GROOVY)
-                .features(['jax-rs'])
+                .features([JaxRs.NAME])
                 .render()
 
         then:

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/jaxrs/JaxRsSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/jaxrs/JaxRsSpec.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.starter.core.test.feature.jaxrs
+
+import io.micronaut.starter.feature.config.Yaml
+import io.micronaut.starter.feature.jaxrs.JaxRs
+import io.micronaut.starter.feature.validator.MicronautValidationFeature
+import io.micronaut.starter.io.ConsoleOutput
+import io.micronaut.starter.io.FileSystemOutputHandler
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.template.RockerWritable
+import io.micronaut.starter.test.BuildToolTest
+import io.micronaut.starter.test.CommandSpec
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.IgnoreIf
+import spock.lang.Unroll
+
+class JaxRsSpec extends CommandSpec {
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "jaxRs"
+    }
+
+    @IgnoreIf({ BuildToolTest.IGNORE_MAVEN })
+    @Unroll
+    void "test maven jax-rs with #language"(Language language) {
+        when:
+        generateProject(language, BuildTool.MAVEN, [Yaml.NAME, JaxRs.NAME, MicronautValidationFeature.NAME])
+
+        and:
+        // Write a class that requires serialization
+        def fsoh = new FileSystemOutputHandler(dir, ConsoleOutput.NOOP)
+        fsoh.write(
+                "src/main/${language.name}/example/micronaut/Book.${language.extension}",
+                new RockerWritable(Class.forName("io.micronaut.starter.core.test.feature.jaxrs.book${language.name}").template())
+        )
+
+        and:
+        String output = executeMaven("compile")
+
+        then:
+        output?.contains("BUILD SUCCESS")
+
+        where:
+        language << Language.values()
+    }
+
+    @Unroll
+    void "test gradle jax-rs with #language"(Language language) {
+        when:
+        generateProject(language, BuildTool.GRADLE, [Yaml.NAME, JaxRs.NAME, MicronautValidationFeature.NAME])
+
+        and:
+        // Write a class that requires serialization
+        def fsoh = new FileSystemOutputHandler(dir, ConsoleOutput.NOOP)
+        fsoh.write(
+                "src/main/${language.name}/example/micronaut/Book.${language.extension}",
+                new RockerWritable(Class.forName("io.micronaut.starter.core.test.feature.jaxrs.book${language.name}").template())
+        )
+
+        and:
+        BuildResult result = executeGradle("compileJava")
+
+        then:
+        result?.output?.contains("BUILD SUCCESS")
+
+        where:
+        language << Language.values()
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/jaxrs/bookgroovy.rocker.raw
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/jaxrs/bookgroovy.rocker.raw
@@ -1,0 +1,23 @@
+package example.micronaut
+
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.serde.annotation.Serdeable
+
+import jakarta.validation.constraints.NotBlank
+
+@@Serdeable
+class Book {
+
+    @@NonNull
+    @@NotBlank
+    private final String name
+
+    Book(@@NonNull String name) {
+        this.name = name
+    }
+
+    @@NonNull
+    String getName() {
+        name
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/jaxrs/bookjava.rocker.raw
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/jaxrs/bookjava.rocker.raw
@@ -1,0 +1,23 @@
+package example.micronaut;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.serde.annotation.Serdeable;
+
+import jakarta.validation.constraints.NotBlank;
+
+@@Serdeable
+public class Book {
+
+    @@NonNull
+    @@NotBlank
+    private final String name;
+
+    public Book(@@NonNull String name) {
+        this.name = name;
+    }
+
+    @@NonNull
+    public String getName() {
+        return name;
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/jaxrs/bookkotlin.rocker.raw
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/jaxrs/bookkotlin.rocker.raw
@@ -1,0 +1,8 @@
+package example.micronaut
+
+import io.micronaut.serde.annotation.Serdeable
+
+import jakarta.validation.constraints.NotBlank
+
+@@Serdeable
+public data class Book(@@field:NotBlank val name: String)


### PR DESCRIPTION
We discovered an issue with Micronaut 4.1.1 whilst building the guides:

https://github.com/micronaut-projects/micronaut-guides/pull/1328

Excluding micronaut-inject from the plugin dependency path seems to fix the issue, and we no longer get

https://ge.micronaut.io/s/vrqeirg3xxjoe/failure#1

java.lang.ClassNotFoundException: io.micronaut.core.annotation.Introspected$IntrospectionBuilder