### PR TITLE
add DependencyContext:removeDuplicates

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Dependency.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Dependency.java
@@ -18,12 +18,17 @@ package io.micronaut.starter.build.dependencies;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
-public final class Dependency {
+public final class Dependency implements Coordinate {
+
+    public static final Comparator<Dependency> COMPARATOR = (o1, o2) -> {
+        int comparison = Integer.compare(o1.getScope().getOrder(), o2.getScope().getOrder());
+        if (comparison != 0) {
+            return comparison;
+        }
+        return Coordinate.COMPARATOR.compare(o1, o2);
+    };
 
     @Nullable
     private final Scope scope;
@@ -148,15 +153,18 @@ public final class Dependency {
         return scope;
     }
 
+    @Override
     public String getGroupId() {
         return groupId;
     }
 
+    @Override
     public String getArtifactId() {
         return artifactId;
     }
 
     @Nullable
+    @Override
     public String getVersion() {
         return version;
     }
@@ -170,6 +178,7 @@ public final class Dependency {
         return order;
     }
 
+    @Override
     public boolean isPom() {
         return pom;
     }

--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/DependencyContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/DependencyContext.java
@@ -92,22 +92,12 @@ public interface DependencyContext {
     }
 
     private static List<Dependency> filterDuplicates(List<Dependency> dependencies) {
-        List<Dependency> dependenciesWithoutDuplicates = new ArrayList<>();
-        Map<MavenCoordinate, Scope> dependenciesWithScope = new HashMap<>();
-        for (Dependency dep : dependencies.stream().sorted(Dependency.COMPARATOR).toList()) {
-            MavenCoordinate coordinate = new MavenCoordinate(dep.getGroupId(), dep.getArtifactId(), dep.getVersion());
-            if (dependenciesWithScope.containsKey(coordinate)) {
-                if (dependenciesWithScope.get(coordinate).getOrder() < dep.getOrder()) {
-                    dependenciesWithScope.remove(coordinate);
-                    dependenciesWithoutDuplicates.removeIf(f -> new MavenCoordinate(f.getGroupId(), f.getArtifactId(), f.getVersion()).equals(coordinate));
-                    dependenciesWithScope.put(coordinate, dep.getScope());
-                    dependenciesWithoutDuplicates.add(dep);
-                }
-            } else {
-                dependenciesWithScope.put(coordinate, dep.getScope());
-                dependenciesWithoutDuplicates.add(dep);
-            }
-        }
-        return dependenciesWithoutDuplicates;
+        return new ArrayList<>(dependencies.stream().collect(
+                Collectors.toMap(
+                        d -> new MavenCoordinate(d.getGroupId(), d.getArtifactId(), d.getVersion()),
+                        Function.identity(),
+                        BinaryOperator.minBy(Comparator.comparing(d -> d.getScope().getOrder()))
+                )
+        ).values());
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/DependencyContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/DependencyContext.java
@@ -17,11 +17,20 @@ package io.micronaut.starter.build.dependencies;
 
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.options.Language;
 
-import java.util.Collection;
+import java.util.*;
+import java.util.function.Function;
+
+import static io.micronaut.starter.build.dependencies.Phase.COMPILATION;
+import static io.micronaut.starter.build.dependencies.Phase.RUNTIME;
 
 public interface DependencyContext {
-
+    Function<Dependency, Boolean> IS_COMPILE_API_OR_RUNTIME = d -> d.getScope().getPhases().contains(COMPILATION) ||
+            d.getScope().getPhases().contains(Phase.PUBLIC_API) ||
+            d.getScope().getPhases().contains(Phase.RUNTIME);
+    
     @NonNull
     Collection<Dependency> getDependencies();
 
@@ -31,4 +40,70 @@ public interface DependencyContext {
         addDependency(dependency.build());
     }
 
+    @NonNull
+    default List<Dependency> removeDuplicates(Collection<Dependency> dependencies, Language language, BuildTool buildTool) {
+
+        List<Dependency> dependenciesNotInMainOrTestClasspath = new ArrayList<>(dependencies.stream()
+                .filter(d -> {
+                    if (language == Language.GROOVY && buildTool == BuildTool.MAVEN) {
+                        return !IS_COMPILE_API_OR_RUNTIME.apply(d) && !d.getScope().getPhases().contains(Phase.ANNOTATION_PROCESSING);
+                    }
+                    return !IS_COMPILE_API_OR_RUNTIME.apply(d);
+                })
+                .toList());
+
+        List<Dependency> dependenciesInMainClasspath = new ArrayList<>(dependencies.stream()
+                .filter(d -> {
+                    if (d.getScope().getSource() != Source.MAIN) {
+                        return false;
+                    }
+                    if (language == Language.GROOVY && buildTool == BuildTool.MAVEN) {
+                        return IS_COMPILE_API_OR_RUNTIME.apply(d) || d.getScope().getPhases().contains(Phase.ANNOTATION_PROCESSING);
+                    }
+                    return IS_COMPILE_API_OR_RUNTIME.apply(d);
+
+                })
+                .toList());
+        List<Dependency> dependenciesInMainClasspathWithoutDuplicates = filterDuplicates(dependenciesInMainClasspath);
+
+        List<Dependency> dependenciesInTestClasspath = new ArrayList<>(dependencies.stream()
+                .filter(d -> d.getScope().getSource() == Source.TEST && IS_COMPILE_API_OR_RUNTIME.apply(d))
+                .toList());
+
+        List<Dependency> dependenciesInTestClasspathWithoutDuplicates = filterDuplicates(dependenciesInTestClasspath);
+
+        dependenciesInTestClasspathWithoutDuplicates.removeIf(testDep -> {
+            MavenCoordinate test = new MavenCoordinate(testDep.getGroupId(), testDep.getArtifactId(), testDep.getVersion());
+            return dependenciesInMainClasspathWithoutDuplicates.stream()
+                    .filter(mainDep -> (mainDep.getScope().getPhases().contains(RUNTIME) && mainDep.getScope().getPhases().contains(COMPILATION)))
+                    .anyMatch(mainDep -> {
+                        MavenCoordinate main = new MavenCoordinate(mainDep.getGroupId(), mainDep.getArtifactId(), mainDep.getVersion());
+                        return main.equals(test);
+                    });
+        });
+        List<Dependency> result = new ArrayList<>(dependenciesNotInMainOrTestClasspath);
+        result.addAll(dependenciesInMainClasspathWithoutDuplicates);
+        result.addAll(dependenciesInTestClasspathWithoutDuplicates);
+        return result.stream().sorted(Dependency.COMPARATOR).toList();
+    }
+
+    private static List<Dependency> filterDuplicates(List<Dependency> dependencies) {
+        List<Dependency> dependenciesWithoutDuplicates = new ArrayList<>();
+        Map<MavenCoordinate, Scope> dependenciesWithScope = new HashMap<>();
+        for (Dependency dep : dependencies.stream().sorted(Dependency.COMPARATOR).toList()) {
+            MavenCoordinate coordinate = new MavenCoordinate(dep.getGroupId(), dep.getArtifactId(), dep.getVersion());
+            if (dependenciesWithScope.containsKey(coordinate)) {
+                if (dependenciesWithScope.get(coordinate).getOrder() < dep.getOrder()) {
+                    dependenciesWithScope.remove(coordinate);
+                    dependenciesWithoutDuplicates.removeIf(f -> new MavenCoordinate(f.getGroupId(), f.getArtifactId(), f.getVersion()).equals(coordinate));
+                    dependenciesWithScope.put(coordinate, dep.getScope());
+                    dependenciesWithoutDuplicates.add(dep);
+                }
+            } else {
+                dependenciesWithScope.put(coordinate, dep.getScope());
+                dependenciesWithoutDuplicates.add(dep);
+            }
+        }
+        return dependenciesWithoutDuplicates;
+    }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MavenCoordinate.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MavenCoordinate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.build.dependencies;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * Maven Coordinate.
+ * @see <a href="https://maven.apache.org/pom.html#maven-coordinates">Maven Coordinates</a>
+ * @param groupId This is generally unique amongst an organization or a project.
+ * @param artifactId The artifactId is generally the name that the project is known by.
+ * @param version artifact version
+ */
+@Introspected
+public record MavenCoordinate(@NonNull String groupId,
+                              @NonNull String artifactId,
+                              @Nullable String version) {
+}

--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Scope.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Scope.java
@@ -16,27 +16,31 @@
 package io.micronaut.starter.build.dependencies;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.order.Ordered;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public class Scope {
-    public static final Scope ANNOTATION_PROCESSOR = new Scope(Source.MAIN, Collections.singletonList(Phase.ANNOTATION_PROCESSING));
-    public static final Scope AOT_PLUGIN = new Scope(Source.MAIN, Collections.singletonList(Phase.AOT_PLUGIN));
-    public static final Scope API = new Scope(Source.MAIN, Arrays.asList(Phase.COMPILATION, Phase.PUBLIC_API, Phase.RUNTIME));
-    public static final Scope COMPILE = new Scope(Source.MAIN, Arrays.asList(Phase.COMPILATION, Phase.RUNTIME));
-    public static final Scope DEVELOPMENT_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.DEVELOPMENT));
-    public static final Scope COMPILE_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.COMPILATION));
-    public static final Scope TEST_RESOURCES_SERVICE = new Scope(Source.MAIN, Collections.singletonList(Phase.TEST_RESOURCES_SERVICE));
-    public static final Scope RUNTIME = new Scope(Source.MAIN, Collections.singletonList(Phase.RUNTIME));
-    public static final Scope TEST = new Scope(Source.TEST, Arrays.asList(Phase.COMPILATION, Phase.RUNTIME));
-    public static final Scope TEST_ANNOTATION_PROCESSOR = new Scope(Source.TEST, Collections.singletonList(Phase.ANNOTATION_PROCESSING));
-    public static final Scope TEST_COMPILE_ONLY = new Scope(Source.TEST, Collections.singletonList(Phase.COMPILATION));
-    public static final Scope TEST_RUNTIME = new Scope(Source.TEST, Collections.singletonList(Phase.RUNTIME));
-    public static final Scope OPENREWRITE = new Scope(Source.MAIN, Collections.singletonList(Phase.OPENREWRITE));
-    public static final Scope NATIVE_IMAGE_COMPILE_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.NATIVE_IMAGE_COMPILATION));
+public class Scope implements Ordered {
+    public static final Scope ANNOTATION_PROCESSOR = new Scope(Source.MAIN, Collections.singletonList(Phase.ANNOTATION_PROCESSING), 0);
+    public static final Scope API = new Scope(Source.MAIN, Arrays.asList(Phase.COMPILATION, Phase.PUBLIC_API, Phase.RUNTIME), 1);
+    public static final Scope COMPILE = new Scope(Source.MAIN, Arrays.asList(Phase.COMPILATION, Phase.RUNTIME), 2);
+    public static final Scope COMPILE_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.COMPILATION), 3);
+    public static final Scope RUNTIME = new Scope(Source.MAIN, Collections.singletonList(Phase.RUNTIME), 4);
+    public static final Scope DEVELOPMENT_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.DEVELOPMENT), 5);
+
+    public static final Scope AOT_PLUGIN = new Scope(Source.MAIN, Collections.singletonList(Phase.AOT_PLUGIN), 6);
+    public static final Scope OPENREWRITE = new Scope(Source.MAIN, Collections.singletonList(Phase.OPENREWRITE), 7);
+    public static final Scope NATIVE_IMAGE_COMPILE_ONLY = new Scope(Source.MAIN, Collections.singletonList(Phase.NATIVE_IMAGE_COMPILATION), 8);
+
+    public static final Scope TEST = new Scope(Source.TEST, Arrays.asList(Phase.COMPILATION, Phase.RUNTIME), 9);
+    public static final Scope TEST_ANNOTATION_PROCESSOR = new Scope(Source.TEST, Collections.singletonList(Phase.ANNOTATION_PROCESSING), 10);
+    public static final Scope TEST_COMPILE_ONLY = new Scope(Source.TEST, Collections.singletonList(Phase.COMPILATION), 11);
+    public static final Scope TEST_RUNTIME = new Scope(Source.TEST, Collections.singletonList(Phase.RUNTIME), 12);
+
+    public static final Scope TEST_RESOURCES_SERVICE = new Scope(Source.MAIN, Collections.singletonList(Phase.TEST_RESOURCES_SERVICE), 13);
 
     @NonNull
     private Source source;
