### PR TITLE
Fix aws tests

### DIFF
--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AmazonApiGatewayHttpSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/AmazonApiGatewayHttpSpec.groovy
@@ -47,14 +47,14 @@ class AmazonApiGatewayHttpSpec extends ApplicationContextSpec implements Command
 
     void 'lambda runtime main class configuration is present for amazon-api-gateway-http and build #buildTool'(BuildTool buildTool) {
         when:
-        Map<String, String> output = generate(ApplicationType.DEFAULT, options, [AmazonApiGatewayHttp.NAME])
+        Map<String, String> output = generate(ApplicationType.DEFAULT, options.withBuildTool(buildTool), [AmazonApiGatewayHttp.NAME])
 
         then:
         if (buildTool == BuildTool.GRADLE) {
             assert output['build.gradle']
             assert output['build.gradle'].contains('nativeLambda {')
             assert output['build.gradle'].contains('lambdaRuntimeClassName = "io.micronaut.function.aws.runtime.APIGatewayV2HTTPEventMicronautLambdaRuntime"')
-        } else if (buildTool == BuildTool.GRADLE) {
+        } else if (buildTool == BuildTool.GRADLE_KOTLIN) {
             assert output['build.gradle.kts']
             assert output['build.gradle.kts'].contains('nativeLambda {')
             assert output['build.gradle.kts'].contains('lambdaRuntimeClassName.set("io.micronaut.function.aws.runtime.APIGatewayV2HTTPEventMicronautLambdaRuntime")')

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/LambdaFunctionUrlSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/LambdaFunctionUrlSpec.groovy
@@ -59,7 +59,7 @@ class LambdaFunctionUrlSpec extends ApplicationContextSpec implements CommandOut
             assert output['app/build.gradle']
             assert output['app/build.gradle'].contains('nativeLambda {')
             assert output['app/build.gradle'].contains('lambdaRuntimeClassName = "io.micronaut.function.aws.runtime.MicronautLambdaRuntime"')
-        } else if (buildTool == BuildTool.GRADLE) {
+        } else if (buildTool == BuildTool.GRADLE_KOTLIN) {
             assert output['app/build.gradle.kts']
             assert output['app/build.gradle.kts'].contains('nativeLambda {')
             assert output['app/build.gradle.kts'].contains('lambdaRuntimeClassName.set("io.micronaut.function.aws.runtime.MicronautLambdaRuntime")')


### PR DESCRIPTION
Whilst looking through the build tool defaults, I spotted that these tests didn't check the Gradle-kotlin option.

They both pass, but this just corrects them so they are run