### PR TITLE
Prepare starter to create dockerBuildCrac

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ plugins {
     // https://github.com/bmuschko/gradle-docker-plugin/issues/1123
     // https://github.com/gradle/gradle/issues/17559
     id("com.bmuschko.docker-remote-api") version "9.0.1" apply false
-    id("io.micronaut.application") version(templateLibs.versions.micronaut.gradle.plugin.get()) apply false
-    id("io.micronaut.crac") version version(templateLibs.versions.micronaut.gradle.plugin.get()) apply false
+    id("io.micronaut.application") version(templateLibs.versions.micronaut.gradle.plugin) apply false
+    id("io.micronaut.crac") version(templateLibs.versions.micronaut.gradle.plugin) apply false
 }
 
 tasks.register("micronautCoreNextSnapshot", GradlePropertiesNextSnapshot) {

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ plugins {
     // https://github.com/bmuschko/gradle-docker-plugin/issues/1123
     // https://github.com/gradle/gradle/issues/17559
     id("com.bmuschko.docker-remote-api") version "9.0.1" apply false
+    id("io.micronaut.application") version(templateLibs.versions.micronaut.gradle.plugin.get()) apply false
+    id("io.micronaut.crac") version version(templateLibs.versions.micronaut.gradle.plugin.get()) apply false
 }
 
 tasks.register("micronautCoreNextSnapshot", GradlePropertiesNextSnapshot) {

--- a/starter-analytics-postgres/build.gradle.kts
+++ b/starter-analytics-postgres/build.gradle.kts
@@ -2,7 +2,7 @@ import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 
 plugins {
     id("io.micronaut.internal.starter.convention")
-    alias(templateLibs.plugins.micronaut.application)
+    id("io.micronaut.application")
 }
 
 dependencies {

--- a/starter-aws-lambda/build.gradle
+++ b/starter-aws-lambda/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "io.micronaut.internal.starter.convention"
-    alias(templateLibs.plugins.micronaut.application)
+    id "io.micronaut.application"
 }
 
 micronaut {

--- a/starter-cli/build.gradle
+++ b/starter-cli/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'io.micronaut.internal.build.starter-cli-module'
-    alias(templateLibs.plugins.micronaut.application)
+    id "io.micronaut.application"
 }
 
 ext {

--- a/starter-web-netty/build.gradle
+++ b/starter-web-netty/build.gradle
@@ -1,7 +1,8 @@
 plugins {
     id "io.micronaut.internal.starter.convention"
     id "com.github.johnrengelman.shadow"
-    alias(templateLibs.plugins.micronaut.application)
+    id "io.micronaut.crac"
+    id "io.micronaut.application"
 }
 
 ext.publish = false
@@ -14,6 +15,7 @@ dependencies {
     implementation project(":starter-api")
     implementation "io.micronaut.gcp:micronaut-gcp-http-client"
     runtimeOnly "ch.qos.logback:logback-classic"
+    implementation "io.micronaut.crac:micronaut-crac"
 
     annotationProcessor("io.micronaut.serde:micronaut-serde-processor")
     implementation("io.micronaut.serde:micronaut-serde-jackson")

--- a/test-suite-graal/build.gradle
+++ b/test-suite-graal/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "io.micronaut.build.internal.common"
-    alias(templateLibs.plugins.micronaut.application)
+    id "io.micronaut.application"
 }
 
 repositories {


### PR DESCRIPTION
Supersedes https://github.com/micronaut-projects/micronaut-starter/pull/1805 targetting 4.2.x.

Stops using alias to work around Gradle bug.