@@ -44,10 +48,19 @@ public class Scope {
     @NonNull
     private List<Phase> phases;
 
+    private final Integer order;
+
     public Scope(@NonNull Source source,
-                 @NonNull List<Phase> phases) {
+                 @NonNull List<Phase> phases,
+                 int order) {
         this.source = source;
         this.phases = phases;
+        this.order = order;
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
     }
 
     @NonNull

--- a/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleDependency.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/gradle/GradleDependency.java
@@ -18,16 +18,9 @@ package io.micronaut.starter.build.gradle;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.starter.application.generator.GeneratorContext;
-import io.micronaut.starter.build.dependencies.Coordinate;
-import io.micronaut.starter.build.dependencies.Dependency;
-import io.micronaut.starter.build.dependencies.DependencyContext;
-import io.micronaut.starter.build.dependencies.DependencyCoordinate;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import io.micronaut.starter.build.dependencies.*;
 
+import java.util.*;
 import static io.micronaut.core.util.CollectionUtils.isNotEmpty;
 
 public class GradleDependency extends DependencyCoordinate {
@@ -151,10 +144,10 @@ public class GradleDependency extends DependencyCoordinate {
 
     @NonNull
     public static List<GradleDependency> listOf(DependencyContext dependencyContext, GeneratorContext generatorContext, boolean useVersionCatalogue) {
-        return dependencyContext.getDependencies()
+        return generatorContext.removeDuplicates(dependencyContext.getDependencies(), generatorContext.getLanguage(), generatorContext.getBuildTool())
                 .stream()
                 .map(dep -> new GradleDependency(dep, generatorContext, useVersionCatalogue))
                 .sorted(GradleDependency.COMPARATOR)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenDependency.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenDependency.java
@@ -18,15 +18,11 @@ package io.micronaut.starter.build.maven;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.OrderUtil;
-import io.micronaut.starter.build.dependencies.Dependency;
-import io.micronaut.starter.build.dependencies.DependencyContext;
-import io.micronaut.starter.build.dependencies.DependencyCoordinate;
-import io.micronaut.starter.build.dependencies.Phase;
+import io.micronaut.starter.build.dependencies.*;
+import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.Language;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.*;
 
 public class MavenDependency extends DependencyCoordinate {
 
@@ -87,11 +83,11 @@ public class MavenDependency extends DependencyCoordinate {
 
     @NonNull
     public static List<MavenDependency> listOf(@NonNull DependencyContext dependencyContext, Language language) {
-        return dependencyContext.getDependencies()
+        return dependencyContext.removeDuplicates(dependencyContext.getDependencies(), language, BuildTool.MAVEN)
                 .stream()
-                .filter(dep -> dep.getScope() != null && !dep.getScope().getPhases().contains(Phase.ANNOTATION_PROCESSING) && !dep.getScope().getPhases().contains(Phase.AOT_PLUGIN))
                 .map(dep -> new MavenDependency(dep, language))
+                .filter(mavenDependency -> mavenDependency.getMavenScope() != null)
                 .sorted(MavenDependency.COMPARATOR)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/microstream/MicroStream.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/microstream/MicroStream.java
@@ -22,8 +22,6 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.options.BuildTool;
-import io.micronaut.starter.options.Language;
 import jakarta.inject.Singleton;
 
 @Singleton
@@ -33,6 +31,15 @@ public class MicroStream implements MicroStreamFeature {
     public static final String MICRONAUT_MICROSTREAM_ANNOTATIONS_ARTIFACT = "micronaut-microstream-annotations";
     public static final String MICRONAUT_MICROSTREAM_VERSION = "micronaut.microstream.version";
     public static final String ARTIFACT_ID_MICRONAUT_MICROSTREAM = "micronaut-microstream";
+    private static final Dependency DEPENDENCY_MICRONAUT_MICROSTREAM = MicronautDependencyUtils.microstreamDependency()
+            .artifactId(ARTIFACT_ID_MICRONAUT_MICROSTREAM)
+            .compile()
+            .build();
+
+    private static final Dependency DEPENDENCY_MICRONAUT_MICROSTREAM_ANNOTATIONS = MicronautDependencyUtils.microstreamDependency()
+            .artifactId(MICRONAUT_MICROSTREAM_ANNOTATIONS_ARTIFACT)
+            .compile()
+            .build();
 
     @Override
     @NonNull
@@ -63,28 +70,14 @@ public class MicroStream implements MicroStreamFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.addDependency(MicronautDependencyUtils.microstreamDependency()
-                .artifactId(ARTIFACT_ID_MICRONAUT_MICROSTREAM)
-                .compile());
-        // For Groovy and Maven we only require the annotation in provided scope (from the processor below)
-        // Adding it in both compile, and provided via the processor results in a build failure
-        if (generatorContext.getBuildTool() != BuildTool.MAVEN || generatorContext.getLanguage() != Language.GROOVY) {
-            generatorContext.addDependency(MicronautDependencyUtils.microstreamDependency()
-                    .artifactId(MICRONAUT_MICROSTREAM_ANNOTATIONS_ARTIFACT)
-                    .compile()
-            );
-        }
-        Dependency.Builder dependency = MicronautDependencyUtils.annotationProcessor(generatorContext.getBuildTool(),
-                        MicronautDependencyUtils.GROUP_ID_MICRONAUT_MICROSTREAM, MICRONAUT_MICROSTREAM_ANNOTATIONS_ARTIFACT, MICRONAUT_MICROSTREAM_VERSION);
-        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
-            dependency.exclude(
-                    MicronautDependencyUtils.coreDependency()
-                            .artifactId("micronaut-core")
-                            .compile()
-                            .build()
-            );
-        }
-        generatorContext.addDependency(dependency);
+        addDependencies(generatorContext);
+    }
+
+    protected void addDependencies(@NonNull GeneratorContext generatorContext) {
+        generatorContext.addDependency(DEPENDENCY_MICRONAUT_MICROSTREAM);
+        generatorContext.addDependency(DEPENDENCY_MICRONAUT_MICROSTREAM_ANNOTATIONS);
+        generatorContext.addDependency(MicronautDependencyUtils.annotationProcessor(generatorContext.getBuildTool(),
+                MicronautDependencyUtils.GROUP_ID_MICRONAUT_MICROSTREAM, MICRONAUT_MICROSTREAM_ANNOTATIONS_ARTIFACT, MICRONAUT_MICROSTREAM_VERSION));
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/microstream/MicroStreamCache.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/microstream/MicroStreamCache.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.Category;
 import jakarta.inject.Singleton;
@@ -28,6 +29,10 @@ public class MicroStreamCache implements MicroStreamFeature {
 
     public static final String NAME = "microstream-cache";
     public static final String ARTIFACT_ID_MICRONAUT_MICROSTREAM_CACHE = "micronaut-microstream-cache";
+    public static final Dependency DEPENDENCY_MICROSTREAM_CACHE = MicronautDependencyUtils.microstreamDependency()
+            .artifactId(ARTIFACT_ID_MICRONAUT_MICROSTREAM_CACHE)
+            .compile()
+            .build();
 
     @Override
     @NonNull
@@ -60,10 +65,7 @@ public class MicroStreamCache implements MicroStreamFeature {
     public void apply(GeneratorContext generatorContext) {
         generatorContext.getConfiguration().put("microstream.cache.my-cache.key-type", "java.lang.Integer");
         generatorContext.getConfiguration().put("microstream.cache.my-cache.value-type", "java.lang.String");
-        generatorContext.addDependency(MicronautDependencyUtils.microstreamDependency()
-                .artifactId(ARTIFACT_ID_MICRONAUT_MICROSTREAM_CACHE)
-                .compile()
-        );
+        generatorContext.addDependency(DEPENDENCY_MICROSTREAM_CACHE);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/security/SecurityAnnotations.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/security/SecurityAnnotations.java
@@ -24,8 +24,8 @@ import jakarta.inject.Singleton;
 
 @Singleton
 public class SecurityAnnotations implements Feature, MicronautServerDependent {
-    public static final String ARTIFACT_ID_MICRONAUT_SECURITY_ANNOTATIONS = "micronaut-security-annotations";
-    public static final String PROPERTY_MICRONAUT_SECURITY_VERSION = "micronaut.security.version";
+    private static final String ARTIFACT_ID_MICRONAUT_SECURITY_ANNOTATIONS = "micronaut-security-annotations";
+    private static final String PROPERTY_MICRONAUT_SECURITY_VERSION = "micronaut.security.version";
 
     @Override
     public String getName() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/FeatureWithDuplicates.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/FeatureWithDuplicates.groovy
@@ -1,0 +1,46 @@
+package io.micronaut.starter.build.dependencies
+
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.application.generator.GeneratorContext
+import io.micronaut.starter.feature.Feature
+import jakarta.inject.Singleton
+
+@Singleton
+class FeatureWithDuplicates implements Feature {
+
+    private static final String GROUP = "org.gebish"
+    private static final String ART_GEB_CORE = "geb-core"
+    private static final String GROUP_SELENIUM = "org.seleniumhq.selenium"
+    private static final String ART_SELENIUM_FIREFOX = "selenium-firefox-driver"
+
+
+
+    @Override
+    String getName() {
+        return "feature-with-duplicates"
+    }
+
+    @Override
+    boolean supports(ApplicationType applicationType) {
+        true
+    }
+
+    @Override
+    boolean isVisible() {
+        false
+    }
+
+    @Override
+    void apply(GeneratorContext ctx) {
+        ctx.addDependency(Dependency.builder().groupId(GROUP).artifactId(ART_GEB_CORE).runtime().build())
+        ctx.addDependency(Dependency.builder().groupId(GROUP).artifactId(ART_GEB_CORE).compile().build())
+        ctx.addDependency(Dependency.builder().groupId(GROUP).artifactId(ART_GEB_CORE).compileOnly().build())
+        ctx.addDependency(Dependency.builder().groupId(GROUP).artifactId(ART_GEB_CORE).test().build())
+        ctx.addDependency(Dependency.builder().groupId(GROUP).artifactId(ART_GEB_CORE).testCompileOnly().build())
+        ctx.addDependency(Dependency.builder().groupId(GROUP).artifactId(ART_GEB_CORE).testRuntime().build())
+
+        ctx.addDependency(Dependency.builder().groupId(GROUP_SELENIUM).artifactId(ART_SELENIUM_FIREFOX).testRuntime().build())
+        ctx.addDependency(Dependency.builder().groupId(GROUP_SELENIUM).artifactId(ART_SELENIUM_FIREFOX).test().build())
+        ctx.addDependency(Dependency.builder().groupId(GROUP_SELENIUM).artifactId(ART_SELENIUM_FIREFOX).runtime().build())
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/FeatureWithDuplicatesSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/FeatureWithDuplicatesSpec.groovy
@@ -1,0 +1,37 @@
+package io.micronaut.starter.build.dependencies
+
+import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+
+
+class FeatureWithDuplicatesSpec extends BeanContextSpec implements CommandOutputFixture {
+
+    void "test dependencies added for feature-with-duplicates"(Language language, BuildTool buildTool) {
+        when:
+        String template = new BuildBuilder(beanContext, buildTool)
+                .language(language)
+                .features(['feature-with-duplicates'])
+                .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, language, template)
+
+        then: 'for a dependency in compile, runtime, compileOnly, testRuntimeOnly, testCompileOnly and test, only compile should be added'
+        !verifier.hasDependency("org.gebish", "geb-core", Scope.RUNTIME)
+        !verifier.hasDependency("org.gebish", "geb-core", Scope.TEST)
+        !verifier.hasDependency("org.gebish", "geb-core", Scope.TEST_COMPILE_ONLY)
+        !verifier.hasDependency("org.gebish", "geb-core", Scope.COMPILE_ONLY)
+        !verifier.hasDependency("org.gebish", "geb-core", Scope.TEST_RUNTIME)
+        verifier.hasDependency("org.gebish", "geb-core", Scope.COMPILE)
+
+        and: 'for a dependency in runtime and test, both runtime and test should be added'
+        verifier.hasDependency("org.seleniumhq.selenium", "selenium-firefox-driver", Scope.RUNTIME)
+        verifier.hasDependency("org.seleniumhq.selenium", "selenium-firefox-driver", Scope.TEST)
+
+        where:
+        [language, buildTool] << [Language.values(), BuildTool.values()].combinations()
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/GradleConfigurationSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/GradleConfigurationSpec.groovy
@@ -34,7 +34,7 @@ class GradleConfigurationSpec extends Specification {
 
     void "#source #phases should return #configuration"() {
         expect:
-        configuration == GradleConfiguration.of(new Scope(source, phases), Language.JAVA, TestFramework.JUNIT, null).get()
+        configuration == GradleConfiguration.of(new Scope(source, phases, 1), Language.JAVA, TestFramework.JUNIT, null).get()
 
         where:
         source      | phases                                               || configuration
@@ -56,7 +56,7 @@ class GradleConfigurationSpec extends Specification {
             isFeaturePresent(KotlinSymbolProcessingFeature.class) >> ksp
         }
         expect:
-        configuration == GradleConfiguration.of(new Scope(source, phases), Language.KOTLIN, TestFramework.JUNIT, generatorContext).get()
+        configuration == GradleConfiguration.of(new Scope(source, phases, 1), Language.KOTLIN, TestFramework.JUNIT, generatorContext).get()
 
         where:
         ksp   | source      | phases                        || configuration

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/MavenScopeSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/MavenScopeSpec.groovy
@@ -15,7 +15,7 @@ class MavenScopeSpec extends Specification {
     @Unroll("#source #phases should return #scope")
     void "verify MavenScope::of"(Source source, List<Phase> phases, Language language, MavenScope scope) {
         expect:
-        scope == MavenScope.of(new Scope(source, phases), language).get()
+        scope == MavenScope.of(new Scope(source, phases, 1), language).get()
 
         where:
         source      | phases                                               | language        || scope

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/CdkFeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/aws/CdkFeatureSpec.groovy
@@ -78,9 +78,10 @@ class CdkFeatureSpec extends ApplicationContextSpec implements CommandOutputFixt
     void "dependencies are added for cdk to infra project for #buildTool"(BuildTool buildTool, String buildFile) {
         when:
         Map<String, String> output = generate(ApplicationType.DEFAULT, createOptions(buildTool), [Cdk.NAME, AwsLambda.FEATURE_NAME_AWS_LAMBDA])
+        String infraBuild = output."$Cdk.INFRA_MODULE/$buildFile"
 
         then:
-        output."$Cdk.INFRA_MODULE/$buildFile".contains($/implementation("io.micronaut.starter:micronaut-starter-aws-cdk/$)
+        infraBuild.contains($/implementation("io.micronaut.starter:micronaut-starter-aws-cdk/$)
 
         where:
         buildTool               | buildFile


### PR DESCRIPTION
I added an api to remove dependency duplication: 

----
Example A


if a feature contributes: 
```groovy
implementation("io.micronaut:micronaut-http-client")
```

and another one: 

```groovy
testImplementation("io.micronaut:micronaut-http-client")
```

then: 

the project has only: 

```groovy
implementation("io.micronaut:micronaut-http-client")
```

----

Example B


if a feature contributes: 
```groovy
compileOnly("io.micronaut:micronaut-http-client")
```

and another one: 

```groovy
testImplementation("io.micronaut:micronaut-http-client")
```

then: 

the project has both: 

```groovy
compileOnly("io.micronaut:micronaut-http-client")
testImplementation("io.micronaut:micronaut-http-client")
```

----

