### PR TITLE
build: Check via gradle tasks versions are not snapshots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,18 +20,18 @@ jobs:
       - name: Set the current release version
         id: release_version
         run: echo "release_version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
-      - name: projectVersion is not a snapshot
-        run: ./gradlew projectVersionNotSnapshot
-      - name: Micronaut Core is not a snapshot
-        run: ./gradlew micronautCoreNotSnapshot
-      - name: Micronaut Platform is not a snapshot
-        run: ./gradlew micronautPlatformNotSnapshot
       - name: Run pre-release
         uses: micronaut-projects/github-actions/pre-release@master
         env:
           MICRONAUT_BUILD_EMAIL: ${{ secrets.MICRONAUT_BUILD_EMAIL }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: projectVersion is not a snapshot
+        run: ./gradlew projectVersionNotSnapshot
+      - name: Micronaut Core is not a snapshot
+        run: ./gradlew micronautCoreNotSnapshot
+      - name: Micronaut Platform is not a snapshot
+        run: ./gradlew micronautPlatformNotSnapshot
       - name: Build All
         run: ./gradlew micronaut-cli:assemble
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Set the current release version
         id: release_version
         run: echo "release_version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
+      - name: projectVersion is not a snapshot
+        run: ./gradlew projectVersionNotSnapshot
+      - name: Micronaut Core is not a snapshot
+        run: ./gradlew micronautCoreNotSnapshot
+      - name: Micronaut Platform is not a snapshot
+        run: ./gradlew micronautPlatformNotSnapshot
       - name: Run pre-release
         uses: micronaut-projects/github-actions/pre-release@master
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import io.micronaut.internal.starter.tasks.GradlePropertiesNextSnapshot
+import io.micronaut.internal.starter.tasks.PropertiesNotSnapshot
 
 plugins {
     id "io.micronaut.internal.starter.aggregator"
@@ -14,4 +15,15 @@ tasks.register("micronautCoreNextSnapshot", GradlePropertiesNextSnapshot) {
 
 tasks.register("micronautPlatformNextSnapshot", GradlePropertiesNextSnapshot) {
     propertyName = 'micronautVersion'
+}
+
+tasks.register("micronautCoreNotSnapshot", PropertiesNotSnapshot) {
+    propertyName = 'micronautCoreVersion'
+}
+
+tasks.register("micronautPlatformNotSnapshot", PropertiesNotSnapshot) {
+    propertyName = 'micronautVersion'
+}
+tasks.register("projectVersionNotSnapshot", PropertiesNotSnapshot) {
+    propertyName = 'projectVersion'
 }

--- a/buildSrc/src/main/groovy/io/micronaut/internal/starter/tasks/PropertiesNotSnapshot.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/internal/starter/tasks/PropertiesNotSnapshot.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.internal.starter.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class PropertiesNotSnapshot extends DefaultTask {
+    @Input
+    abstract Property<String> getPropertyName()
+
+    @InputFile
+    abstract RegularFileProperty getGradleProperties()
+
+    PropertiesNotSnapshot() {
+        getGradleProperties().convention(getProject().getLayout().getProjectDirectory().file("gradle.properties"))
+    }
+
+    @TaskAction
+    def validatedPropertiesFile() {
+        File propertiesFile = getGradleProperties().get().asFile
+        Properties properties = new Properties()
+        propertiesFile.withInputStream {
+            properties.load(it)
+        }
+        String key = propertyName.get()
+        String version = properties.get(key)
+        SoftwareVersion softwareVersion = SoftwareVersion.build(version)
+        if (softwareVersion.isSnapshot()) {
+            throw new GradleException("Property $key is a snapshot version: $version")
+        }
+    }
+}


### PR DESCRIPTION
This PR adds Gradle Tasks to ensure a release can be triggered with non snapshot versions of `projectVersion`, `micronautCoreVersion` and micronautVersion`.

These tasks help to have a release with integrity.