### PR TITLE
Exclude micronaut-core from microstream-annotation

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/microstream/MicroStream.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/microstream/MicroStream.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.Language;
@@ -29,6 +30,8 @@ import jakarta.inject.Singleton;
 public class MicroStream implements MicroStreamFeature {
 
     public static final String NAME = "microstream";
+    public static final String MICRONAUT_MICROSTREAM_ANNOTATIONS_ARTIFACT = "micronaut-microstream-annotations";
+    public static final String MICRONAUT_MICROSTREAM_VERSION = "micronaut.microstream.version";
 
     @Override
     @NonNull
@@ -71,17 +74,25 @@ public class MicroStream implements MicroStreamFeature {
             generatorContext.addDependency(Dependency.builder()
                     .compile()
                     .groupId(MICRONAUT_MICROSTREAM_GROUP_ID)
-                    .artifactId("micronaut-microstream-annotations")
+                    .artifactId(MICRONAUT_MICROSTREAM_ANNOTATIONS_ARTIFACT)
                     .build()
             );
         }
-        generatorContext.addDependency(Dependency.builder()
+        Dependency.Builder dependency = Dependency.builder()
                 .annotationProcessor()
                 .groupId(MICRONAUT_MICROSTREAM_GROUP_ID)
-                .artifactId("micronaut-microstream-annotations")
-                .versionProperty("micronaut.microstream.version")
-                .build()
-        );
+                .artifactId(MICRONAUT_MICROSTREAM_ANNOTATIONS_ARTIFACT)
+                .versionProperty(MICRONAUT_MICROSTREAM_VERSION);
+
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
+            dependency.exclude(
+                    MicronautDependencyUtils.coreDependency()
+                            .artifactId("micronaut-core")
+                            .compile()
+                            .build()
+            );
+        }
+        generatorContext.addDependency(dependency);
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/microstream/MicroStreamSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/microstream/MicroStreamSpec.groovy
@@ -149,6 +149,12 @@ class MicroStreamSpec extends BeanContextSpec implements CommandOutputFixture {
               <groupId>io.micronaut.microstream</groupId>
               <artifactId>micronaut-microstream-annotations</artifactId>
               <version>${micronaut.microstream.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-core</artifactId>
+                </exclusion>
+              </exclusions>
             </path>''')
         }
 

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/microstream/MicroStreamSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/microstream/MicroStreamSpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.starter.core.test.feature.microstream
+
+import io.micronaut.starter.feature.config.Yaml
+import io.micronaut.starter.feature.microstream.MicroStream
+import io.micronaut.starter.feature.validator.MicronautValidationFeature
+import io.micronaut.starter.io.ConsoleOutput
+import io.micronaut.starter.io.FileSystemOutputHandler
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.template.RockerWritable
+import io.micronaut.starter.test.BuildToolTest
+import io.micronaut.starter.test.CommandSpec
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.IgnoreIf
+
+class MicroStreamSpec extends CommandSpec {
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "microStream"
+    }
+
+    @IgnoreIf({ BuildToolTest.IGNORE_MAVEN })
+    void "test maven MicroStream with #language"(Language language) {
+        when:
+        generateProject(language, BuildTool.MAVEN, [Yaml.NAME, MicroStream.NAME, MicronautValidationFeature.NAME])
+
+        and:
+        // Write a class that requires serialization
+        def fsoh = new FileSystemOutputHandler(dir, ConsoleOutput.NOOP)
+        fsoh.write(
+                "src/main/${language.name}/example/micronaut/Book.${language.extension}",
+                new RockerWritable(Class.forName("${this.class.package.name}.book${language.name}").template())
+        )
+
+        and:
+        String output = executeMaven("compile")
+
+        then:
+        output?.contains("BUILD SUCCESS")
+
+        where:
+        language << Language.values()
+    }
+
+    void "test gradle MicroStream with #language"(Language language) {
+        when:
+        generateProject(language, BuildTool.GRADLE, [Yaml.NAME, MicroStream.NAME, MicronautValidationFeature.NAME])
+
+        and:
+        // Write a class that requires serialization
+        def fsoh = new FileSystemOutputHandler(dir, ConsoleOutput.NOOP)
+        fsoh.write(
+                "src/main/${language.name}/example/micronaut/Book.${language.extension}",
+                new RockerWritable(Class.forName("${this.class.package.name}.book${language.name}").template())
+        )
+
+        and:
+        BuildResult result = executeGradle("compileJava")
+
+        then:
+        result?.output?.contains("BUILD SUCCESS")
+
+        where:
+        language << Language.values()
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/microstream/bookgroovy.rocker.raw
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/microstream/bookgroovy.rocker.raw
@@ -1,0 +1,34 @@
+package example.micronaut
+
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.microstream.annotations.StoreReturn;
+import io.micronaut.serde.annotation.Serdeable
+
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotBlank
+
+@@Serdeable
+class Book {
+
+    @@NonNull
+    @@NotBlank
+    private final String name
+
+    Book(@@NonNull String name) {
+        this.name = name
+    }
+
+    @@NonNull
+    String getName() {
+        name
+    }
+}
+
+@@Singleton
+class BookRepository {
+
+    @@StoreReturn
+    Book performUpdate(@@NonNull Book book) {
+        return book;
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/microstream/bookjava.rocker.raw
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/microstream/bookjava.rocker.raw
@@ -1,0 +1,34 @@
+package example.micronaut;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.microstream.annotations.StoreReturn;
+import io.micronaut.serde.annotation.Serdeable;
+
+import jakarta.inject.Singleton;
+import jakarta.validation.constraints.NotBlank;
+
+@@Serdeable
+public class Book {
+
+    @@NonNull
+    @@NotBlank
+    private final String name;
+
+    public Book(@@NonNull String name) {
+        this.name = name;
+    }
+
+    @@NonNull
+    public String getName() {
+        return name;
+    }
+}
+
+@@Singleton
+class BookRepository {
+
+    @@StoreReturn
+    Book performUpdate(@@NonNull Book book) {
+        return book;
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/microstream/bookkotlin.rocker.raw
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/microstream/bookkotlin.rocker.raw
@@ -1,0 +1,17 @@
+package example.micronaut
+
+import io.micronaut.microstream.annotations.StoreReturn
+import io.micronaut.serde.annotation.Serdeable
+
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotBlank
+
+@@Serdeable
+public data class Book(@@field:NotBlank val name: String)
+
+@@Singleton
+open class BookRepository {
+
+    @@StoreReturn
+    open fun performUpdate(book: Book) = book
+}


### PR DESCRIPTION
As with https://github.com/micronaut-projects/micronaut-starter/pull/2052 we need to add an exclusion to prevent different versions of micronaut-core ending up in the annotation classpath