### PR TITLE
enable logback coloring

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/logging/Logback.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/logging/Logback.java
@@ -32,7 +32,7 @@ import java.util.Set;
 
 @Singleton
 public class Logback implements LoggingFeature, DefaultFeature {
-
+    public static final boolean DEFAULT_COLORING = true;
     private static final boolean USE_JANSI = false;
     private static final Dependency LOGBACK_CLASSIC = Dependency.builder()
             .groupId("ch.qos.logback")
@@ -70,7 +70,7 @@ public class Logback implements LoggingFeature, DefaultFeature {
 
     protected void addConfig(GeneratorContext generatorContext) {
         generatorContext.addTemplate("loggingConfig", new RockerTemplate("src/main/resources/logback.xml",
-                logback.template(useJansi(generatorContext))));
+                logback.template(useJansi(generatorContext), DEFAULT_COLORING)));
     }
 
     protected boolean useJansi(@NonNull GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/logging/template/logback.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/logging/template/logback.rocker.raw
@@ -1,4 +1,4 @@
-@args (boolean jansi)
+@args (boolean jansi, boolean coloring)
 
 <configuration>
 
@@ -9,7 +9,7 @@
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-@if(jansi) {
+@if(coloring) {
             <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
 } else {
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/LogbackSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/LogbackSpec.groovy
@@ -15,7 +15,7 @@ class LogbackSpec extends ApplicationContextSpec  implements CommandOutputFixtur
     @Shared
     Options options = new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, AwsLambdaFeatureValidator.firstSupportedJdk())
 
-    void 'by default jansi true'() {
+    void 'by default jansi false and coloring true'() {
         when:
         Map<String, String> output = generate([])
         String xml = output["src/main/resources/logback.xml"]
@@ -23,8 +23,8 @@ class LogbackSpec extends ApplicationContextSpec  implements CommandOutputFixtur
         then:
         xml
         !xml.contains("<withJansi>true</withJansi>")
-        !xml.contains("<pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>")
-        xml.contains("<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>")
+        xml.contains("<pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>")
+        !xml.contains("<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>")
     }
 
     void 'with aws-lambda with jansi false since CloudWatch does not works with jansi'() {
@@ -35,6 +35,7 @@ class LogbackSpec extends ApplicationContextSpec  implements CommandOutputFixtur
         then:
         xml
         !xml.contains("<withJansi>true</withJansi>")
-        xml.contains("<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>")
+        !xml.contains("<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>")
+        xml.contains("<pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>")
     }
 }


### PR DESCRIPTION
We removed coloring when we removed jansi true as part of Micronaut Framework 4 upgrade.   https://logback.qos.ch/manual/layouts.html#coloring