### PR TITLE
ci: Manual Release workflow [ci skip]

### DIFF
--- a/.github/workflows/release-manually.yml
+++ b/.github/workflows/release-manually.yml
@@ -1,0 +1,107 @@
+name: Manual Release
+on: workflow_dispatch
+jobs:
+  build:
+    name: Verify versions not Snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+      - uses: gradle/wrapper-validation-action@v1
+      - name: Set up JDK
+        uses: actions/setup-java@v3.11.0
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: projectVersion is not a snapshot
+        run: ./gradlew projectVersionNotSnapshot
+      - name: Micronaut Core is not a snapshot
+        run: ./gradlew micronautCoreNotSnapshot
+      - name: Micronaut Platform is not a snapshot
+        run: ./gradlew micronautPlatformNotSnapshot
+  gcr:
+    name: Deploy to Cloud Run
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Set the current release version
+        id: release_version
+        run: |
+          release_version=${GITHUB_REF:11}
+          sed -i "s/^projectVersion.*$/projectVersion\=${release_version}/" gradle.properties
+          echo "release_version=${release_version}" >> $GITHUB_OUTPUT
+      - name: Run Tests
+        run: ./gradlew starter-api:test starter-web-netty:test starter-gcp-function:shadowJar
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+          GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+      - name: Build Docker image
+        run: |
+          ./gradlew starter-web-netty:dockerBuild -PdockerImageName="gcr.io/${{ secrets.GCLOUD_PROJECT }}/micronaut-starter:latest"
+      - name: Authenticate into Google Cloud Platform
+        uses: google-github-actions/setup-gcloud@v0.2.1
+        with:
+          service_account_email: ${{ secrets.GCLOUD_EMAIL }}
+          service_account_key: ${{ secrets.GCLOUD_AUTH }}
+      - name: Configure Docker to use Google Cloud Platform
+        run: "gcloud auth configure-docker --quiet"
+      - name: Push image to Google Cloud Container Registry
+        run: |
+          ./gradlew starter-web-netty:dockerPush -PdockerImageName="gcr.io/${{ secrets.GCLOUD_PROJECT }}/micronaut-starter:latest"
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud components install beta --quiet
+          gcloud beta run deploy micronaut-starter-latest --quiet --image gcr.io/${{ secrets.GCLOUD_PROJECT }}/micronaut-starter:latest --project ${{ secrets.GCLOUD_PROJECT }} --region  us-central1 --update-env-vars=HOSTNAME="launch.micronaut.io",GITHUB_OAUTH_APP_CLIENT_ID=${{ secrets.GH_OAUTH_CLIENT_ID }},GITHUB_OAUTH_APP_CLIENT_SECRET=${{ secrets.GH_OAUTH_CLIENT_SECRET }} --platform managed --allow-unauthenticated --service-account=${{ secrets.GCLOUD_EMAIL }}
+  analytics:
+    name: Release Analytics Job
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Authenticate into Google Cloud Platform
+        uses: google-github-actions/setup-gcloud@v0.2.1
+        with:
+          service_account_email: ${{ secrets.GCLOUD_EMAIL }}
+          service_account_key: ${{ secrets.GCLOUD_AUTH }}
+      - name: Configure Docker to use Google Cloud Platform
+        run: "gcloud auth configure-docker --quiet"
+      - name: Run Tests
+        run: ./gradlew starter-analytics-postgres:test
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+          GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
+      - name: Build Docker image and Push it GCR
+        run:
+          ./gradlew dockerPush
+        env:
+          DOCKER_TAG: latest
+          GCLOUD_PROJECT: ${{ secrets.GCLOUD_PROJECT }}
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+          GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud components install beta --quiet
+          gcloud beta run deploy micronaut-starter-analytics --quiet --image gcr.io/${{ secrets.GCLOUD_PROJECT }}/micronaut-starter-analytics:latest --project ${{ secrets.GCLOUD_PROJECT }} --region  us-central1 --platform managed --service-account=${{ secrets.GCLOUD_EMAIL }}

--- a/.github/workflows/release-manually.yml
+++ b/.github/workflows/release-manually.yml
@@ -1,4 +1,4 @@
-name: Manual Release
+name: Manual Release to GCR
 on: workflow_dispatch
 jobs:
   build:

--- a/.github/workflows/release-manually.yml
+++ b/.github/workflows/release-manually.yml
@@ -35,12 +35,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Set the current release version
-        id: release_version
-        run: |
-          release_version=${GITHUB_REF:11}
-          sed -i "s/^projectVersion.*$/projectVersion\=${release_version}/" gradle.properties
-          echo "release_version=${release_version}" >> $GITHUB_OUTPUT
       - name: Run Tests
         run: ./gradlew starter-api:test starter-web-netty:test starter-gcp-function:shadowJar
         env:

--- a/.github/workflows/release-manually.yml
+++ b/.github/workflows/release-manually.yml
@@ -1,4 +1,4 @@
-name: Manual Release to GCR
+name: Manual Release to GCR # Commit micronautCoreVersion, micronautVersion (platform), and projectVersion manually to not snapshot versions. Then, run this workflow via the GitHub Actions UI.
 on: workflow_dispatch
 jobs:
   build:


### PR DESCRIPTION
Close #2097

Uses a docker tag `latest` to release `analytics` and `starter` to Google Cloud Run. 