### PR TITLE
Exclude micronaut-core from spring-annotations

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/spring/Spring.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/spring/Spring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,9 @@ package io.micronaut.starter.feature.spring;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
-import io.micronaut.starter.build.dependencies.Scope;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.options.BuildTool;
-import io.micronaut.starter.options.Language;
 import jakarta.inject.Singleton;
 
 import static io.micronaut.starter.build.dependencies.MicronautDependencyUtils.coreDependency;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/spring/Spring.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/spring/Spring.java
@@ -18,9 +18,14 @@ package io.micronaut.starter.feature.spring;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.Scope;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.options.Language;
 import jakarta.inject.Singleton;
+
+import static io.micronaut.starter.build.dependencies.MicronautDependencyUtils.coreDependency;
 
 @Singleton
 public class Spring implements Feature {
@@ -48,7 +53,18 @@ public class Spring implements Feature {
                 .versionProperty("micronaut.spring.version")
                 .template();
 
-        generatorContext.addDependency(springAnnotation.annotationProcessor());
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
+            generatorContext.addDependency(springAnnotation
+                    .annotationProcessor()
+                    .exclude(coreDependency()
+                            .artifactId("micronaut-core")
+                            .compile()
+                            .build()
+                    )
+            );
+        } else {
+            generatorContext.addDependency(springAnnotation.annotationProcessor());
+        }
         generatorContext.addDependency(springAnnotation.testAnnotationProcessor());
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.springframework.boot")

--- a/starter-core/src/main/java/io/micronaut/starter/feature/spring/SpringBoot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/spring/SpringBoot.java
@@ -25,13 +25,15 @@ import jakarta.inject.Singleton;
 @Singleton
 public class SpringBoot extends SpringFeature {
 
+    public static final String NAME = "spring-boot";
+
     public SpringBoot(Spring spring) {
         super(spring);
     }
 
     @Override
     public String getName() {
-        return "spring-boot";
+        return NAME;
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringBootSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringBootSpec.groovy
@@ -101,6 +101,12 @@ class SpringBootSpec extends ApplicationContextSpec {
               <groupId>io.micronaut.spring</groupId>
               <artifactId>micronaut-spring-annotation</artifactId>
               <version>\${micronaut.spring.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-core</artifactId>
+                </exclusion>
+              </exclusions>
             </path>
 """)
         when:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringDataJdbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringDataJdbcSpec.groovy
@@ -96,6 +96,12 @@ class SpringDataJdbcSpec extends ApplicationContextSpec {
               <groupId>io.micronaut.spring</groupId>
               <artifactId>micronaut-spring-annotation</artifactId>
               <version>\${micronaut.spring.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-core</artifactId>
+                </exclusion>
+              </exclusions>
             </path>
 """)
     }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringDataJpaSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringDataJpaSpec.groovy
@@ -104,6 +104,12 @@ class SpringDataJpaSpec extends ApplicationContextSpec {
               <groupId>io.micronaut.spring</groupId>
               <artifactId>micronaut-spring-annotation</artifactId>
               <version>\${micronaut.spring.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-core</artifactId>
+                </exclusion>
+              </exclusions>
             </path>
 """)
     }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringSpec.groovy
@@ -91,6 +91,12 @@ class SpringSpec extends ApplicationContextSpec  implements CommandOutputFixture
               <groupId>io.micronaut.spring</groupId>
               <artifactId>micronaut-spring-annotation</artifactId>
               <version>\${micronaut.spring.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-core</artifactId>
+                </exclusion>
+              </exclusions>
             </path>
 """)
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringWebSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/spring/SpringWebSpec.groovy
@@ -123,6 +123,12 @@ class SpringWebSpec extends ApplicationContextSpec {
               <groupId>io.micronaut.spring</groupId>
               <artifactId>micronaut-spring-annotation</artifactId>
               <version>\${micronaut.spring.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-core</artifactId>
+                </exclusion>
+              </exclusions>
             </path>
 """)
         when:

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/spring/SpringSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/spring/SpringSpec.groovy
@@ -1,0 +1,71 @@
+package io.micronaut.starter.core.test.feature.spring
+
+import io.micronaut.starter.feature.config.Yaml
+import io.micronaut.starter.feature.jaxrs.JaxRs
+import io.micronaut.starter.feature.spring.SpringBoot
+import io.micronaut.starter.feature.validator.MicronautValidationFeature
+import io.micronaut.starter.io.ConsoleOutput
+import io.micronaut.starter.io.FileSystemOutputHandler
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.template.RockerWritable
+import io.micronaut.starter.test.BuildToolTest
+import io.micronaut.starter.test.CommandSpec
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.IgnoreIf
+import spock.lang.Unroll
+
+class SpringSpec extends CommandSpec {
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "spring"
+    }
+
+    @IgnoreIf({ BuildToolTest.IGNORE_MAVEN })
+    @Unroll
+    void "test maven spring with #language"(Language language) {
+        when:
+        generateProject(language, BuildTool.MAVEN, [Yaml.NAME, SpringBoot.NAME])
+
+        and:
+        // Write a class that requires serialization
+        def fsoh = new FileSystemOutputHandler(dir, ConsoleOutput.NOOP)
+        fsoh.write(
+                "src/main/${language.name}/example/micronaut/Book.${language.extension}",
+                new RockerWritable(Class.forName("${this.class.package.name}.book${language.name}").template())
+        )
+
+        and:
+        String output = executeMaven("compile")
+
+        then:
+        output?.contains("BUILD SUCCESS")
+
+        where:
+        language << Language.values() - Language.GROOVY
+    }
+
+    @Unroll
+    void "test gradle jax-rs with #language"(Language language) {
+        when:
+        generateProject(language, BuildTool.GRADLE, [Yaml.NAME, SpringBoot.NAME])
+
+        and:
+        // Write a class that requires serialization
+        def fsoh = new FileSystemOutputHandler(dir, ConsoleOutput.NOOP)
+        fsoh.write(
+                "src/main/${language.name}/example/micronaut/Book.${language.extension}",
+                new RockerWritable(Class.forName("${this.class.package.name}.book${language.name}").template())
+        )
+
+        and:
+        BuildResult result = executeGradle("compileJava")
+
+        then:
+        result?.output?.contains("BUILD SUCCESS")
+
+        where:
+        language << Language.values()
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/spring/bookgroovy.rocker.raw
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/spring/bookgroovy.rocker.raw
@@ -1,0 +1,19 @@
+package example.micronaut
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@@Component
+@@ConfigurationProperties("greeting")
+class Book {
+
+    private String template = "Hello, %s!"
+
+    String getTemplate() {
+        return template
+    }
+
+    void setTemplate(String template) {
+        this.template = template
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/spring/bookjava.rocker.raw
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/spring/bookjava.rocker.raw
@@ -1,0 +1,19 @@
+package example.micronaut;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@@Component
+@@ConfigurationProperties("greeting")
+public class Book {
+
+    private String template = "Hello, %s!";
+
+    public String getTemplate() {
+        return template;
+    }
+
+    public void setTemplate(String template) {
+        this.template = template;
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/spring/bookkotlin.rocker.raw
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/spring/bookkotlin.rocker.raw
@@ -1,0 +1,8 @@
+package example.micronaut
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@@Component
+@@ConfigurationProperties("greeting")
+data class Book(var template: String = "Hello, %s!")


### PR DESCRIPTION
As with https://github.com/micronaut-projects/micronaut-starter/pull/2052 we need to add an exclusion to prevent different versions of micronaut-core ending up in the annotation classpath

There's another issue that it doesn't work with Groovy and Maven

I don't know why...  Any ideas what's missing @alvarosanchez?

(to reproduce, re-enable groovy in the test-func maven test in this PR)