### PR TITLE
Add jul-to-slf4j feature

### DIFF
--- a/gradle/templates.versions.toml
+++ b/gradle/templates.versions.toml
@@ -58,6 +58,7 @@ rocker-gradle-plugin = "3.0.4"
 rocker-maven-plugin = "1.3.0"
 scram-client = "2.1"
 slf4j = "1.7.36"
+jul-to-slf4j="2.0.9"
 slf4j-simple-logger = "2.0.0"
 zeebe-micronaut-client = "1.14.0"
 ktor = "2.2.4"
@@ -114,6 +115,7 @@ ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.
 kotlin-noarg = { module = "org.jetbrains.kotlin:kotlin-noarg", version.ref = "kotlin" }
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
+jul-to-slf4j = { module = "org.slf4j:jul-to-slf4j", version.ref = "jul-to-slf4j" }
 log4j-over-slf4j = { module = "org.slf4j:log4j-over-slf4j", version.ref = "slf4j" }
 log4j-slf4j = { module = "org.apache.logging.log4j:log4j-slf4j-impl", version.ref = "log4j" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/logging/Logback.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/logging/Logback.java
@@ -34,6 +34,7 @@ import java.util.Set;
 public class Logback implements LoggingFeature, DefaultFeature {
     public static final boolean DEFAULT_COLORING = true;
     private static final boolean USE_JANSI = false;
+    private static final boolean DEFAULT_JUL = false;
     private static final Dependency LOGBACK_CLASSIC = Dependency.builder()
             .groupId("ch.qos.logback")
             .artifactId("logback-classic")
@@ -64,13 +65,13 @@ public class Logback implements LoggingFeature, DefaultFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        addConfig(generatorContext);
-        generatorContext.addDependency(LOGBACK_CLASSIC);
+        addConfig(generatorContext, DEFAULT_JUL);
+        addDependency(generatorContext);
     }
 
-    protected void addConfig(GeneratorContext generatorContext) {
+    protected void addConfig(GeneratorContext generatorContext, boolean useJul) {
         generatorContext.addTemplate("loggingConfig", new RockerTemplate("src/main/resources/logback.xml",
-                logback.template(useJansi(generatorContext), DEFAULT_COLORING)));
+                logback.template(useJansi(generatorContext), DEFAULT_COLORING, useJul)));
     }
 
     protected boolean useJansi(@NonNull GeneratorContext generatorContext) {
@@ -81,6 +82,10 @@ public class Logback implements LoggingFeature, DefaultFeature {
             return false;
         }
         return USE_JANSI;
+    }
+
+    protected void addDependency(GeneratorContext generatorContext) {
+        generatorContext.addDependency(LOGBACK_CLASSIC);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/logging/Logback.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/logging/Logback.java
@@ -34,7 +34,6 @@ import java.util.Set;
 public class Logback implements LoggingFeature, DefaultFeature {
     public static final boolean DEFAULT_COLORING = true;
     private static final boolean USE_JANSI = false;
-    private static final boolean DEFAULT_JUL = false;
     private static final Dependency LOGBACK_CLASSIC = Dependency.builder()
             .groupId("ch.qos.logback")
             .artifactId("logback-classic")
@@ -65,7 +64,7 @@ public class Logback implements LoggingFeature, DefaultFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        addConfig(generatorContext, DEFAULT_JUL);
+        addConfig(generatorContext, generatorContext.hasFeature(Slf4jJulBridge.class));
         addDependency(generatorContext);
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/logging/Slf4jJulBridge.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/logging/Slf4jJulBridge.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.logging;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.feature.logging.template.julToSlf4j;
+import io.micronaut.starter.template.RockerTemplate;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class Slf4jJulBridge implements LoggingFeature {
+
+    private final Logback logback;
+    private static final boolean USE_JUL = true;
+    private static final Dependency JUL_TO_SLF4J = Dependency.builder()
+            .groupId("org.slf4j")
+            .artifactId("jul-to-slf4j")
+            .version("2.0.9")
+            .runtime()
+            .build();
+
+    public Slf4jJulBridge(Logback logback) {
+        this.logback = logback;
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return "jul-to-slf4j";
+    }
+
+    @Override
+    public String getTitle() {
+        return "SLF4J JUL Bridge";
+    }
+
+    @Override
+    @NonNull
+    public String getDescription() {
+        return "Java Util Logging bridge for SLF4J with Logback.";
+    }
+
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://www.slf4j.org/legacy.html#jul-to-slf4jBridge";
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        logback.addConfig(generatorContext, USE_JUL);
+        addLoggingProperties(generatorContext);
+        logback.addDependency(generatorContext);
+        generatorContext.addDependency(JUL_TO_SLF4J);
+    }
+
+    protected void addLoggingProperties(GeneratorContext generatorContext) {
+        generatorContext.addTemplate("loggingProperties", new RockerTemplate("src/main/resources/logging.properties", julToSlf4j.template()));
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/logging/Slf4jJulBridge.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/logging/Slf4jJulBridge.java
@@ -19,18 +19,17 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.feature.Category;
+import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.logging.template.julToSlf4j;
 import io.micronaut.starter.template.RockerTemplate;
 import jakarta.inject.Singleton;
 
 @Singleton
-public class Slf4jJulBridge implements LoggingFeature {
-
-    private static final boolean USE_JUL = true;
-    private final Logback logback;
-
-    public Slf4jJulBridge(Logback logback) {
-        this.logback = logback;
+public class Slf4jJulBridge implements Feature {
+    @Override
+    public String getCategory() {
+        return Category.LOGGING;
     }
 
     @Override
@@ -57,9 +56,7 @@ public class Slf4jJulBridge implements LoggingFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        logback.addConfig(generatorContext, USE_JUL);
         addLoggingProperties(generatorContext);
-        logback.addDependency(generatorContext);
         generatorContext.addDependency(Dependency.builder().lookupArtifactId("jul-to-slf4j").runtime());
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/logging/Slf4jJulBridge.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/logging/Slf4jJulBridge.java
@@ -27,12 +27,6 @@ import jakarta.inject.Singleton;
 public class Slf4jJulBridge implements LoggingFeature {
 
     private static final boolean USE_JUL = true;
-    private static final Dependency JUL_TO_SLF4J = Dependency.builder()
-            .groupId("org.slf4j")
-            .artifactId("jul-to-slf4j")
-            .version("2.0.9")
-            .runtime()
-            .build();
     private final Logback logback;
 
     public Slf4jJulBridge(Logback logback) {
@@ -66,7 +60,7 @@ public class Slf4jJulBridge implements LoggingFeature {
         logback.addConfig(generatorContext, USE_JUL);
         addLoggingProperties(generatorContext);
         logback.addDependency(generatorContext);
-        generatorContext.addDependency(JUL_TO_SLF4J);
+        generatorContext.addDependency(Dependency.builder().lookupArtifactId("jul-to-slf4j").runtime());
     }
 
     protected void addLoggingProperties(GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/logging/Slf4jJulBridge.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/logging/Slf4jJulBridge.java
@@ -26,7 +26,6 @@ import jakarta.inject.Singleton;
 @Singleton
 public class Slf4jJulBridge implements LoggingFeature {
 
-    private final Logback logback;
     private static final boolean USE_JUL = true;
     private static final Dependency JUL_TO_SLF4J = Dependency.builder()
             .groupId("org.slf4j")
@@ -34,6 +33,7 @@ public class Slf4jJulBridge implements LoggingFeature {
             .version("2.0.9")
             .runtime()
             .build();
+    private final Logback logback;
 
     public Slf4jJulBridge(Logback logback) {
         this.logback = logback;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/logging/template/julToSlf4j.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/logging/template/julToSlf4j.rocker.raw
@@ -1,0 +1,2 @@
+// register SLF4JBridgeHandler as handler for the j.u.l. root logger
+handlers = org.slf4j.bridge.SLF4JBridgeHandler

--- a/starter-core/src/main/java/io/micronaut/starter/feature/logging/template/logback.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/logging/template/logback.rocker.raw
@@ -1,6 +1,10 @@
-@args (boolean jansi, boolean coloring)
+@args (boolean jansi, boolean coloring, boolean jul)
 
 <configuration>
+
+@if(jul){
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
+}
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 @if(jansi) {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/LogbackSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/LogbackSpec.groovy
@@ -15,13 +15,14 @@ class LogbackSpec extends ApplicationContextSpec  implements CommandOutputFixtur
     @Shared
     Options options = new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE, AwsLambdaFeatureValidator.firstSupportedJdk())
 
-    void 'by default jansi false and coloring true'() {
+    void 'by default jansi false, coloring true, and jul false'() {
         when:
         Map<String, String> output = generate([])
         String xml = output["src/main/resources/logback.xml"]
 
         then:
         xml
+        !xml.contains("<contextListener class=\"ch.qos.logback.classic.jul.LevelChangePropagator\"/>")
         !xml.contains("<withJansi>true</withJansi>")
         xml.contains("<pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>")
         !xml.contains("<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>")
@@ -34,6 +35,7 @@ class LogbackSpec extends ApplicationContextSpec  implements CommandOutputFixtur
 
         then:
         xml
+        !xml.contains("<contextListener class=\"ch.qos.logback.classic.jul.LevelChangePropagator\"/>")
         !xml.contains("<withJansi>true</withJansi>")
         !xml.contains("<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>")
         xml.contains("<pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>")

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/Slf4jJulBridgeSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/Slf4jJulBridgeSpec.groovy
@@ -1,0 +1,52 @@
+package io.micronaut.starter.feature.logging
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+
+class Slf4jJulBridgeSpec  extends ApplicationContextSpec  implements CommandOutputFixture {
+
+    private static final JUL_FEATURE = "jul-to-slf4j"
+
+    void "logback configuration is generated with JUL config"() {
+        when:
+        def output = generate([JUL_FEATURE])
+        String xml = output["src/main/resources/logback.xml"]
+
+        then:
+        xml
+        xml.contains("<contextListener class=\"ch.qos.logback.classic.jul.LevelChangePropagator\"/>")
+        !xml.contains("<withJansi>true</withJansi>")
+        xml.contains("<pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>")
+        !xml.contains("<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>")
+    }
+
+    void "JUL logging.properties file is generated with SLF4JBridgeHandler"() {
+        when:
+        def output = generate([JUL_FEATURE])
+        def props = output["src/main/resources/logging.properties"]
+
+        then:
+        props
+        props.contains("handlers = org.slf4j.bridge.SLF4JBridgeHandler")
+    }
+
+    void "logback and jul-to-slf4j dependencies are configured for gradle" (BuildTool buildTool)  {
+        when:
+        String template = new BuildBuilder(beanContext, buildTool)
+                .features([JUL_FEATURE])
+                .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, template)
+
+        then:
+        verifier.hasDependency("ch.qos.logback", "logback-classic", Scope.RUNTIME)
+        verifier.hasDependency("org.slf4j", "jul-to-slf4j", Scope.RUNTIME, "2.0.9", false)
+
+        where:
+        buildTool << BuildTool.values()
+    }
+}


### PR DESCRIPTION
A new feature is added for configuring the JUL to SLF4J logging bridge.

When the feature is enabled, the logback configuration is modified, the necessary dependency is added, and a logging.properties file is generated that installs the bridge.

The resolves #2151