### PR TITLE
Fix Swagger

### DIFF
--- a/starter-web-netty/src/main/resources/application.yml
+++ b/starter-web-netty/src/main/resources/application.yml
@@ -4,6 +4,12 @@ micronaut:
       swagger:
         paths: classpath:META-INF/swagger
         mapping: /swagger/**
+      swagger-ui:
+        paths: classpath:META-INF/swagger/views/swagger-ui
+        mapping: /swagger-ui/**
+      rapidoc:
+        paths: classpath:META-INF/swagger/views/rapidoc
+        mapping: /rapidoc/**
   server:
     cors:
       enabled: true

--- a/starter-web-netty/src/test/groovy/io/micronaut/starter/netty/OpenAPISpec.groovy
+++ b/starter-web-netty/src/test/groovy/io/micronaut/starter/netty/OpenAPISpec.groovy
@@ -1,0 +1,60 @@
+package io.micronaut.starter.netty
+
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class OpenAPISpec extends Specification {
+
+    @Inject
+    EmbeddedServer server
+
+    @Client("/")
+    @Inject
+    HttpClient client
+
+    void "test swagger-ui"() {
+        when:
+        def response = server.getURI().resolve("/swagger-ui").toURL().text
+
+        List<String> matches = (response =~ /(?:src|href)=['"]([^'"]+)['"]/).collect { it[1] as String }
+        String yml = (response =~ /['"]([^'"]+\.yml)['"]/)[0][1]
+
+        then:
+        matches.size()
+        yml
+
+        and:
+        server.getURI().resolve(yml).toURL().text.contains("title: Micronaut Launch")
+
+        and:
+        matches.each {
+            assert client.toBlocking().exchange(it).status() == HttpStatus.OK
+        }
+    }
+
+    void "test rapidoc"() {
+        when:
+        def response = server.getURI().resolve("/rapidoc").toURL().text
+
+        List<String> matches = (response =~ /(?:src|href)=['"]([^'"]+)['"]/).collect { it[1] as String }
+        String yml = (response =~ /['"]([^'"]+\.yml)['"]/)[0][1]
+
+        then:
+        matches.size()
+        yml
+
+        and:
+        server.getURI().resolve(yml).toURL().text.contains("title: Micronaut Launch")
+
+        and:
+        matches.each {
+            assert client.toBlocking().exchange(it).status() == HttpStatus.OK
+        }
+    }
+}

--- a/starter-web-servlet/src/main/resources/application.properties
+++ b/starter-web-servlet/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 micronaut.router.static-resources.swagger.paths=classpath:META-INF/swagger
 micronaut.router.static-resources.swagger.mapping=/swagger/**
-
+micronaut.router.static-resources.swagger-ui.paths=classpath:META-INF/swagger/views/swagger-ui
+micronaut.router.static-resources.swagger-ui.mapping=/swagger-ui/**
+micronaut.router.static-resources.rapidoc.paths=classpath:META-INF/swagger/views/rapidoc
+micronaut.router.static-resources.rapidoc.mapping=/rapidoc/**

--- a/starter-web-servlet/src/test/groovy/io/micronaut/starter/servlet/OpenAPISpec.groovy
+++ b/starter-web-servlet/src/test/groovy/io/micronaut/starter/servlet/OpenAPISpec.groovy
@@ -1,0 +1,60 @@
+package io.micronaut.starter.servlet
+
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class OpenAPISpec extends Specification {
+
+    @Inject
+    EmbeddedServer server
+
+    @Client("/")
+    @Inject
+    HttpClient client
+
+    void "test swagger-ui"() {
+        when:
+        def response = server.getURI().resolve("/swagger-ui").toURL().text
+
+        List<String> matches = (response =~ /(?:src|href)=['"]([^'"]+)['"]/).collect { it[1] as String }
+        String yml = (response =~ /['"]([^'"]+\.yml)['"]/)[0][1]
+
+        then:
+        matches.size()
+        yml
+
+        and:
+        server.getURI().resolve(yml).toURL().text.contains("title: Micronaut Launch")
+
+        and:
+        matches.each {
+            assert client.toBlocking().exchange(it).status() == HttpStatus.OK
+        }
+    }
+
+    void "test rapidoc"() {
+        when:
+        def response = server.getURI().resolve("/rapidoc").toURL().text
+
+        List<String> matches = (response =~ /(?:src|href)=['"]([^'"]+)['"]/).collect { it[1] as String }
+        String yml = (response =~ /['"]([^'"]+\.yml)['"]/)[0][1]
+
+        then:
+        matches.size()
+        yml
+
+        and:
+        server.getURI().resolve(yml).toURL().text.contains("title: Micronaut Launch")
+
+        and:
+        matches.each {
+            assert client.toBlocking().exchange(it).status() == HttpStatus.OK
+        }
+    }
+}


### PR DESCRIPTION
We seem to be missing the static resource mapping for swagger and rapidoc.

This change adds the 2 static-resource mappings in to the config so they work again.

Run locally with `./gradlew :s-w-n:run` and then navigate to

http://localhost:8080/rapidoc/index.html
http://localhost:8080/swagger-ui/index.html