### PR TITLE
Exclude dependencies in Maven for metrics annotation

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/micrometer/MicrometerAnnotations.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/micrometer/MicrometerAnnotations.java
@@ -23,12 +23,16 @@ import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.other.Management;
 import io.micronaut.starter.feature.server.MicronautServerDependent;
+import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.util.NameUtils;
 import jakarta.inject.Singleton;
+
+import static io.micronaut.starter.build.dependencies.MicronautDependencyUtils.coreDependency;
 
 @Singleton
 public class MicrometerAnnotations implements Feature, MicronautServerDependent {
 
+    public static final String NAME = "micrometer-annotation";
     private final Core core;
     private final Management management;
 
@@ -39,7 +43,7 @@ public class MicrometerAnnotations implements Feature, MicronautServerDependent 
 
     @Override
     public String getName() {
-        return "micrometer-annotation";
+        return NAME;
     }
 
     @Override
@@ -64,11 +68,22 @@ public class MicrometerAnnotations implements Feature, MicronautServerDependent 
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.addDependency(Dependency.builder()
+        Dependency.Builder dependency = Dependency
+                .builder()
                 .groupId("io.micronaut.micrometer")
                 .artifactId("micronaut-micrometer-annotation")
                 .versionProperty("micronaut.micrometer.version")
-                .annotationProcessor());
+                .annotationProcessor();
+
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
+            dependency.exclude(
+                    coreDependency()
+                            .artifactId("micronaut-core")
+                            .compile()
+                            .build()
+            );
+        }
+        generatorContext.addDependency(dependency);
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/micrometer/MicrometerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/micrometer/MicrometerSpec.groovy
@@ -158,8 +158,10 @@ class MicrometerSpec extends ApplicationContextSpec {
                 .features(['micrometer-annotation', 'kapt'])
                 .render()
 
+        BuildTestVerifier verifier = BuildTestUtil.verifier(BuildTool.GRADLE, template)
+
         then:
-        template.contains("$scope(\"io.micronaut.micrometer:micronaut-micrometer-annotation\")")
+        verifier.hasDependency("io.micronaut.micrometer", "micronaut-micrometer-annotation", scope)
 
         where:
         language        | scope
@@ -174,16 +176,16 @@ class MicrometerSpec extends ApplicationContextSpec {
                 .language(language)
                 .features(['micrometer-annotation'])
                 .render()
-        def xml = new XmlSlurper().parseText(template)
-                .'**'.find{ it.artifactId == 'micronaut-micrometer-annotation'}
+        def xml = new XmlSlurper().parseText(template).'**'.find{ it.artifactId == 'micronaut-micrometer-annotation' }
 
         then:
-        xml
         xml.name()  == group
         xml.groupId == 'io.micronaut.micrometer'
         xml[versionOrScope] == expected
 
-        where:
+        and: "micronaut-core is excluded for java"
+        language != Language.JAVA || xml.exclusions.exclusion.artifactId.text() == 'micronaut-core'
+
         where:
         language        | group                     | versionOrScope || expected
         Language.JAVA   | 'path'                    | 'version'      || '${micronaut.micrometer.version}'

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/micrometer/MicrometerSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/micrometer/MicrometerSpec.groovy
@@ -1,0 +1,65 @@
+package io.micronaut.starter.core.test.feature.micrometer
+
+import io.micronaut.starter.feature.database.DataJdbc
+import io.micronaut.starter.feature.micrometer.MicrometerAnnotations
+import io.micronaut.starter.feature.validator.MicronautValidationFeature
+import io.micronaut.starter.io.ConsoleOutput
+import io.micronaut.starter.io.FileSystemOutputHandler
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.template.RockerWritable
+import io.micronaut.starter.test.BuildToolTest
+import io.micronaut.starter.test.CommandSpec
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.IgnoreIf
+
+class MicrometerSpec extends CommandSpec {
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "micrometer"
+    }
+
+    @IgnoreIf({ BuildToolTest.IGNORE_MAVEN })
+    void "test maven micrometer-cloudwatch with #language"(Language language) {
+        when:
+        generateProject(language, BuildTool.MAVEN, ["micrometer-cloudwatch", MicrometerAnnotations.NAME, DataJdbc.NAME, MicronautValidationFeature.NAME])
+
+        and:
+        createTemplate(language)
+
+        and:
+        String output = executeMaven("compile")
+
+        then:
+        output?.contains("BUILD SUCCESS")
+
+        where:
+        language << Language.values()
+    }
+
+    void "test gradle micrometer-cloudwatch with #language"(Language language) {
+        when:
+        generateProject(language, BuildTool.GRADLE, ["micrometer-cloudwatch", MicrometerAnnotations.NAME, DataJdbc.NAME, MicronautValidationFeature.NAME])
+
+        and:
+        createTemplate(language)
+
+        and:
+        BuildResult result = executeGradle("compileJava")
+
+        then:
+        result?.output?.contains("BUILD SUCCESS")
+
+        where:
+        language << Language.values()
+    }
+
+    private void createTemplate(Language language) {
+        def fsoh = new FileSystemOutputHandler(dir, ConsoleOutput.NOOP)
+        fsoh.write(
+                "src/main/${language.name}/example/micronaut/BookController.${language.extension}",
+                new RockerWritable(Class.forName("io.micronaut.starter.core.test.feature.micrometer.book${language.name}").template())
+        )
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/micrometer/bookgroovy.rocker.raw
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/micrometer/bookgroovy.rocker.raw
@@ -1,0 +1,52 @@
+package example.micronaut
+
+import io.micrometer.core.annotation.Counted
+import io.micrometer.core.annotation.Timed
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.repository.CrudRepository
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.validation.constraints.NotBlank
+
+import static io.micronaut.data.annotation.GeneratedValue.Type.AUTO
+import static io.micronaut.data.model.query.builder.sql.Dialect.H2
+
+@@JdbcRepository(dialect = H2) // <1>
+interface BookRepository extends CrudRepository<Book, Long> { // <2>
+
+    @@NonNull
+    Optional<Book> findByIsbn(@@NotBlank String isbn)
+}
+
+@@Controller
+class BookController {
+
+    @@Get
+    @@Counted("books.find")
+    @@Timed("books.index")
+    Optional<String> findBook(String isbn) {
+        Optional.empty()
+    }
+}
+
+@@Serdeable
+@@MappedEntity
+class Book {
+
+    @@Id
+    @@GeneratedValue(AUTO)
+    Long id
+
+    String name
+    String isbn
+
+    Book(String isbn, String name) {
+        this.isbn = isbn
+        this.name = name
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/micrometer/bookjava.rocker.raw
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/micrometer/bookjava.rocker.raw
@@ -1,0 +1,78 @@
+package example.micronaut;
+
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.repository.CrudRepository;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.serde.annotation.Serdeable;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.Optional;
+
+import static io.micronaut.data.annotation.GeneratedValue.Type.AUTO;
+import static io.micronaut.data.model.query.builder.sql.Dialect.H2;
+
+@@JdbcRepository(dialect = H2) // <1>
+interface BookRepository extends CrudRepository<Book, Long> { // <2>
+
+    @@NonNull
+    Optional<Book> findByIsbn(@@NotBlank String isbn);
+}
+
+@@Controller
+public class BookController {
+
+    @@Get
+    @@Counted("books.find")
+    @@Timed("books.index")
+    Optional<String> findBook(String isbn) {
+        return Optional.empty();
+    }
+}
+
+@@Serdeable
+@@MappedEntity
+class Book {
+
+    @@Id
+    @@GeneratedValue(AUTO)
+    private Long id;
+
+    private String name;
+    private String isbn;
+
+    public Book(String isbn, String name) {
+        this.isbn = isbn;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getIsbn() {
+        return isbn;
+    }
+
+    public void setIsbn(String isbn) {
+        this.isbn = isbn;
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/micrometer/bookkotlin.rocker.raw
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/micrometer/bookkotlin.rocker.raw
@@ -1,0 +1,39 @@
+package example.micronaut
+
+import io.micrometer.core.annotation.Counted
+import io.micrometer.core.annotation.Timed
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.serde.annotation.Serdeable
+
+@@JdbcRepository(dialect = Dialect.H2)
+open interface BookRepository : CrudRepository<Book, Long> {
+
+    open fun findByIsbn(isbn: String): Book
+}
+
+@@Controller
+open class BookController {
+
+    @@Get
+    @@Counted("books.find")
+    @@Timed("books.index")
+    open fun findBook(isbn: String): String? {
+        return null
+    }
+}
+
+@@Serdeable
+@@MappedEntity
+open class Book(var isbn: String, var name: String) {
+
+    @@field:Id
+    @@field:GeneratedValue(GeneratedValue.Type.AUTO)
+    var id: Long? = null
+}


### PR DESCRIPTION
The metrics-annotation has an api dependency on aop, which is pulling in other versions of things.

This PR excludes `micronaut-core` from the dependencies for the metrics annotation processor.

Excluding `micronaut-inject` as with the other processors is not enough as we also need to exclude `io.micronaut.core.beans.BeanIntrospection$Builder`