### PR TITLE
regression: Enable groovy tests

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/discovery/DiscoveryCore.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/discovery/DiscoveryCore.java
@@ -26,7 +26,8 @@ import jakarta.inject.Singleton;
 
 @Singleton
 public class DiscoveryCore implements Feature {
-    private static final String ARTIFACT_ID_MICRONAUT_DISCOVERY_CORE = "micronaut-discovery-core";
+
+    public static final String ARTIFACT_ID_MICRONAUT_DISCOVERY_CORE = "micronaut-discovery-core";
     private static final Dependency DEPENDENCY_MICRONAUT_DISCOVERY_CORE = MicronautDependencyUtils.coreDependency()
             .artifactId(ARTIFACT_ID_MICRONAUT_DISCOVERY_CORE)
             .compile()

--- a/starter-core/src/main/java/io/micronaut/starter/feature/k8s/KubernetesClient.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/k8s/KubernetesClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,12 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.discovery.DiscoveryCore;
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.options.Language;
 import jakarta.inject.Singleton;
 
 /**
@@ -76,5 +80,18 @@ public class KubernetesClient implements Feature {
                 .groupId(MICRONAUT_KUBERNETES_GROUP_ID)
                 .artifactId("micronaut-kubernetes-client")
                 .compile());
+        fixupDependencies(generatorContext);
+    }
+
+    static void fixupDependencies(GeneratorContext generatorContext) {
+        if (!generatorContext.hasFeature(DiscoveryCore.class)
+                && generatorContext.getBuildTool() == BuildTool.MAVEN
+                && generatorContext.getLanguage() == Language.GROOVY
+        ) {
+            // Maven requires discovery core provided to work with http-validation under groovy
+            generatorContext.addDependency(MicronautDependencyUtils.coreDependency()
+                    .artifactId(DiscoveryCore.ARTIFACT_ID_MICRONAUT_DISCOVERY_CORE)
+                    .compileOnly());
+        }
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/k8s/KubernetesReactorClient.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/k8s/KubernetesReactorClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,5 +89,7 @@ public class KubernetesReactorClient implements Feature {
                 .groupId(KubernetesClient.MICRONAUT_KUBERNETES_GROUP_ID)
                 .artifactId("micronaut-kubernetes-client-reactor")
                 .compile());
+
+        KubernetesClient.fixupDependencies(generatorContext);
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/k8s/KubernetesRxJava2Client.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/k8s/KubernetesRxJava2Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,5 +89,7 @@ public class KubernetesRxJava2Client implements Feature {
                 .groupId(KubernetesClient.MICRONAUT_KUBERNETES_GROUP_ID)
                 .artifactId("micronaut-kubernetes-client-rxjava2")
                 .compile());
+
+        KubernetesClient.fixupDependencies(generatorContext);
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/other/HttpClientTest.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/other/HttpClientTest.java
@@ -71,7 +71,7 @@ public class HttpClientTest implements DefaultFeature {
             generatorContext.addDependency(HttpClient.DEPENDENCY_MICRONAUT_HTTP_CLIENT);
         } else if (generatorContext.getApplicationType() == ApplicationType.DEFAULT) {
             generatorContext.addDependency(DEPENDENCY_MICRONAUT_HTTP_CLIENT_TEST);
-            if (generatorContext.hasFeature(MicronautHttpValidation.class)) {
+            if (generatorContext.hasFeature(MicronautHttpValidation.class) && generatorContext.getBuildTool().isGradle()) {
                 generatorContext.addDependency(DEPENDENCY_MICRONAUT_HTTP_CLIENT_COMPILE_ONLY);
             }
         }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/other/HttpClientTest.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/other/HttpClientTest.java
@@ -25,6 +25,7 @@ import io.micronaut.starter.feature.awslambdacustomruntime.AwsLambdaCustomRuntim
 import io.micronaut.starter.feature.function.awslambda.AwsLambda;
 import io.micronaut.starter.feature.graalvm.GraalVM;
 import io.micronaut.starter.feature.httpclient.HttpClientFeature;
+import io.micronaut.starter.feature.validator.MicronautHttpValidation;
 import io.micronaut.starter.options.Options;
 import jakarta.inject.Singleton;
 import java.util.Set;
@@ -33,9 +34,15 @@ import static io.micronaut.starter.feature.other.HttpClient.ARTIFACT_ID_MICRONAU
 
 @Singleton
 public class HttpClientTest implements DefaultFeature {
+
     private static final Dependency DEPENDENCY_MICRONAUT_HTTP_CLIENT_TEST = MicronautDependencyUtils.coreDependency()
             .artifactId(ARTIFACT_ID_MICRONAUT_HTTP_CLIENT)
             .test()
+            .build();
+
+    private static final Dependency DEPENDENCY_MICRONAUT_HTTP_CLIENT_COMPILE_ONLY = MicronautDependencyUtils.coreDependency()
+            .artifactId(ARTIFACT_ID_MICRONAUT_HTTP_CLIENT)
+            .compileOnly()
             .build();
 
     @Override
@@ -64,6 +71,9 @@ public class HttpClientTest implements DefaultFeature {
             generatorContext.addDependency(HttpClient.DEPENDENCY_MICRONAUT_HTTP_CLIENT);
         } else if (generatorContext.getApplicationType() == ApplicationType.DEFAULT) {
             generatorContext.addDependency(DEPENDENCY_MICRONAUT_HTTP_CLIENT_TEST);
+            if (generatorContext.hasFeature(MicronautHttpValidation.class)) {
+                generatorContext.addDependency(DEPENDENCY_MICRONAUT_HTTP_CLIENT_COMPILE_ONLY);
+            }
         }
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/validator/MicronautHttpValidation.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/validator/MicronautHttpValidation.java
@@ -71,6 +71,7 @@ public class MicronautHttpValidation implements DefaultFeature {
     protected void addDependencies(GeneratorContext generatorContext) {
         generatorContext.addDependency(DEPENDENCY_MICRONAUT_HTTP_VALIDATION);
     }
+
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
         return applicationType == ApplicationType.DEFAULT;

--- a/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateControllerSpec.groovy
+++ b/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateControllerSpec.groovy
@@ -41,7 +41,7 @@ class CreateControllerSpec extends CommandSpec {
         output?.contains("BUILD SUCCESS")
 
         where:
-        [language, buildTool, testFramework] << LanguageBuildTestFrameworkCombinations.combinations().findAll { it[0] != Language.GROOVY }
+        [language, buildTool, testFramework] << LanguageBuildTestFrameworkCombinations.combinations()
     }
 
     @Override

--- a/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateControllerSpec.groovy
+++ b/test-cli/src/test/groovy/io/micronaut/starter/cli/test/CreateControllerSpec.groovy
@@ -9,11 +9,9 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.CommandSpec
 import io.micronaut.starter.test.LanguageBuildTestFrameworkCombinations
-import spock.lang.Unroll
 
 class CreateControllerSpec extends CommandSpec {
 
-    @Unroll
     void "test creating a controller and running the test for #language and #testFramework and #buildTool"(Language language,
                                                                                                            BuildTool buildTool,
                                                                                                            TestFramework testFramework) {

--- a/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
+++ b/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/azure/CreateAzureFunctionSpec.groovy
@@ -31,7 +31,7 @@ class CreateAzureFunctionSpec extends CommandSpec {
         output.contains("BUILD SUCCESS")
 
         where:
-        [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.DEFAULT, ApplicationType.FUNCTION], Language.values() as List<Language>, BuildToolCombinations.buildTools).findAll { it[1] != Language.GROOVY }
+        [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.DEFAULT, ApplicationType.FUNCTION], Language.values() as List<Language>, BuildToolCombinations.buildTools)
     }
 
     void 'default application with features azure-function, #serializationFeature, #lang and #build and test framework: #testFramework'(
@@ -56,6 +56,6 @@ class CreateAzureFunctionSpec extends CommandSpec {
                 ['serialization-jackson', 'serialization-bson', 'serialization-jsonp'],
                 BuildToolCombinations.buildTools,
                 TestFramework.values()
-        ].combinations().findAll { it[0] != Language.GROOVY }
+        ].combinations()
     }
 }

--- a/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/gcp/CreateGoogleCloudFunctionSpec.groovy
+++ b/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/gcp/CreateGoogleCloudFunctionSpec.groovy
@@ -33,6 +33,6 @@ class CreateGoogleCloudFunctionSpec extends CommandSpec {
         output.contains("BUILD SUCCESS")
 
         where:
-        [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.DEFAULT]).findAll { it[1] != Language.GROOVY }
+        [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.DEFAULT])
     }
 }

--- a/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleFunctionSpec.groovy
+++ b/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleFunctionSpec.groovy
@@ -31,7 +31,7 @@ class CreateOracleFunctionSpec extends CommandSpec{
         output.contains("BUILD SUCCESS")
 
         where:
-        [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.DEFAULT], Language.values() as List<Language>, BuildTool.valuesGradle()).findAll { it[1] != Language.GROOVY }
+        [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.DEFAULT], Language.values() as List<Language>, BuildTool.valuesGradle())
     }
 
     void 'default application with features oracle-function, #serializationFeature, #lang and #build and test framework: #testFramework'(
@@ -60,6 +60,6 @@ class CreateOracleFunctionSpec extends CommandSpec{
                 .stream()
                 .filter(it -> !(
                 it[1] == 'serialization-jsonp' || (it[1] == 'serialization-bson' && it[0] == Language.KOTLIN)
-                )).findAll { it[0] != Language.GROOVY }
+                ))
     }
 }

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/k8s/KubernetesClientSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/k8s/KubernetesClientSpec.groovy
@@ -28,7 +28,7 @@ class KubernetesClientSpec extends CommandSpec {
         where:
         [feature, language] << [
                 ["kubernetes-client", "kubernetes-reactor-client", "kubernetes-rxjava2-client"],
-                Language.values()].combinations().findAll { it[1] != Language.GROOVY }
+                Language.values()].combinations()
     }
 
     @Unroll

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/k8s/KubernetesClientSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/k8s/KubernetesClientSpec.groovy
@@ -6,7 +6,6 @@ import io.micronaut.starter.test.BuildToolTest
 import io.micronaut.starter.test.CommandSpec
 import org.gradle.testkit.runner.BuildResult
 import spock.lang.IgnoreIf
-import spock.lang.Unroll
 
 class KubernetesClientSpec extends CommandSpec {
 
@@ -16,7 +15,6 @@ class KubernetesClientSpec extends CommandSpec {
     }
 
     @IgnoreIf({ BuildToolTest.IGNORE_MAVEN })
-    @Unroll
     void "test maven #feature with #language"(String feature, Language language) {
         when:
         generateProject(language, BuildTool.MAVEN, [feature])
@@ -31,7 +29,6 @@ class KubernetesClientSpec extends CommandSpec {
                 Language.values()].combinations()
     }
 
-    @Unroll
     void "test gradle #feature with #language"(String feature, Language language) {
         when:
         generateProject(language, BuildTool.GRADLE, [feature])


### PR DESCRIPTION
We have a regression in groovy support from 4.1.2 to 4.1.3.

Core changes:

https://github.com/micronaut-projects/micronaut-core/compare/v4.1.6...v4.1.8

Starter changes: 

https://github.com/micronaut-projects/micronaut-starter/compare/v4.1.2...v4.1.3

 This PR reverts commit a53a2d7a3138a8795706a3d1ff0d5b5827047d35.