### PR TITLE
don’t add flyway postgres until Micronaut Flyway 7

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/migration/Flyway.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/migration/Flyway.java
@@ -24,7 +24,11 @@ import io.micronaut.starter.feature.database.Oracle;
 import io.micronaut.starter.feature.database.PostgreSQL;
 import io.micronaut.starter.feature.database.SQLServer;
 import io.micronaut.starter.feature.oraclecloud.OracleCloudAutonomousDatabase;
+import io.micronaut.starter.util.VersionInfo;
 import jakarta.inject.Singleton;
+
+import java.util.Map;
+import java.util.Optional;
 
 @Singleton
 public class Flyway implements MigrationFeature {
@@ -101,7 +105,11 @@ public class Flyway implements MigrationFeature {
             generatorContext.addDependency(DEPENDENCY_FLYWAY_ORACLE);
         }
         if (generatorContext.isFeaturePresent(PostgreSQL.class)) {
-            generatorContext.addDependency(DEPENDENCY_FLYWAY_POSTGRESQL);
+            Map.Entry<String, String> version = VersionInfo.getDependencyVersion("micronaut.flyway");
+            Optional<Integer> majorVersion = VersionInfo.getMajorVersion(version.getValue());
+            if (majorVersion.isPresent() && majorVersion.get() >= 7) { // 7 is the first major of Micronaut Flyway version which includes flyway 10
+                generatorContext.addDependency(DEPENDENCY_FLYWAY_POSTGRESQL);
+            }
         }
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/util/VersionInfo.java
+++ b/starter-core/src/main/java/io/micronaut/starter/util/VersionInfo.java
@@ -80,8 +80,11 @@ public class VersionInfo {
     }
 
     public static Optional<Integer> getMicronautMajorVersion() {
-        String micronautVersion = getMicronautVersion();
-        String[] parts = micronautVersion.split("\\.");
+        return getMajorVersion(getMicronautVersion());
+    }
+
+    public static Optional<Integer> getMajorVersion(String version) {
+        String[] parts = version.split("\\.");
         if (parts.length >= 1) {
             try {
                 return Optional.of(Integer.parseInt(parts[0]));

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/FlywaySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/FlywaySpec.groovy
@@ -8,6 +8,7 @@ import io.micronaut.starter.build.dependencies.Scope
 import io.micronaut.starter.feature.config.Yaml
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
+import spock.lang.PendingFeature
 
 class FlywaySpec extends ApplicationContextSpec implements CommandOutputFixture {
 
@@ -116,6 +117,7 @@ flyway:
         buildTool << BuildTool.values()
     }
 
+    @PendingFeature
     void "test the flyway-database-postgresql dependency is added to the gradle build when postgres is selected"(BuildTool buildTool) {
         when:
         BuildTestVerifier verifier = verifier(buildTool, ['flyway', 'postgres'])


### PR DESCRIPTION
This is breaking guides currently. 