### PR TITLE
Configure compileTestResourcesKotlin when using Kotest or Kotlin

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -57,7 +57,7 @@ application {
 }
 
 java {
-@if (features.language().isKotlin()) {
+@if (features.testFramework().isKotlinTestFramework() || features.language().isKotlin()) {
     sourceCompatibility = JavaVersion.toVersion("@features.getTargetJdk(17)")
 } else {
     sourceCompatibility = JavaVersion.toVersion("@features.getTargetJdk()")
@@ -89,6 +89,15 @@ tasks {
 
 @if (features.testFramework().isKotlinTestFramework() || features.language().isKotlin()) {
     compileTestKotlin {
+        compilerOptions {
+@if(gradleBuild.getDsl() == GradleDsl.KOTLIN) {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_@features.getTargetJdk(17))
+} else {
+           jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_@features.getTargetJdk(17)
+}
+        }
+    }
+    compileTestResourcesKotlin {
         compilerOptions {
 @if(gradleBuild.getDsl() == GradleDsl.KOTLIN) {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_@features.getTargetJdk(17))

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/test/SpockSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/test/SpockSpec.groovy
@@ -54,26 +54,44 @@ java {
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-starter/issues/514")
-    void 'With Kotlin or KoTest and JDK17 the sourceCompatibility is JDK17'() {
+    void 'With Kotlin or KoTest and #jdk the sourceCompatibility is JDK17'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
                 .language(language)
-                .jdkVersion(JdkVersion.JDK_17)
+                .jdkVersion(jdk)
                 .testFramework(testFramework)
                 .render()
 
         then:
-        template.contains("sourceCompatibility = JavaVersion.toVersion(\"17\")")
+        template.contains('sourceCompatibility = JavaVersion.toVersion("17")')
+
+        and: 'compilation option is defined for kotlin projects'
         template.contains('''\
+    compileKotlin {
         compilerOptions {
            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
         }
-''')
+    }''') == (language == Language.KOTLIN)
+
+        and: 'compilation option is defined for kotlin test projects'
+        template.contains('''\
+    compileTestKotlin {
+        compilerOptions {
+           jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
+    }
+    compileTestResourcesKotlin {
+        compilerOptions {
+           jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
+    }''')
 
         where:
-        language        | testFramework
-        Language.KOTLIN | TestFramework.JUNIT
-        Language.JAVA   | TestFramework.KOTEST
+        language        | testFramework        | jdk
+        Language.KOTLIN | TestFramework.JUNIT  | JdkVersion.JDK_17
+        Language.KOTLIN | TestFramework.JUNIT  | JdkVersion.JDK_21
+        Language.JAVA   | TestFramework.KOTEST | JdkVersion.JDK_17
+        Language.JAVA   | TestFramework.KOTEST | JdkVersion.JDK_21
     }
 
     void 'test spock with Maven applies gmavenplus plugin'() {


### PR DESCRIPTION
Previously we configured compileKotlin and compileTestKotlin when using Kotest or Kotlin and Java 21.

This failed with one of the guides when generated with Java 21 https://ge.micronaut.io/s/kbdu4j2l3qg44/console-log?page=2#L1057

This is because we were not comfiguring kotlinTestResources as well.