### PR TITLE
Enhancements to BuildTestVerifier API

### DIFF
--- a/starter-core/src/test/groovy/io/micronaut/starter/build/BuildTestUtil.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/BuildTestUtil.groovy
@@ -14,7 +14,7 @@ class BuildTestUtil {
                                       Language language,
                                       TestFramework testFramework,
                                       String template) {
-        buildTool.isGradle() ? new GradleBuildTestVerifier(template, language, testFramework) : new MavenBuildTestVerifier(template)
+        buildTool.isGradle() ? new GradleBuildTestVerifier(template, language, testFramework) : new MavenBuildTestVerifier(template, language)
     }
 
     static BuildTestVerifier verifier(BuildTool buildTool,

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/BuildTestVerifier.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/BuildTestVerifier.groovy
@@ -19,6 +19,8 @@ interface BuildTestVerifier {
 
     boolean hasDependency(String groupId, String artifactId)
 
+    boolean hasExclusion(String groupId, String artifactId)
+
     boolean hasTestResourceDependency(String groupId, String artifactId)
 
     boolean hasTestResourceDependency(String artifactId)

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifier.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifier.groovy
@@ -64,6 +64,14 @@ class GradleBuildTestVerifier implements BuildTestVerifier {
     }
 
     @Override
+    boolean hasExclusion(String groupId, String artifactId) {
+        // GRADLE: exclude(group: "io.micronaut.sql", module: "micronaut-hibernate-jpa")
+        // GRADLE_KOTLIN: exclude(group = "io.micronaut.sql", module = "micronaut-hibernate-jpa")
+        String pattern = /(?s).*exclude\(group\s?[:=]\s*"${groupId}", module\s?[:=]\s*"${artifactId}"\)\s*/
+        Pattern.compile(pattern).matcher(template).find()
+    }
+
+    @Override
     boolean hasTestResourceDependency(String groupId, String artifactId) {
         hasDependency(groupId, artifactId, Scope.TEST_RESOURCES_SERVICE)
     }

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifierSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/gradle/GradleBuildTestVerifierSpec.groovy
@@ -24,4 +24,18 @@ class GradleBuildTestVerifierSpec extends Specification {
         false    | 'implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-function-http")'       |  "io.micronaut.oraclecloud" | "micronaut-oraclecloud-function"      | GradleConfiguration.IMPLEMENTATION.toString()
 
     }
+
+    void "hasExclusionRegex" () {
+        given:
+        GradleBuildTestVerifier verifier = new GradleBuildTestVerifier(template, Language.JAVA, TestFramework.JUNIT)
+
+        expect:
+        expected == verifier.hasExclusion(groupId, artifactId)
+
+        where:
+        expected | template | groupId | artifactId
+        false    | 'implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-function-http")' |  "io.micronaut.oraclecloud" | "micronaut-oraclecloud-function-http"
+        true     | 'exclude(group: "io.micronaut.sql", module: "micronaut-hibernate-jpa"))'         |  "io.micronaut.sql"         | "micronaut-hibernate-jpa"
+        true     | 'exclude(group = "io.micronaut.sql", module = "micronaut-hibernate-jpa")'        |  "io.micronaut.sql"         | "micronaut-hibernate-jpa"
+    }
 }


### PR DESCRIPTION
- Add Gradle/Maven hasExclusions method to test if dependencies have a specified exclusion
- Fix Maven hasAnnotationProcessor method to add support for Groovy and Kotlin

@timyates @sdelamo If this looks good I woulld like to get it merged ASAP. I need it for a 3.10.x bugfix.