### PR TITLE
Telegram ChatBot support in Starter

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/application/generator/GeneratorContext.java
@@ -309,6 +309,10 @@ public class GeneratorContext implements DependencyContext {
         return features.isFeaturePresent(feature);
     }
 
+    public boolean isFeatureMissing(Class<? extends Feature> feature) {
+        return !features.isFeaturePresent(feature);
+    }
+
     public <T extends Feature> Optional<T> getFeature(Class<T> feature) {
         return features.getFeature(feature);
     }

--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MicronautDependencyUtils.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MicronautDependencyUtils.java
@@ -34,6 +34,7 @@ public final class MicronautDependencyUtils {
     public static final String GROUP_ID_MICRONAUT_AWS = "io.micronaut.aws";
     public static final String GROUP_ID_MICRONAUT_AZURE = "io.micronaut.azure";
     public static final String GROUP_ID_MICRONAUT_CASSANDRA = "io.micronaut.cassandra";
+    public static final String GROUP_ID_MICRONAUT_CHATBOTS = "io.micronaut.chatbots";
     public static final String GROUP_ID_MICRONAUT_COHERENCE = "io.micronaut.coherence";
     public static final String GROUP_ID_MICRONAUT_CRAC = "io.micronaut.crac";
     public static final String GROUP_ID_MICRONAUT_ECLIPSESTORE = "io.micronaut.eclipsestore";
@@ -179,6 +180,11 @@ public final class MicronautDependencyUtils {
     @NonNull
     public static Dependency.Builder cassandraDependency() {
         return micronautDependency(GROUP_ID_MICRONAUT_CASSANDRA);
+    }
+
+    @NonNull
+    public static Dependency.Builder chatBotsDependency() {
+        return micronautDependency(GROUP_ID_MICRONAUT_CHATBOTS);
     }
 
     @NonNull

--- a/starter-core/src/main/java/io/micronaut/starter/feature/Category.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/Category.java
@@ -25,6 +25,7 @@ public class Category {
     public static final String API                  = "API";
     public static final String BPM                  = "BPM";
     public static final String CACHE                = "Cache";
+    public static final String CHATBOTS             = "ChatBots";
     public static final String CICD                 = "CI/CD";
     public static final String CLIENT               = "Client";
     public static final String CLOUD                = "Cloud";

--- a/starter-core/src/main/java/io/micronaut/starter/feature/CodeContributingFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/CodeContributingFeature.java
@@ -13,22 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.starter.feature.chatbots;
-
-import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.feature.CodeContributingFeature;
+package io.micronaut.starter.feature;
 
 /**
- * Marker interface for chatbot features.
- *
- * @author Tim Yates
- * @since 4.3.0
+ * Marker interface for {@link Feature} which contribute code to the generated project.
  */
-
-public interface ChatBotsFeature extends CodeContributingFeature {
-
-    @Override
-    default String getCategory() {
-        return Category.CHATBOTS;
-    }
+public interface CodeContributingFeature extends Feature {
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
@@ -55,7 +55,6 @@ import io.micronaut.starter.feature.build.gradle.templates.useJunitPlatform;
 import io.micronaut.starter.feature.build.maven.templates.execMavenPlugin;
 import io.micronaut.starter.feature.build.maven.templates.genericPom;
 import io.micronaut.starter.feature.build.maven.templates.mavenCompilerPlugin;
-import io.micronaut.starter.feature.chatbots.telegram.TelegramAwsChatBot;
 import io.micronaut.starter.feature.function.HandlerClassFeature;
 import io.micronaut.starter.feature.function.awslambda.AwsLambda;
 import io.micronaut.starter.feature.graalvm.GraalVM;
@@ -149,9 +148,7 @@ public class Cdk implements MultiProjectFeature, InfrastructureAsCodeFeature {
         generatorContext.addTemplate("cdk-main", new RockerTemplate(INFRA_MODULE, "src/main/java/{packagePath}/" + MAIN_CLASS_NAME + ".java",
                 cdkmain.template(generatorContext.getProject())));
 
-        String handler = generatorContext.isFeaturePresent(TelegramAwsChatBot.class) ?
-                TelegramAwsChatBot.HANDLER_CLASS :
-                HandlerClassFeature.resolveHandler(generatorContext);
+        String handler = HandlerClassFeature.resolveHandler(generatorContext);
         Language lang = Language.JAVA;
         addAppStackTest(generatorContext, lang, handler);
         CpuArchitecture architecture = generatorContext.getFeatures().getFeature(CpuArchitecture.class)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
@@ -55,6 +55,7 @@ import io.micronaut.starter.feature.build.gradle.templates.useJunitPlatform;
 import io.micronaut.starter.feature.build.maven.templates.execMavenPlugin;
 import io.micronaut.starter.feature.build.maven.templates.genericPom;
 import io.micronaut.starter.feature.build.maven.templates.mavenCompilerPlugin;
+import io.micronaut.starter.feature.chatbots.telegram.TelegramAwsChatBot;
 import io.micronaut.starter.feature.function.HandlerClassFeature;
 import io.micronaut.starter.feature.function.awslambda.AwsLambda;
 import io.micronaut.starter.feature.graalvm.GraalVM;
@@ -148,7 +149,9 @@ public class Cdk implements MultiProjectFeature, InfrastructureAsCodeFeature {
         generatorContext.addTemplate("cdk-main", new RockerTemplate(INFRA_MODULE, "src/main/java/{packagePath}/" + MAIN_CLASS_NAME + ".java",
                 cdkmain.template(generatorContext.getProject())));
 
-        String handler = HandlerClassFeature.resolveHandler(generatorContext);
+        String handler = generatorContext.isFeaturePresent(TelegramAwsChatBot.class) ?
+                TelegramAwsChatBot.HANDLER_CLASS :
+                HandlerClassFeature.resolveHandler(generatorContext);
         Language lang = Language.JAVA;
         addAppStackTest(generatorContext, lang, handler);
         CpuArchitecture architecture = generatorContext.getFeatures().getFeature(CpuArchitecture.class)

--- a/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/AwsAlexa.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awsalexa/AwsAlexa.java
@@ -20,6 +20,7 @@ import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.Category;
+import io.micronaut.starter.feature.CodeContributingFeature;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.aws.AwsCloudFeature;
 import io.micronaut.starter.feature.awsalexa.templates.cancelIntentHandlerGroovy;
@@ -75,7 +76,7 @@ import io.micronaut.starter.options.TestRockerModelProvider;
 import jakarta.inject.Singleton;
 
 @Singleton
-public class AwsAlexa implements Feature, AwsCloudFeature {
+public class AwsAlexa implements Feature, AwsCloudFeature, CodeContributingFeature {
     public static final String NAME = "aws-alexa";
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/buildless/Buildless.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/buildless/Buildless.java
@@ -29,9 +29,9 @@ import jakarta.inject.Singleton;
 @Singleton
 public class Buildless implements CommunityFeature, GradleSpecificFeature {
     public static final String NAME = "buildless";
+    public static final String BUILDLESS_PLUGIN_ARTIFACT = "buildless-plugin-gradle";
     private static final String FEATURE_NAME_BUILDLESS = "buildless";
     private static final String BUILDLESS_PLUGIN_ID = "build.less";
-    static final String BUILDLESS_PLUGIN_ARTIFACT = "buildless-plugin-gradle";
 
     @Override
     public String getName() {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/ChatBotType.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/ChatBotType.java
@@ -15,20 +15,13 @@
  */
 package io.micronaut.starter.feature.chatbots;
 
-import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.feature.CodeContributingFeature;
+import io.micronaut.core.util.StringUtils;
 
-/**
- * Marker interface for chatbot features.
- *
- * @author Tim Yates
- * @since 4.3.0
- */
-
-public interface ChatBotsFeature extends CodeContributingFeature {
+public enum ChatBotType {
+    TELEGRAM;
 
     @Override
-    default String getCategory() {
-        return Category.CHATBOTS;
+    public String toString() {
+        return StringUtils.capitalize(this.name().toLowerCase());
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/ChatBots.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/ChatBots.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.starter.feature.chatbots;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.chatbots.template.about;
@@ -39,7 +40,7 @@ public abstract class ChatBots implements ChatBotsFeature {
         this.validationFeature = validationFeature;
     }
 
-    protected void renderTemplates(GeneratorContext generatorContext) {
+    protected void renderTemplates(@NonNull GeneratorContext generatorContext) {
         generatorContext.addTemplate(
                 "about-markdown",
                 new RockerTemplate("src/main/resources/botcommands/about.md", about.template(getChatBotType()))
@@ -63,13 +64,16 @@ public abstract class ChatBots implements ChatBotsFeature {
         return "https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/";
     }
 
-    protected abstract void addDependencies(GeneratorContext generatorContext);
+    protected abstract void addDependencies(@NonNull GeneratorContext generatorContext);
 
-    protected abstract void addConfigurations(GeneratorContext generatorContext);
+    protected abstract void addConfigurations(@NonNull GeneratorContext generatorContext);
 
-    protected abstract String getChatBotType();
+    @NonNull
+    protected abstract ChatBotType getChatBotType();
 
-    protected abstract String rootReadMeTemplate(GeneratorContext generatorContext);
+    @NonNull
+    protected abstract String rootReadMeTemplate(@NonNull GeneratorContext generatorContext);
 
-    protected abstract String getBuildCommand(BuildTool buildTool);
+    @NonNull
+    protected abstract String getBuildCommand(@NonNull BuildTool buildTool);
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/ChatBots.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/ChatBots.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.chatbots;
+
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.chatbots.template.about;
+import io.micronaut.starter.feature.validator.MicronautValidationFeature;
+import io.micronaut.starter.feature.validator.ValidationFeature;
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.template.RockerTemplate;
+
+/**
+ * Base class for chatbot features.
+ * <p>
+ * Used to template out the common code between the chatbot features.
+ *
+ * @author Tim Yates
+ * @since 4.3.0
+ */
+public abstract class ChatBots implements ChatBotsFeature {
+
+    private final MicronautValidationFeature validationFeature;
+
+    protected ChatBots(MicronautValidationFeature validationFeature) {
+        this.validationFeature = validationFeature;
+    }
+
+    protected void renderTemplates(GeneratorContext generatorContext) {
+        generatorContext.addTemplate(
+                "about-markdown",
+                new RockerTemplate("src/main/resources/botcommands/about.md", about.template(getChatBotType()))
+        );
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        addDependencies(generatorContext);
+        addConfigurations(generatorContext);
+        renderTemplates(generatorContext);
+    }
+
+    @Override
+    public void processSelectedFeatures(FeatureContext featureContext) {
+        featureContext.addFeatureIfNotPresent(ValidationFeature.class, validationFeature);
+    }
+
+    @Override
+    public String getMicronautDocumentation() {
+        return "https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/";
+    }
+
+    protected abstract void addDependencies(GeneratorContext generatorContext);
+
+    protected abstract void addConfigurations(GeneratorContext generatorContext);
+
+    protected abstract String getChatBotType();
+
+    protected abstract String rootReadMeTemplate(GeneratorContext generatorContext);
+
+    protected abstract String getBuildCommand(BuildTool buildTool);
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/ChatBotsFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/ChatBotsFeature.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.chatbots;
+
+import io.micronaut.starter.feature.Category;
+import io.micronaut.starter.feature.Feature;
+
+/**
+ * Marker interface for chatbot features.
+ *
+ * @author Tim Yates
+ * @since 4.3.0
+ */
+public interface ChatBotsFeature extends Feature {
+
+    @Override
+    default String getCategory() {
+        return Category.CHATBOTS;
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/ChatBotsTelegram.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/ChatBotsTelegram.java
@@ -16,6 +16,7 @@
 package io.micronaut.starter.feature.chatbots.telegram;
 
 import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.feature.chatbots.ChatBotType;
 import io.micronaut.starter.feature.chatbots.ChatBots;
 import io.micronaut.starter.feature.chatbots.template.aboutCommandHandlerGroovy;
 import io.micronaut.starter.feature.chatbots.template.aboutCommandHandlerGroovyJunit;
@@ -113,7 +114,7 @@ abstract class ChatBotsTelegram extends ChatBots {
     }
 
     @Override
-    public String getChatBotType() {
-        return "Telegram";
+    public ChatBotType getChatBotType() {
+        return ChatBotType.TELEGRAM;
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/ChatBotsTelegram.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/ChatBotsTelegram.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.chatbots.telegram;
+
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.feature.chatbots.ChatBots;
+import io.micronaut.starter.feature.chatbots.template.aboutCommandHandlerGroovy;
+import io.micronaut.starter.feature.chatbots.template.aboutCommandHandlerGroovyJunit;
+import io.micronaut.starter.feature.chatbots.template.aboutCommandHandlerGroovySpock;
+import io.micronaut.starter.feature.chatbots.template.aboutCommandHandlerJava;
+import io.micronaut.starter.feature.chatbots.template.aboutCommandHandlerJavaJunit;
+import io.micronaut.starter.feature.chatbots.template.aboutCommandHandlerKotlin;
+import io.micronaut.starter.feature.chatbots.template.aboutCommandHandlerKotlinJunit;
+import io.micronaut.starter.feature.chatbots.template.finalCommandHandlerGroovy;
+import io.micronaut.starter.feature.chatbots.template.finalCommandHandlerJava;
+import io.micronaut.starter.feature.chatbots.template.finalCommandHandlerKotlin;
+import io.micronaut.starter.feature.chatbots.template.mockAboutCommandJson;
+import io.micronaut.starter.feature.chatbots.template.telegramReadme;
+import io.micronaut.starter.feature.validator.MicronautValidationFeature;
+import io.micronaut.starter.options.TestFramework;
+import io.micronaut.starter.template.RockerTemplate;
+import io.micronaut.starter.template.RockerWritable;
+
+/**
+ * Base class for Telegram chatbot features.
+ *
+ * @since 4.3.0
+ * @author Tim Yates
+ */
+abstract class ChatBotsTelegram extends ChatBots {
+
+    protected ChatBotsTelegram(MicronautValidationFeature validationFeature) {
+        super(validationFeature);
+    }
+
+    @Override
+    protected void addConfigurations(GeneratorContext generatorContext) {
+        generatorContext.getConfiguration().put(
+                "micronaut.chatbots.telegram.bots.example.token",
+                "WEBHOOK_TOKEN"
+        );
+        generatorContext.getConfiguration().put(
+                "micronaut.chatbots.telegram.bots.example.at-username",
+                "@MyMicronautExampleBot"
+        );
+        generatorContext.getConfiguration().put(
+                "micronaut.chatbots.folder",
+                "botcommands"
+        );
+    }
+
+    @Override
+    protected void renderTemplates(GeneratorContext generatorContext) {
+        super.renderTemplates(generatorContext);
+        generatorContext.addTemplate(
+                "about-command-handler",
+                generatorContext.getSourcePath("/{packagePath}/AboutCommandHandler"),
+                aboutCommandHandlerJava.template(generatorContext.getProject()),
+                aboutCommandHandlerKotlin.template(generatorContext.getProject()),
+                aboutCommandHandlerGroovy.template(generatorContext.getProject())
+        );
+        if (!generatorContext.getTestFramework().isKotlinTestFramework()) {
+            generatorContext.addTemplate(
+                    "mock-about-command-json",
+                    new RockerTemplate(
+                            "src/test/resources/mockAboutCommand.json",
+                            mockAboutCommandJson.template()
+                    )
+            );
+        }
+        if (generatorContext.getTestFramework() == TestFramework.JUNIT) {
+            generatorContext.addTemplate(
+                    "about-command-handler-junit-test",
+                    generatorContext.getTestSourcePath("/{packagePath}/AboutCommandHandler"),
+                    aboutCommandHandlerJavaJunit.template(generatorContext.getProject()),
+                    aboutCommandHandlerKotlinJunit.template(generatorContext.getProject()),
+                    aboutCommandHandlerGroovyJunit.template(generatorContext.getProject())
+            );
+        } else if (generatorContext.getTestFramework() == TestFramework.SPOCK) {
+            generatorContext.addTemplate(
+                    "about-command-handler-spock-groovy-test",
+                    new RockerTemplate(generatorContext.getTestSourcePath("/{packagePath}/AboutCommandHandler"), aboutCommandHandlerGroovySpock.template(generatorContext.getProject()))
+            );
+        }
+
+        generatorContext.addHelpTemplate(new RockerWritable(telegramReadme.template(
+                rootReadMeTemplate(generatorContext),
+                generatorContext.getProject(),
+                generatorContext.getFeatures(),
+                getBuildCommand(generatorContext.getBuildTool()))
+        ));
+
+        generatorContext.addTemplate(
+                "final-command-handler",
+                generatorContext.getSourcePath("/{packagePath}/FinalCommandHandler"),
+                finalCommandHandlerJava.template(generatorContext.getProject()),
+                finalCommandHandlerKotlin.template(generatorContext.getProject()),
+                finalCommandHandlerGroovy.template(generatorContext.getProject())
+        );
+    }
+
+    @Override
+    public String getChatBotType() {
+        return "Telegram";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramAwsChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramAwsChatBot.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.chatbots.telegram;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
+import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.aws.AwsMicronautRuntimeFeature;
+import io.micronaut.starter.feature.aws.Cdk;
+import io.micronaut.starter.feature.chatbots.template.awsCdkReadme;
+import io.micronaut.starter.feature.chatbots.template.awsReadme;
+import io.micronaut.starter.feature.function.Cloud;
+import io.micronaut.starter.feature.function.CloudFeature;
+import io.micronaut.starter.feature.function.awslambda.AwsLambda;
+import io.micronaut.starter.feature.validator.MicronautValidationFeature;
+import io.micronaut.starter.options.BuildTool;
+import jakarta.inject.Singleton;
+
+/**
+ * Adds support for Telegram chatbots as Lambdas.
+ *
+ * @author Tim Yates
+ * @since 4.3.0
+ */
+@Singleton
+public class TelegramAwsChatBot extends ChatBotsTelegram implements CloudFeature, AwsMicronautRuntimeFeature {
+
+    public static final String NAME = "chatbots-telegram-lambda";
+
+    public static final Dependency CHATBOTS_TELEGRAM_LAMBDA = MicronautDependencyUtils
+            .chatBotsDependency()
+            .artifactId("micronaut-chatbots-telegram-lambda")
+            .compile()
+            .build();
+
+    public static final String MAVEN_AZURE_DEPLOY_COMMAND = "mvnw package azure-functions:deploy";
+    public static final String GRADLE_AZURE_DEPLOY_COMMAND = "gradlew azureFunctionsDeploy";
+    public static final String HANDLER_CLASS = "io.micronaut.chatbots.telegram.lambda.Handler";
+
+    private final AwsLambda awsLambda;
+
+    public TelegramAwsChatBot(MicronautValidationFeature validationFeature, AwsLambda awsLambda) {
+        super(validationFeature);
+        this.awsLambda = awsLambda;
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return applicationType == ApplicationType.FUNCTION;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Cloud getCloud() {
+        return Cloud.AZURE;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Telegram ChatBot as Lambda";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Generates an application that can be deployed as an Lambda that implements a Telegram chatbot";
+    }
+
+    @Override
+    public void processSelectedFeatures(FeatureContext featureContext) {
+        super.processSelectedFeatures(featureContext);
+        featureContext.addFeatureIfNotPresent(AwsLambda.class, awsLambda);
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        super.apply(generatorContext);
+        addMicronautRuntimeBuildProperty(generatorContext);
+    }
+
+    @Override
+    protected String getBuildCommand(BuildTool buildTool) {
+        if (buildTool == BuildTool.MAVEN) {
+            return MAVEN_AZURE_DEPLOY_COMMAND;
+        } else {
+            return GRADLE_AZURE_DEPLOY_COMMAND;
+        }
+    }
+
+    @Override
+    protected void addDependencies(GeneratorContext generatorContext) {
+        generatorContext.addDependency(CHATBOTS_TELEGRAM_LAMBDA);
+    }
+
+    @Override
+    public String rootReadMeTemplate(GeneratorContext generatorContext) {
+        return generatorContext.isFeaturePresent(Cdk.class) ?
+            awsCdkReadme.class.getName().replace(".", "/") + ".rocker.raw" :
+            awsReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramAwsChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramAwsChatBot.java
@@ -17,16 +17,17 @@ package io.micronaut.starter.feature.chatbots.telegram;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.aws.AwsFeature;
 import io.micronaut.starter.feature.aws.AwsMicronautRuntimeFeature;
 import io.micronaut.starter.feature.aws.Cdk;
 import io.micronaut.starter.feature.chatbots.template.awsCdkReadme;
 import io.micronaut.starter.feature.chatbots.template.awsReadme;
-import io.micronaut.starter.feature.function.Cloud;
-import io.micronaut.starter.feature.function.CloudFeature;
+import io.micronaut.starter.feature.function.HandlerClassFeature;
 import io.micronaut.starter.feature.function.awslambda.AwsLambda;
 import io.micronaut.starter.feature.validator.MicronautValidationFeature;
 import io.micronaut.starter.options.BuildTool;
@@ -39,7 +40,7 @@ import jakarta.inject.Singleton;
  * @since 4.3.0
  */
 @Singleton
-public class TelegramAwsChatBot extends ChatBotsTelegram implements CloudFeature, AwsMicronautRuntimeFeature {
+public class TelegramAwsChatBot extends ChatBotsTelegram implements AwsFeature, AwsMicronautRuntimeFeature, HandlerClassFeature {
 
     public static final String NAME = "chatbots-telegram-lambda";
 
@@ -49,10 +50,7 @@ public class TelegramAwsChatBot extends ChatBotsTelegram implements CloudFeature
             .compile()
             .build();
 
-    public static final String MAVEN_AZURE_DEPLOY_COMMAND = "mvnw package azure-functions:deploy";
-    public static final String GRADLE_AZURE_DEPLOY_COMMAND = "gradlew azureFunctionsDeploy";
     public static final String HANDLER_CLASS = "io.micronaut.chatbots.telegram.lambda.Handler";
-
     private final AwsLambda awsLambda;
 
     public TelegramAwsChatBot(MicronautValidationFeature validationFeature, AwsLambda awsLambda) {
@@ -72,18 +70,13 @@ public class TelegramAwsChatBot extends ChatBotsTelegram implements CloudFeature
     }
 
     @Override
-    public Cloud getCloud() {
-        return Cloud.AZURE;
-    }
-
-    @Override
     public String getTitle() {
-        return "Telegram ChatBot as Lambda";
+        return "Telegram ChatBot as AWS Lambda function";
     }
 
     @Override
     public String getDescription() {
-        return "Generates an application that can be deployed as an Lambda that implements a Telegram chatbot";
+        return "Generates an application that can be deployed as an AWS Lambda function that implements a Telegram ChatBot";
     }
 
     @Override
@@ -99,15 +92,6 @@ public class TelegramAwsChatBot extends ChatBotsTelegram implements CloudFeature
     }
 
     @Override
-    protected String getBuildCommand(BuildTool buildTool) {
-        if (buildTool == BuildTool.MAVEN) {
-            return MAVEN_AZURE_DEPLOY_COMMAND;
-        } else {
-            return GRADLE_AZURE_DEPLOY_COMMAND;
-        }
-    }
-
-    @Override
     protected void addDependencies(GeneratorContext generatorContext) {
         generatorContext.addDependency(CHATBOTS_TELEGRAM_LAMBDA);
     }
@@ -117,5 +101,15 @@ public class TelegramAwsChatBot extends ChatBotsTelegram implements CloudFeature
         return generatorContext.isFeaturePresent(Cdk.class) ?
             awsCdkReadme.class.getName().replace(".", "/") + ".rocker.raw" :
             awsReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    }
+
+    @Override
+    protected String getBuildCommand(BuildTool buildTool) {
+        return "";
+    }
+
+    @Override
+    public String handlerClass(ApplicationType applicationType, Project project) {
+        return HANDLER_CLASS;
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramAzureChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramAzureChatBot.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.chatbots.telegram;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
+import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.chatbots.template.azureReadme;
+import io.micronaut.starter.feature.function.Cloud;
+import io.micronaut.starter.feature.function.CloudFeature;
+import io.micronaut.starter.feature.function.azure.AzureMicronautRuntimeFeature;
+import io.micronaut.starter.feature.function.azure.AzureRawFunction;
+import io.micronaut.starter.feature.validator.MicronautValidationFeature;
+import io.micronaut.starter.options.BuildTool;
+import jakarta.inject.Singleton;
+
+/**
+ * Adds support for Telegram chatbots as Azure Functions.
+ *
+ * @author Tim Yates
+ * @since 4.3.0
+ */
+@Singleton
+public class TelegramAzureChatBot extends ChatBotsTelegram implements CloudFeature, AzureMicronautRuntimeFeature {
+
+    public static final String NAME = "chatbots-telegram-azure-function";
+
+    public static final Dependency CHATBOTS_TELEGRAM_AZURE_FUNCTION = MicronautDependencyUtils
+            .chatBotsDependency()
+            .artifactId("micronaut-chatbots-telegram-azure-function")
+            .compile()
+            .build();
+
+    public static final String MAVEN_AZURE_DEPLOY_COMMAND = "mvnw package azure-functions:deploy";
+    public static final String GRADLE_AZURE_DEPLOY_COMMAND = "gradlew azureFunctionsDeploy";
+
+    private final AzureRawFunction azureRawFunction;
+
+    public TelegramAzureChatBot(MicronautValidationFeature validationFeature, AzureRawFunction azureRawFunction) {
+        super(validationFeature);
+        this.azureRawFunction = azureRawFunction;
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return applicationType == ApplicationType.FUNCTION;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Cloud getCloud() {
+        return Cloud.AZURE;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Telegram ChatBot as Azure Function";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Generates an application that can be deployed as an Azure Function that implements a Telegram chatbot";
+    }
+
+    @Override
+    public void processSelectedFeatures(FeatureContext featureContext) {
+        super.processSelectedFeatures(featureContext);
+        featureContext.addFeatureIfNotPresent(AzureRawFunction.class, azureRawFunction);
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        super.apply(generatorContext);
+        addMicronautRuntimeBuildProperty(generatorContext);
+    }
+
+    @Override
+    protected String getBuildCommand(BuildTool buildTool) {
+        if (buildTool == BuildTool.MAVEN) {
+            return MAVEN_AZURE_DEPLOY_COMMAND;
+        } else {
+            return GRADLE_AZURE_DEPLOY_COMMAND;
+        }
+    }
+
+    @Override
+    protected void addDependencies(GeneratorContext generatorContext) {
+        generatorContext.addDependency(CHATBOTS_TELEGRAM_AZURE_FUNCTION);
+    }
+
+    @Override
+    public String rootReadMeTemplate(GeneratorContext generatorContext) {
+        return azureReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramAzureChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramAzureChatBot.java
@@ -22,8 +22,8 @@ import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.chatbots.template.azureReadme;
-import io.micronaut.starter.feature.function.Cloud;
-import io.micronaut.starter.feature.function.CloudFeature;
+import io.micronaut.starter.feature.function.azure.AzureBuildCommandUtils;
+import io.micronaut.starter.feature.function.azure.AzureCloudFeature;
 import io.micronaut.starter.feature.function.azure.AzureMicronautRuntimeFeature;
 import io.micronaut.starter.feature.function.azure.AzureRawFunction;
 import io.micronaut.starter.feature.validator.MicronautValidationFeature;
@@ -37,7 +37,7 @@ import jakarta.inject.Singleton;
  * @since 4.3.0
  */
 @Singleton
-public class TelegramAzureChatBot extends ChatBotsTelegram implements CloudFeature, AzureMicronautRuntimeFeature {
+public class TelegramAzureChatBot extends ChatBotsTelegram implements AzureCloudFeature, AzureMicronautRuntimeFeature {
 
     public static final String NAME = "chatbots-telegram-azure-function";
 
@@ -46,9 +46,6 @@ public class TelegramAzureChatBot extends ChatBotsTelegram implements CloudFeatu
             .artifactId("micronaut-chatbots-telegram-azure-function")
             .compile()
             .build();
-
-    public static final String MAVEN_AZURE_DEPLOY_COMMAND = "mvnw package azure-functions:deploy";
-    public static final String GRADLE_AZURE_DEPLOY_COMMAND = "gradlew azureFunctionsDeploy";
 
     private final AzureRawFunction azureRawFunction;
 
@@ -69,18 +66,13 @@ public class TelegramAzureChatBot extends ChatBotsTelegram implements CloudFeatu
     }
 
     @Override
-    public Cloud getCloud() {
-        return Cloud.AZURE;
-    }
-
-    @Override
     public String getTitle() {
-        return "Telegram ChatBot as Azure Function";
+        return "Telegram ChatBot as an Azure Function";
     }
 
     @Override
     public String getDescription() {
-        return "Generates an application that can be deployed as an Azure Function that implements a Telegram chatbot";
+        return "Generates an application that can be deployed as an Azure Function that implements a Telegram ChatBot";
     }
 
     @Override
@@ -97,11 +89,7 @@ public class TelegramAzureChatBot extends ChatBotsTelegram implements CloudFeatu
 
     @Override
     protected String getBuildCommand(BuildTool buildTool) {
-        if (buildTool == BuildTool.MAVEN) {
-            return MAVEN_AZURE_DEPLOY_COMMAND;
-        } else {
-            return GRADLE_AZURE_DEPLOY_COMMAND;
-        }
+        return AzureBuildCommandUtils.getBuildCommand(buildTool);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramGcpChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramGcpChatBot.java
@@ -22,8 +22,8 @@ import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.chatbots.template.gcpReadme;
-import io.micronaut.starter.feature.function.Cloud;
-import io.micronaut.starter.feature.function.CloudFeature;
+import io.micronaut.starter.feature.function.gcp.GcpCloudFeature;
+import io.micronaut.starter.feature.function.gcp.GcpCloudFunctionBuildCommandUtils;
 import io.micronaut.starter.feature.function.gcp.GcpMicronautRuntimeFeature;
 import io.micronaut.starter.feature.function.gcp.GoogleCloudRawFunction;
 import io.micronaut.starter.feature.validator.MicronautValidationFeature;
@@ -37,8 +37,7 @@ import jakarta.inject.Singleton;
  * @since 4.3.0
  */
 @Singleton
-public class TelegramGcpChatBot extends ChatBotsTelegram implements CloudFeature, GcpMicronautRuntimeFeature {
-
+public class TelegramGcpChatBot extends ChatBotsTelegram implements GcpCloudFeature, GcpMicronautRuntimeFeature {
     public static final String NAME = "chatbots-telegram-gcp-function";
 
     public static final Dependency CHATBOTS_TELEGRAM_GCP_FUNCTION = MicronautDependencyUtils
@@ -46,9 +45,6 @@ public class TelegramGcpChatBot extends ChatBotsTelegram implements CloudFeature
             .artifactId("micronaut-chatbots-telegram-gcp-function")
             .compile()
             .build();
-    public static final String MAVEN_PACKAGE_COMMAND = "mvnw clean package";
-    public static final String GRADLE_PACKAGE_COMMAND = "gradlew shadowJar";
-
     private final GoogleCloudRawFunction rawFunction;
 
     public TelegramGcpChatBot(MicronautValidationFeature validationFeature, GoogleCloudRawFunction rawFunction) {
@@ -68,18 +64,13 @@ public class TelegramGcpChatBot extends ChatBotsTelegram implements CloudFeature
     }
 
     @Override
-    public Cloud getCloud() {
-        return Cloud.GCP;
-    }
-
-    @Override
     public String getTitle() {
-        return "Telegram ChatBot as Google Cloud Function";
+        return "Telegram ChatBot as a Google Cloud Function";
     }
 
     @Override
     public String getDescription() {
-        return "Generates an application that can be deployed as an Google Cloud Function that implements a Telegram chatbot";
+        return "Generates an application that can be deployed as a Google Cloud Function that implements a Telegram ChatBot";
     }
 
     @Override
@@ -96,11 +87,7 @@ public class TelegramGcpChatBot extends ChatBotsTelegram implements CloudFeature
 
     @Override
     protected String getBuildCommand(BuildTool buildTool) {
-        if (buildTool == BuildTool.MAVEN) {
-            return MAVEN_PACKAGE_COMMAND;
-        } else {
-            return GRADLE_PACKAGE_COMMAND;
-        }
+        return GcpCloudFunctionBuildCommandUtils.getBuildCommand(buildTool);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramGcpChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramGcpChatBot.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.chatbots.telegram;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
+import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.chatbots.template.gcpReadme;
+import io.micronaut.starter.feature.function.Cloud;
+import io.micronaut.starter.feature.function.CloudFeature;
+import io.micronaut.starter.feature.function.gcp.GcpMicronautRuntimeFeature;
+import io.micronaut.starter.feature.function.gcp.GoogleCloudRawFunction;
+import io.micronaut.starter.feature.validator.MicronautValidationFeature;
+import io.micronaut.starter.options.BuildTool;
+import jakarta.inject.Singleton;
+
+/**
+ * Adds support for Telegram chatbots as Google Cloud Functions.
+ *
+ * @author Tim Yates
+ * @since 4.3.0
+ */
+@Singleton
+public class TelegramGcpChatBot extends ChatBotsTelegram implements CloudFeature, GcpMicronautRuntimeFeature {
+
+    public static final String NAME = "chatbots-telegram-gcp-function";
+
+    public static final Dependency CHATBOTS_TELEGRAM_GCP_FUNCTION = MicronautDependencyUtils
+            .chatBotsDependency()
+            .artifactId("micronaut-chatbots-telegram-gcp-function")
+            .compile()
+            .build();
+    public static final String MAVEN_PACKAGE_COMMAND = "mvnw clean package";
+    public static final String GRADLE_PACKAGE_COMMAND = "gradlew shadowJar";
+
+    private final GoogleCloudRawFunction rawFunction;
+
+    public TelegramGcpChatBot(MicronautValidationFeature validationFeature, GoogleCloudRawFunction rawFunction) {
+        super(validationFeature);
+        this.rawFunction = rawFunction;
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return applicationType == ApplicationType.FUNCTION;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Cloud getCloud() {
+        return Cloud.GCP;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Telegram ChatBot as Google Cloud Function";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Generates an application that can be deployed as an Google Cloud Function that implements a Telegram chatbot";
+    }
+
+    @Override
+    public void processSelectedFeatures(FeatureContext featureContext) {
+        super.processSelectedFeatures(featureContext);
+        featureContext.addFeatureIfNotPresent(GoogleCloudRawFunction.class, rawFunction);
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        super.apply(generatorContext);
+        addMicronautRuntimeBuildProperty(generatorContext);
+    }
+
+    @Override
+    protected String getBuildCommand(BuildTool buildTool) {
+        if (buildTool == BuildTool.MAVEN) {
+            return MAVEN_PACKAGE_COMMAND;
+        } else {
+            return GRADLE_PACKAGE_COMMAND;
+        }
+    }
+
+    @Override
+    protected void addDependencies(GeneratorContext generatorContext) {
+        generatorContext.addDependency(CHATBOTS_TELEGRAM_GCP_FUNCTION);
+    }
+
+    @Override
+    protected String rootReadMeTemplate(GeneratorContext generatorContext) {
+        return gcpReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramHttpChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramHttpChatBot.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.chatbots.telegram;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
+import io.micronaut.starter.feature.chatbots.template.controllerGroovyJunit;
+import io.micronaut.starter.feature.chatbots.template.controllerGroovySpock;
+import io.micronaut.starter.feature.chatbots.template.controllerJavaJunit;
+import io.micronaut.starter.feature.chatbots.template.controllerKotlinJunit;
+import io.micronaut.starter.feature.chatbots.template.controllerReadme;
+import io.micronaut.starter.feature.validator.MicronautValidationFeature;
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.options.TestFramework;
+import io.micronaut.starter.template.RockerTemplate;
+import jakarta.inject.Singleton;
+
+/**
+ * Adds support for Telegram chatbots as Google Cloud Functions.
+ *
+ * @author Tim Yates
+ * @since 4.3.0
+ */
+@Singleton
+public class TelegramHttpChatBot extends ChatBotsTelegram {
+
+    public static final String NAME = "chatbots-telegram-http";
+
+    public static final Dependency CHATBOTS_TELEGRAM_HTTP = MicronautDependencyUtils
+            .chatBotsDependency()
+            .artifactId("micronaut-chatbots-telegram-http")
+            .compile()
+            .build();
+
+    public TelegramHttpChatBot(MicronautValidationFeature validationFeature) {
+        super(validationFeature);
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return applicationType == ApplicationType.FUNCTION || applicationType == ApplicationType.DEFAULT;
+    }
+
+    @Override
+    protected void renderTemplates(GeneratorContext generatorContext) {
+        super.renderTemplates(generatorContext);
+        if (generatorContext.getTestFramework() == TestFramework.JUNIT) {
+            generatorContext.addTemplate(
+                    "http-client-command-handler-junit-test",
+                    generatorContext.getTestSourcePath("/{packagePath}/TelegramController"),
+                    controllerJavaJunit.template(generatorContext.getProject()),
+                    controllerKotlinJunit.template(generatorContext.getProject()),
+                    controllerGroovyJunit.template(generatorContext.getProject())
+            );
+        } else if (generatorContext.getTestFramework() == TestFramework.SPOCK) {
+            generatorContext.addTemplate(
+                    "http-client-command-handler-spock-test",
+                    new RockerTemplate(generatorContext.getTestSourcePath("/{packagePath}/TelegramController"), controllerGroovySpock.template(generatorContext.getProject()))
+            );
+        }
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    protected String getBuildCommand(BuildTool buildTool) {
+        return "";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Telegram ChatBot as a controller";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Generates an application that implements a Telegram chatbot controller";
+    }
+
+    @Override
+    protected void addDependencies(GeneratorContext generatorContext) {
+        generatorContext.addDependency(CHATBOTS_TELEGRAM_HTTP);
+    }
+
+    @Override
+    protected String rootReadMeTemplate(GeneratorContext generatorContext) {
+        return controllerReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramHttpChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramHttpChatBot.java
@@ -20,11 +20,7 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
-import io.micronaut.starter.feature.chatbots.template.controllerGroovyJunit;
-import io.micronaut.starter.feature.chatbots.template.controllerGroovySpock;
-import io.micronaut.starter.feature.chatbots.template.controllerJavaJunit;
-import io.micronaut.starter.feature.chatbots.template.controllerKotlinJunit;
-import io.micronaut.starter.feature.chatbots.template.controllerReadme;
+import io.micronaut.starter.feature.chatbots.template.*;
 import io.micronaut.starter.feature.validator.MicronautValidationFeature;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.TestFramework;
@@ -54,7 +50,7 @@ public class TelegramHttpChatBot extends ChatBotsTelegram {
 
     @Override
     public boolean supports(ApplicationType applicationType) {
-        return applicationType == ApplicationType.FUNCTION || applicationType == ApplicationType.DEFAULT;
+        return applicationType == ApplicationType.DEFAULT;
     }
 
     @Override
@@ -83,11 +79,6 @@ public class TelegramHttpChatBot extends ChatBotsTelegram {
     }
 
     @Override
-    protected String getBuildCommand(BuildTool buildTool) {
-        return "";
-    }
-
-    @Override
     public String getTitle() {
         return "Telegram ChatBot as a controller";
     }
@@ -105,5 +96,10 @@ public class TelegramHttpChatBot extends ChatBotsTelegram {
     @Override
     protected String rootReadMeTemplate(GeneratorContext generatorContext) {
         return controllerReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    }
+
+    @Override
+    protected String getBuildCommand(BuildTool buildTool) {
+        return "";
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/about.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/about.rocker.raw
@@ -1,0 +1,3 @@
+@args(String type)
+
+@type Bot developed with 💙 and [Micronaut](https://micronaut.io) 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/about.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/about.rocker.raw
@@ -1,3 +1,4 @@
-@args(String type)
+@import io.micronaut.starter.application.Project
+@args(io.micronaut.starter.feature.chatbots.ChatBotType type)
 
 @type Bot developed with 💙 and [Micronaut](https://micronaut.io) 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerGroovy.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerGroovy.rocker.raw
@@ -1,0 +1,35 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName()
+
+}
+
+import io.micronaut.chatbots.core.SpaceParser
+import io.micronaut.chatbots.core.TextResourceLoader
+import io.micronaut.chatbots.telegram.api.Chat
+import io.micronaut.chatbots.telegram.api.Update
+import io.micronaut.chatbots.telegram.core.CommandHandler
+import io.micronaut.chatbots.telegram.core.TelegramSlashCommandParser
+import io.micronaut.core.annotation.NonNull
+import jakarta.inject.Singleton
+
+@@Singleton
+class AboutCommandHandler extends CommandHandler {
+
+    private static final String COMMAND_ABOUT = "/about"
+
+    AboutCommandHandler(
+            TelegramSlashCommandParser slashCommandParser,
+            TextResourceLoader textResourceLoader,
+            SpaceParser<Update, Chat> spaceParser
+    ) {
+        super(slashCommandParser, textResourceLoader, spaceParser)
+    }
+
+    @@Override
+    @@NonNull
+    String getCommand() {
+        COMMAND_ABOUT
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerGroovy.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerGroovy.rocker.raw
@@ -2,7 +2,6 @@
 @args (Project project)
 @if (project.getPackageName() != null) {
 package @project.getPackageName()
-
 }
 
 import io.micronaut.chatbots.core.SpaceParser

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerGroovyJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerGroovyJunit.rocker.raw
@@ -1,0 +1,50 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName()
+
+}
+
+import io.micronaut.chatbots.core.Dispatcher
+import io.micronaut.chatbots.telegram.api.Update
+import io.micronaut.chatbots.telegram.api.send.Send
+import io.micronaut.chatbots.telegram.api.send.SendMessage
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration
+import io.micronaut.context.BeanContext
+import io.micronaut.json.JsonMapper
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+@@MicronautTest(startApplication = false)
+class AboutCommandHandlerTest {
+
+    @@Inject
+    BeanContext ctx
+
+    @@Inject
+    Dispatcher<TelegramBotConfiguration, Update, Send> dispatcher
+
+    @@Inject
+    JsonMapper jsonMapper
+
+    @@Test
+    void beanOfTypeHelloWorldHandlerExists() {
+        assertTrue(ctx.containsBean(AboutCommandHandler))
+    }
+
+    @@Test
+    void aboutCommandHandlerExists() throws Exception {
+        Send send = dispatcher.dispatch(null, jsonMapper.readValue(aboutCommandJson, Update.class)).get()
+
+        assertTrue(send instanceof SendMessage)
+        assertEquals("Telegram Bot developed with 💙 and [Micronaut](https://micronaut.io)", send.text.trim())
+    }
+
+    private String getAboutCommandJson() {
+        AboutCommandHandlerTest.getResourceAsStream("/mockAboutCommand.json").text
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerGroovySpock.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerGroovySpock.rocker.raw
@@ -1,0 +1,48 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName()
+
+}
+
+import io.micronaut.chatbots.core.Dispatcher
+import io.micronaut.chatbots.telegram.api.Update
+import io.micronaut.chatbots.telegram.api.send.Send
+import io.micronaut.chatbots.telegram.api.send.SendMessage
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration
+import io.micronaut.context.BeanContext
+import io.micronaut.json.JsonMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@@MicronautTest(startApplication = false)
+class AboutCommandHandlerSpec extends Specification {
+
+    @@Inject
+    BeanContext ctx
+
+    @@Inject
+    Dispatcher<TelegramBotConfiguration, Update, Send> dispatcher
+
+    @@Inject
+    JsonMapper jsonMapper
+
+    void "about command handler is in the context"() {
+        expect:
+        ctx.containsBean(AboutCommandHandler)
+    }
+
+    void "the about command handler works as expected"() {
+        when:
+        Send send = dispatcher.dispatch(null, jsonMapper.readValue(aboutCommandJson, Update)).get()
+
+        then:
+        send instanceof SendMessage
+        send.text.trim() == "Telegram Bot developed with 💙 and [Micronaut](https://micronaut.io)"
+    }
+
+    private String getAboutCommandJson() {
+        AboutCommandHandlerSpec.getResourceAsStream("/mockAboutCommand.json").text
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerJava.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerJava.rocker.raw
@@ -1,0 +1,35 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName();
+
+}
+
+import io.micronaut.chatbots.core.SpaceParser;
+import io.micronaut.chatbots.core.TextResourceLoader;
+import io.micronaut.chatbots.telegram.api.Chat;
+import io.micronaut.chatbots.telegram.api.Update;
+import io.micronaut.chatbots.telegram.core.CommandHandler;
+import io.micronaut.chatbots.telegram.core.TelegramSlashCommandParser;
+import io.micronaut.core.annotation.NonNull;
+import jakarta.inject.Singleton;
+
+@@Singleton
+class AboutCommandHandler extends CommandHandler {
+
+    private static final String COMMAND_ABOUT = "/about";
+
+    AboutCommandHandler(
+            TelegramSlashCommandParser slashCommandParser,
+            TextResourceLoader textResourceLoader,
+            SpaceParser<Update, Chat> spaceParser
+    ) {
+        super(slashCommandParser, textResourceLoader, spaceParser);
+    }
+
+    @@Override
+    @@NonNull
+    public String getCommand() {
+        return COMMAND_ABOUT;
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerJavaJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerJavaJunit.rocker.raw
@@ -15,9 +15,7 @@ import io.micronaut.json.JsonMapper;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,7 +43,6 @@ class AboutCommandHandlerTest {
         assertTrue(send instanceof SendMessage);
         assertEquals("Telegram Bot developed with 💙 and [Micronaut](https://micronaut.io)", ((SendMessage) send).getText().trim());
     }
-
 
     private String getAboutCommandJson() throws IOException {
         return new String(AboutCommandHandlerTest.class.getResourceAsStream("/mockAboutCommand.json").readAllBytes());

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerJavaJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerJavaJunit.rocker.raw
@@ -1,0 +1,53 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName();
+
+}
+
+import io.micronaut.chatbots.core.Dispatcher;
+import io.micronaut.chatbots.telegram.api.Update;
+import io.micronaut.chatbots.telegram.api.send.Send;
+import io.micronaut.chatbots.telegram.api.send.SendMessage;
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration;
+import io.micronaut.context.BeanContext;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@@MicronautTest(startApplication = false)
+class AboutCommandHandlerTest {
+
+    @@Inject
+    BeanContext ctx;
+
+    @@Inject
+    Dispatcher<TelegramBotConfiguration, Update, Send> dispatcher;
+
+    @@Inject
+    JsonMapper jsonMapper;
+
+    @@Test
+    void beanOfTypeHelloWorldHandlerExists() {
+        assertTrue(ctx.containsBean(AboutCommandHandler.class));
+    }
+
+    @@Test
+    void aboutCommandHandlerExists() throws Exception {
+        Send send = dispatcher.dispatch(null, jsonMapper.readValue(getAboutCommandJson(), Update.class)).get();
+
+        assertTrue(send instanceof SendMessage);
+        assertEquals("Telegram Bot developed with 💙 and [Micronaut](https://micronaut.io)", ((SendMessage) send).getText().trim());
+    }
+
+
+    private String getAboutCommandJson() throws IOException {
+        return new String(AboutCommandHandlerTest.class.getResourceAsStream("/mockAboutCommand.json").readAllBytes());
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerKotlin.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerKotlin.rocker.raw
@@ -2,7 +2,6 @@
 @args (Project project)
 @if (project.getPackageName() != null) {
 package @project.getPackageName()
-
 }
 
 import io.micronaut.chatbots.core.SpaceParser

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerKotlin.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerKotlin.rocker.raw
@@ -1,0 +1,28 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName()
+
+}
+
+import io.micronaut.chatbots.core.SpaceParser
+import io.micronaut.chatbots.core.TextResourceLoader
+import io.micronaut.chatbots.telegram.api.Chat
+import io.micronaut.chatbots.telegram.api.Update
+import io.micronaut.chatbots.telegram.core.CommandHandler
+import io.micronaut.chatbots.telegram.core.TelegramSlashCommandParser
+import jakarta.inject.Singleton
+
+@@Singleton
+open class AboutCommandHandler(
+    slashCommandParser: TelegramSlashCommandParser,
+    textResourceLoader: TextResourceLoader,
+    spaceParser: SpaceParser<Update, Chat>
+) : CommandHandler(slashCommandParser, textResourceLoader, spaceParser) {
+
+    override fun getCommand() = COMMAND_ABOUT
+
+    companion object {
+        private const val COMMAND_ABOUT = "/about"
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerKotlinJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/aboutCommandHandlerKotlinJunit.rocker.raw
@@ -1,0 +1,51 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName()
+
+}
+
+import io.micronaut.chatbots.core.Dispatcher
+import io.micronaut.chatbots.telegram.api.Update
+import io.micronaut.chatbots.telegram.api.send.Send
+import io.micronaut.chatbots.telegram.api.send.SendMessage
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration
+import io.micronaut.context.BeanContext
+import io.micronaut.json.JsonMapper
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@@MicronautTest(startApplication = false)
+class AboutCommandHandlerTest {
+
+    @@Inject
+    lateinit var ctx: BeanContext
+
+    @@Inject
+    lateinit var dispatcher: Dispatcher<TelegramBotConfiguration, Update, Send>
+
+    @@Inject
+    lateinit var jsonMapper: JsonMapper
+
+    @@Test
+    fun beanOfTypeHelloWorldHandlerExists() {
+        assertTrue(ctx.containsBean(AboutCommandHandler::class.java))
+    }
+
+    @@Test
+    @@Throws(Exception::class)
+    fun aboutCommandHandlerExists() {
+        val send = dispatcher.dispatch(null, jsonMapper.readValue(getAboutCommandJson(), Update::class.java)).get()
+
+        assertTrue(send is SendMessage)
+        assertEquals(
+            "Telegram Bot developed with 💙 and [Micronaut](https://micronaut.io)",
+            (send as SendMessage).getText().trim()
+        )
+    }
+
+    private fun getAboutCommandJson() = AboutCommandHandlerTest::class.java.getResource("/mockAboutCommand.json")!!.readText()
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/awsCdkReadme.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/awsCdkReadme.rocker.raw
@@ -1,0 +1,13 @@
+@import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Features
+@import io.micronaut.starter.feature.chatbots.telegram.TelegramAwsChatBot
+
+@args (
+Project project,
+Features features,
+String buildCommand
+)
+
+## Lambda handler class
+
+The Cdk project defined in `infra` is already configured to use `@TelegramAwsChatBot.HANDLER_CLASS` as the handler for your Lambda function.

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/awsReadme.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/awsReadme.rocker.raw
@@ -1,0 +1,13 @@
+@import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Features
+@import io.micronaut.starter.feature.chatbots.telegram.TelegramAwsChatBot
+
+@args (
+Project project,
+Features features,
+String buildCommand
+)
+
+## Lambda handler class
+
+When deployed to AWS Lambda, the lambda handler should be defined as `@TelegramAwsChatBot.HANDLER_CLASS`.

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/azureReadme.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/azureReadme.rocker.raw
@@ -1,0 +1,16 @@
+@import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Features
+
+@args (
+Project project,
+Features features,
+String buildCommand
+)
+
+## Deploying the function to Azure
+
+Once you have an Azure account set up and have logged in via `az login`, deploy the function with:
+
+```bash
+$ ./@buildCommand
+```

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerGroovyJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerGroovyJunit.rocker.raw
@@ -1,0 +1,54 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName()
+
+}
+
+import io.micronaut.chatbots.telegram.api.send.SendMessage
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration
+import io.micronaut.chatbots.telegram.core.TokenValidator
+import io.micronaut.context.BeanContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MutableHttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+@@MicronautTest
+class TelegramControllerTest {
+
+    @@Client("/")
+    @@Inject
+    HttpClient client
+
+    @@Inject
+    BeanContext ctx
+
+    @@Test
+    void aboutCommandHandlerExists() {
+        String token = ctx.getBean(TelegramBotConfiguration.class).token
+        MutableHttpRequest<String> post = HttpRequest.POST("/telegram", aboutCommandJson).header(TokenValidator.X_TELEGRAM_BOT_API_SECRET_TOKEN, token)
+        HttpResponse<SendMessage> messageResponse = client.toBlocking().exchange(post, SendMessage.class)
+        assertEquals("Telegram Bot developed with 💙 and [Micronaut](https://micronaut.io)", messageResponse.body().text.trim())
+    }
+
+    @@Test
+    void tokenIsRequired() {
+        MutableHttpRequest<String> post = HttpRequest.POST("/telegram", aboutCommandJson)
+        HttpClientResponseException httpClientResponseException = assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(post, SendMessage.class))
+        assertEquals(HttpStatus.BAD_REQUEST, httpClientResponseException.getStatus())
+    }
+
+    private String getAboutCommandJson() {
+        TelegramControllerTest.getResourceAsStream("/mockAboutCommand.json").text
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerGroovyJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerGroovyJunit.rocker.raw
@@ -2,7 +2,6 @@
 @args (Project project)
 @if (project.getPackageName() != null) {
 package @project.getPackageName()
-
 }
 
 import io.micronaut.chatbots.telegram.api.send.SendMessage

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerGroovySpock.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerGroovySpock.rocker.raw
@@ -1,0 +1,56 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName()
+
+}
+
+import io.micronaut.chatbots.telegram.api.send.SendMessage
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration
+import io.micronaut.chatbots.telegram.core.TokenValidator
+import io.micronaut.context.BeanContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MutableHttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@@MicronautTest
+class TelegramControllerSpec extends Specification {
+
+    @@Client("/")
+    @@Inject
+    HttpClient client
+
+    @@Inject
+    BeanContext ctx
+
+    void "controller is enabled and responsive"() {
+        when:
+        String token = ctx.getBean(TelegramBotConfiguration.class).token
+        MutableHttpRequest<String> post = HttpRequest.POST("/telegram", aboutCommandJson).header(TokenValidator.X_TELEGRAM_BOT_API_SECRET_TOKEN, token)
+        HttpResponse<SendMessage> messageResponse = client.toBlocking().exchange(post, SendMessage.class)
+
+        then:
+        messageResponse.body().text.trim() == "Telegram Bot developed with 💙 and [Micronaut](https://micronaut.io)"
+    }
+
+    void "controller requires token in header"() {
+        when:
+        MutableHttpRequest<String> post = HttpRequest.POST("/telegram", aboutCommandJson)
+        client.toBlocking().exchange(post, SendMessage.class)
+
+        then:
+        HttpClientResponseException httpClientResponseException = thrown()
+        httpClientResponseException.status == HttpStatus.BAD_REQUEST
+    }
+
+    private String getAboutCommandJson() {
+        TelegramControllerSpec.getResourceAsStream("/mockAboutCommand.json").text
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerJavaJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerJavaJunit.rocker.raw
@@ -19,9 +19,7 @@ import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerJavaJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerJavaJunit.rocker.raw
@@ -1,0 +1,56 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName();
+
+}
+
+import io.micronaut.chatbots.telegram.api.send.SendMessage;
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration;
+import io.micronaut.chatbots.telegram.core.TokenValidator;
+import io.micronaut.context.BeanContext;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@@MicronautTest
+class TelegramControllerTest {
+
+    @@Client("/")
+    @@Inject
+    HttpClient client;
+
+    @@Inject
+    BeanContext ctx;
+
+    @@Test
+    void aboutCommandHandlerExists() throws Exception {
+        String token = ctx.getBean(TelegramBotConfiguration.class).getToken();
+        MutableHttpRequest<String> post = HttpRequest.POST("/telegram", getAboutCommandJson()).header(TokenValidator.X_TELEGRAM_BOT_API_SECRET_TOKEN, token);
+        HttpResponse<SendMessage> messageResponse = client.toBlocking().exchange(post, SendMessage.class);
+        assertEquals("Telegram Bot developed with 💙 and [Micronaut](https://micronaut.io)", messageResponse.body().getText().trim());
+    }
+
+    @@Test
+    void tokenIsRequired() throws Exception {
+        MutableHttpRequest<String> post = HttpRequest.POST("/telegram", getAboutCommandJson());
+        HttpClientResponseException httpClientResponseException = assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(post, SendMessage.class));
+        assertEquals(HttpStatus.BAD_REQUEST, httpClientResponseException.getStatus());
+    }
+
+    private String getAboutCommandJson() throws IOException {
+        return new String(AboutCommandHandlerTest.class.getResourceAsStream("/mockAboutCommand.json").readAllBytes());
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerKotlinJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerKotlinJunit.rocker.raw
@@ -2,7 +2,6 @@
 @args (Project project)
 @if (project.getPackageName() != null) {
 package @project.getPackageName()
-
 }
 
 import io.micronaut.chatbots.telegram.api.send.SendMessage

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerKotlinJunit.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerKotlinJunit.rocker.raw
@@ -1,0 +1,55 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName()
+
+}
+
+import io.micronaut.chatbots.telegram.api.send.SendMessage
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration
+import io.micronaut.chatbots.telegram.core.TokenValidator
+import io.micronaut.context.BeanContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+@@MicronautTest
+class TelegramControllerTest {
+
+    @@field:Client("/")
+    @@Inject
+    lateinit var client: HttpClient
+
+    @@Inject
+    lateinit var ctx: BeanContext
+
+    @@Test
+    fun aboutCommandHandlerExists() {
+        val token = ctx.getBean(TelegramBotConfiguration::class.java).token
+        val post = HttpRequest.POST("/telegram", getAboutCommandJson())
+            .header(TokenValidator.X_TELEGRAM_BOT_API_SECRET_TOKEN, token)
+        val messageResponse = client.toBlocking().exchange(post, SendMessage::class.java)
+        assertEquals(
+            "Telegram Bot developed with 💙 and [Micronaut](https://micronaut.io)",
+            messageResponse.body().text.trim()
+        )
+    }
+
+    @@Test
+    fun tokenIsRequired() {
+        val post = HttpRequest.POST("/telegram", getAboutCommandJson())
+        val httpClientResponseException = assertThrows(HttpClientResponseException::class.java) {
+            client.toBlocking().exchange(post, SendMessage::class.java)
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, httpClientResponseException.status)
+    }
+
+    private fun getAboutCommandJson() = TelegramControllerTest::class.java.getResource("/mockAboutCommand.json")!!.readText()
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerReadme.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/controllerReadme.rocker.raw
@@ -1,0 +1,13 @@
+@import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Features
+
+@args (
+Project project,
+Features features,
+String buildCommand
+)
+
+This project has a dependency on `micronaut-chatbots-telegram-http` which has added a controller to your application with the path `/telegram`.
+
+When registering your bot with Telegram, you will need to provide the HTTPS URL of your application including this path.
+If you are running your application locally, you can use a tool like [ngrok](https://ngrok.com/) to expose your application to the internet.

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/finalCommandHandlerGroovy.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/finalCommandHandlerGroovy.rocker.raw
@@ -1,0 +1,47 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName()
+
+}
+
+import io.micronaut.chatbots.core.SpaceParser
+import io.micronaut.chatbots.telegram.api.Chat
+import io.micronaut.chatbots.telegram.api.Update
+import io.micronaut.chatbots.telegram.api.send.SendMessage
+import io.micronaut.chatbots.telegram.core.SendMessageUtils
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration
+import io.micronaut.chatbots.telegram.core.TelegramHandler
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.core.order.Ordered
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotNull
+
+@@Singleton
+class FinalCommandHandler implements TelegramHandler<SendMessage> {
+
+    private final SpaceParser<Update, Chat> spaceParser
+
+    FinalCommandHandler(SpaceParser<Update, Chat> spaceParser) {
+        this.spaceParser = spaceParser
+    }
+
+    @@Override
+    boolean canHandle(@@Nullable TelegramBotConfiguration bot, @@NotNull Update input) {
+        true
+    }
+
+    @@Override
+    Optional<SendMessage> handle(@@Nullable TelegramBotConfiguration bot, @@NotNull Update input) {
+        SendMessageUtils.compose(
+            spaceParser,
+            input,
+            "I don't how to handle your query: ${input.message.text}"
+        )
+    }
+
+    @@Override
+    int getOrder() {
+        Ordered.LOWEST_PRECEDENCE
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/finalCommandHandlerGroovy.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/finalCommandHandlerGroovy.rocker.raw
@@ -2,7 +2,6 @@
 @args (Project project)
 @if (project.getPackageName() != null) {
 package @project.getPackageName()
-
 }
 
 import io.micronaut.chatbots.core.SpaceParser

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/finalCommandHandlerJava.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/finalCommandHandlerJava.rocker.raw
@@ -1,0 +1,49 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName();
+
+}
+
+import io.micronaut.chatbots.core.SpaceParser;
+import io.micronaut.chatbots.telegram.api.Chat;
+import io.micronaut.chatbots.telegram.api.Update;
+import io.micronaut.chatbots.telegram.api.send.SendMessage;
+import io.micronaut.chatbots.telegram.core.SendMessageUtils;
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration;
+import io.micronaut.chatbots.telegram.core.TelegramHandler;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.order.Ordered;
+import jakarta.inject.Singleton;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Optional;
+
+@@Singleton
+class FinalCommandHandler implements TelegramHandler<SendMessage> {
+
+    private final SpaceParser<Update, Chat> spaceParser;
+
+    FinalCommandHandler(SpaceParser<Update, Chat> spaceParser) {
+        this.spaceParser = spaceParser;
+    }
+
+    @@Override
+    public boolean canHandle(@@Nullable TelegramBotConfiguration bot, @@NotNull Update input) {
+        return true;
+    }
+
+    @@Override
+    public Optional<SendMessage> handle(@@Nullable TelegramBotConfiguration bot, @@NotNull Update input) {
+        return SendMessageUtils.compose(
+            spaceParser,
+            input,
+            "I don't how to handle your query: %s".formatted(input.getMessage().getText())
+        );
+    }
+
+    @@Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/finalCommandHandlerKotlin.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/finalCommandHandlerKotlin.rocker.raw
@@ -2,7 +2,6 @@
 @args (Project project)
 @if (project.getPackageName() != null) {
 package @project.getPackageName()
-
 }
 
 import io.micronaut.chatbots.core.SpaceParser

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/finalCommandHandlerKotlin.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/finalCommandHandlerKotlin.rocker.raw
@@ -1,0 +1,32 @@
+@import io.micronaut.starter.application.Project
+@args (Project project)
+@if (project.getPackageName() != null) {
+package @project.getPackageName()
+
+}
+
+import io.micronaut.chatbots.core.SpaceParser
+import io.micronaut.chatbots.telegram.api.Chat
+import io.micronaut.chatbots.telegram.api.Update
+import io.micronaut.chatbots.telegram.api.send.SendMessage
+import io.micronaut.chatbots.telegram.core.SendMessageUtils
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration
+import io.micronaut.chatbots.telegram.core.TelegramHandler
+import io.micronaut.core.order.Ordered
+import jakarta.inject.Singleton
+import java.util.Optional
+
+@@Singleton
+open class FinalCommandHandler(private val spaceParser: SpaceParser<Update, Chat>) : TelegramHandler<SendMessage> {
+
+    override fun canHandle(bot: TelegramBotConfiguration?, input: Update) = true
+
+    override fun handle(bot: TelegramBotConfiguration?, input: Update): Optional<SendMessage> =
+        SendMessageUtils.compose(
+            spaceParser,
+            input,
+            "I don't how to handle your query: ${input.message.text}"
+        )
+
+    override fun getOrder() = Ordered.LOWEST_PRECEDENCE
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/gcpReadme.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/gcpReadme.rocker.raw
@@ -1,0 +1,39 @@
+@import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Features
+
+@args (
+Project project,
+Features features,
+String buildCommand
+)
+
+## Deploying the function to GCP
+
+Once you have a Google Cloud project selected (with billing enabled), build the function with:
+
+```bash
+$ ./@buildCommand
+```
+
+Then `cd` into the `@features.build().getJarDirectory()` directory (deployment has to be done from the location where the JAR lives):
+
+```bash
+$ cd @features.build().getJarDirectory()
+```
+
+Now run:
+
+```bash
+gcloud functions deploy @project.getName() \
+    --entry-point io.micronaut.chatbots.telegram.googlecloud.Handler \
+    --runtime java17 \
+    --trigger-http
+```
+
+Choose unauthenticated access when prompted.
+
+To obtain the trigger URL do the following:
+
+```bash
+$ YOUR_HTTP_TRIGGER_URL=$(gcloud functions describe @project.getName() --format='value(httpsTrigger.url)')
+```

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/mockAboutCommandJson.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/mockAboutCommandJson.rocker.raw
@@ -1,0 +1,30 @@
+{
+  "update_id": 952034417,
+  "message": {
+    "message_id": 447,
+    "from": {
+      "id": 613021175,
+      "is_bot": false,
+      "first_name": "John",
+      "last_name": "Del Amo",
+      "username": "johnsnow",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": 613021175,
+      "first_name": "John",
+      "last_name": "Del Amo",
+      "username": "johnsnow",
+      "type": "private"
+    },
+    "date": 1662545408,
+    "text": "/about",
+    "entities": [
+      {
+        "offset": 0,
+        "length": 6,
+        "type": "bot_command"
+      }
+    ]
+  }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/telegramReadme.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/template/telegramReadme.rocker.raw
@@ -1,0 +1,27 @@
+@import com.fizzed.rocker.Rocker
+@import io.micronaut.starter.application.Project
+@import io.micronaut.starter.feature.Features
+
+@args(
+    String platformTemplate,
+    Project project,
+    Features features,
+    String buildCommand
+)
+
+# Telegram ChatBot
+
+Follow the instructions in the [Micronaut ChatBot Documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/) to create a Telegram ChatBot.
+
+Once you have a username and HTTP auth key for your new bot, edit the application config in this project to set the bot username and make up a WEBHOOK_TOKEN so you can ensure it's Telegram that's calling your bot.
+
+@Rocker.template(platformTemplate, project, features, buildCommand)
+
+You can then set up the Telegram webhook by running the following command:
+
+```bash
+curl -X POST 'https://api.telegram.org/bot${HTTP_AUTH_KEY}/setWebhook?url=${YOUR_HTTP_TRIGGER_URL}&secret_token=${YOUR_SECRET_TOKEN}'
+```
+
+Where HTTP_AUTH_KEY is the key given to you by the BotFather, YOUR_HTTP_TRIGGER_URL is the URL of your HTTP function and YOUR_SECRET_TOKEN is the value you chose for the WEBHOOK_TOKEN in the configuration.
+

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/AbstractFunctionFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/AbstractFunctionFeature.java
@@ -21,6 +21,7 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.MicronautRuntimeFeature;
+import io.micronaut.starter.feature.chatbots.ChatBotsFeature;
 import io.micronaut.starter.feature.function.template.http.httpFunctionGroovyController;
 import io.micronaut.starter.feature.function.template.http.httpFunctionJavaController;
 import io.micronaut.starter.feature.function.template.http.httpFunctionKotlinController;
@@ -63,8 +64,10 @@ public abstract class AbstractFunctionFeature implements FunctionFeature, Micron
     protected void applyFunction(GeneratorContext generatorContext, ApplicationType type) {
         BuildTool buildTool = generatorContext.getBuildTool();
 
-        readmeTemplate(generatorContext, generatorContext.getProject(), buildTool)
-            .ifPresent(rockerModel -> generatorContext.addHelpTemplate(new RockerWritable(rockerModel)));
+        if (generatorContext.isFeatureMissing(ChatBotsFeature.class)) {
+            readmeTemplate(generatorContext, generatorContext.getProject(), buildTool)
+                    .ifPresent(rockerModel -> generatorContext.addHelpTemplate(new RockerWritable(rockerModel)));
+        }
 
         if (type == ApplicationType.DEFAULT) {
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/AwsLambda.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/AwsLambda.java
@@ -23,10 +23,7 @@ import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
-import io.micronaut.starter.feature.Category;
-import io.micronaut.starter.feature.DefaultFeature;
-import io.micronaut.starter.feature.Feature;
-import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.*;
 import io.micronaut.starter.feature.architecture.CpuArchitecture;
 import io.micronaut.starter.feature.architecture.X86;
 import io.micronaut.starter.feature.aws.AwsApiFeature;
@@ -35,9 +32,7 @@ import io.micronaut.starter.feature.aws.AwsLambdaEventFeature;
 import io.micronaut.starter.feature.aws.AwsLambdaEventsSerde;
 import io.micronaut.starter.feature.aws.AwsLambdaSnapstart;
 import io.micronaut.starter.feature.aws.AwsMicronautRuntimeFeature;
-import io.micronaut.starter.feature.awsalexa.AwsAlexa;
 import io.micronaut.starter.feature.awslambdacustomruntime.AwsLambdaCustomRuntime;
-import io.micronaut.starter.feature.chatbots.ChatBots;
 import io.micronaut.starter.feature.config.ApplicationConfiguration;
 import io.micronaut.starter.feature.function.CloudFeature;
 import io.micronaut.starter.feature.function.DocumentationLink;
@@ -201,7 +196,7 @@ public class AwsLambda implements FunctionFeature, DefaultFeature, AwsCloudFeatu
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        if (shouldGenerateSources(generatorContext)) {
+        if (generatorContext.isFeatureMissing(CodeContributingFeature.class)) {
             ApplicationType applicationType = generatorContext.getApplicationType();
             if (applicationType == DEFAULT || applicationType == FUNCTION) {
                 addCode(generatorContext);
@@ -271,10 +266,6 @@ public class AwsLambda implements FunctionFeature, DefaultFeature, AwsCloudFeatu
             ApplicationConfiguration test = generatorContext.getConfiguration(Environment.FUNCTION, ApplicationConfiguration.functionTestConfig());
             test.put("micronaut.security.filter.enabled", false);
         }
-    }
-
-    boolean shouldGenerateSources(GeneratorContext generatorContext) {
-        return generatorContext.isFeatureMissing(AwsAlexa.class) && generatorContext.isFeatureMissing(ChatBots.class);
     }
 
     private void addHomeControllerTest(GeneratorContext generatorContext, Project project) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/AwsLambda.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/awslambda/AwsLambda.java
@@ -37,6 +37,7 @@ import io.micronaut.starter.feature.aws.AwsLambdaSnapstart;
 import io.micronaut.starter.feature.aws.AwsMicronautRuntimeFeature;
 import io.micronaut.starter.feature.awsalexa.AwsAlexa;
 import io.micronaut.starter.feature.awslambdacustomruntime.AwsLambdaCustomRuntime;
+import io.micronaut.starter.feature.chatbots.ChatBots;
 import io.micronaut.starter.feature.config.ApplicationConfiguration;
 import io.micronaut.starter.feature.function.CloudFeature;
 import io.micronaut.starter.feature.function.DocumentationLink;
@@ -273,7 +274,7 @@ public class AwsLambda implements FunctionFeature, DefaultFeature, AwsCloudFeatu
     }
 
     boolean shouldGenerateSources(GeneratorContext generatorContext) {
-        return !generatorContext.getFeatures().isFeaturePresent(AwsAlexa.class);
+        return generatorContext.isFeatureMissing(AwsAlexa.class) && generatorContext.isFeatureMissing(ChatBots.class);
     }
 
     private void addHomeControllerTest(GeneratorContext generatorContext, Project project) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
@@ -26,6 +26,7 @@ import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.gradle.GradleDsl;
 import io.micronaut.starter.build.gradle.GradlePlugin;
 import io.micronaut.starter.build.maven.MavenPlugin;
+import io.micronaut.starter.feature.chatbots.ChatBotsFeature;
 import io.micronaut.starter.feature.function.AbstractFunctionFeature;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionMavenPlugin;
 import io.micronaut.starter.feature.function.azure.template.azurefunctions;
@@ -136,7 +137,8 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
     }
 
     protected void addFunctionTemplate(GeneratorContext generatorContext, Project project) {
-        if (generatorContext.getApplicationType() == ApplicationType.FUNCTION) {
+        if (generatorContext.getApplicationType() == ApplicationType.FUNCTION
+                && generatorContext.isFeatureMissing(ChatBotsFeature.class)) {
             String triggerFile = generatorContext.getSourcePath("/{packagePath}/Function");
             generatorContext.addTemplate("trigger", triggerFile,
                     azureRawFunctionTriggerJava.template(project),

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
@@ -26,7 +26,7 @@ import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.gradle.GradleDsl;
 import io.micronaut.starter.build.gradle.GradlePlugin;
 import io.micronaut.starter.build.maven.MavenPlugin;
-import io.micronaut.starter.feature.chatbots.ChatBotsFeature;
+import io.micronaut.starter.feature.CodeContributingFeature;
 import io.micronaut.starter.feature.function.AbstractFunctionFeature;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionMavenPlugin;
 import io.micronaut.starter.feature.function.azure.template.azurefunctions;
@@ -138,7 +138,7 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
 
     protected void addFunctionTemplate(GeneratorContext generatorContext, Project project) {
         if (generatorContext.getApplicationType() == ApplicationType.FUNCTION
-                && generatorContext.isFeatureMissing(ChatBotsFeature.class)) {
+                && generatorContext.isFeatureMissing(CodeContributingFeature.class)) {
             String triggerFile = generatorContext.getSourcePath("/{packagePath}/Function");
             generatorContext.addTemplate("trigger", triggerFile,
                     azureRawFunctionTriggerJava.template(project),
@@ -183,13 +183,7 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
 
     @Override
     protected String getBuildCommand(BuildTool buildTool) {
-        if (buildTool == BuildTool.MAVEN) {
-            return "mvnw clean package azure-functions:deploy";
-        } else if (buildTool.isGradle()) {
-            return "gradlew azureFunctionsDeploy";
-        } else {
-            throw new IllegalStateException("Unsupported build tool");
-        }
+        return AzureBuildCommandUtils.getBuildCommand(buildTool);
     }
 
     protected void addDependencies(GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureBuildCommandUtils.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureBuildCommandUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.function.azure;
+
+import io.micronaut.starter.options.BuildTool;
+
+public final class AzureBuildCommandUtils {
+
+    public static final String MAVEN_AZURE_DEPLOY_COMMAND = "mvnw package azure-functions:deploy";
+    public static final String GRADLE_AZURE_DEPLOY_COMMAND = "gradlew azureFunctionsDeploy";
+
+    private AzureBuildCommandUtils() {
+    }
+
+    public static String getBuildCommand(BuildTool buildTool) {
+        if (buildTool == BuildTool.MAVEN) {
+            return MAVEN_AZURE_DEPLOY_COMMAND;
+        } else if (buildTool.isGradle()) {
+            return GRADLE_AZURE_DEPLOY_COMMAND;
+        } else {
+            throw new IllegalStateException("Unsupported build tool");
+        }
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureRawFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureRawFunction.java
@@ -23,6 +23,7 @@ import io.micronaut.starter.build.dependencies.CoordinateResolver;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.chatbots.ChatBotsFeature;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionReadme;
 import io.micronaut.starter.feature.function.azure.template.raw.azureRawFunctionHttpRequestJava;
 import io.micronaut.starter.feature.function.azure.template.raw.azureRawFunctionResponseBuilderJava;
@@ -69,7 +70,9 @@ public class AzureRawFunction extends AbstractAzureFunction {
     protected void applyFunction(GeneratorContext generatorContext, ApplicationType type) {
         super.applyFunction(generatorContext, type);
 
-        if (type == ApplicationType.FUNCTION && !(generatorContext.getBuildTool() == BuildTool.MAVEN && generatorContext.getLanguage() == Language.KOTLIN)) {
+        if (type == ApplicationType.FUNCTION
+                && generatorContext.isFeatureMissing(ChatBotsFeature.class)
+                && !(generatorContext.getBuildTool() == BuildTool.MAVEN && generatorContext.getLanguage() == Language.KOTLIN)) {
             Project project = generatorContext.getProject();
 
             generateJavaTestClass(generatorContext,

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureRawFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureRawFunction.java
@@ -22,8 +22,8 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.CoordinateResolver;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
+import io.micronaut.starter.feature.CodeContributingFeature;
 import io.micronaut.starter.feature.FeatureContext;
-import io.micronaut.starter.feature.chatbots.ChatBotsFeature;
 import io.micronaut.starter.feature.function.azure.template.azureFunctionReadme;
 import io.micronaut.starter.feature.function.azure.template.raw.azureRawFunctionHttpRequestJava;
 import io.micronaut.starter.feature.function.azure.template.raw.azureRawFunctionResponseBuilderJava;
@@ -71,7 +71,7 @@ public class AzureRawFunction extends AbstractAzureFunction {
         super.applyFunction(generatorContext, type);
 
         if (type == ApplicationType.FUNCTION
-                && generatorContext.isFeatureMissing(ChatBotsFeature.class)
+                && generatorContext.isFeatureMissing(CodeContributingFeature.class)
                 && !(generatorContext.getBuildTool() == BuildTool.MAVEN && generatorContext.getLanguage() == Language.KOTLIN)) {
             Project project = generatorContext.getProject();
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GcpCloudFunctionBuildCommandUtils.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GcpCloudFunctionBuildCommandUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.function.gcp;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.options.BuildTool;
+
+public final class GcpCloudFunctionBuildCommandUtils {
+
+    public static final String MAVEN_PACKAGE_COMMAND = "mvnw clean package";
+    public static final String GRADLE_PACKAGE_COMMAND = "gradlew shadowJar";
+
+    private GcpCloudFunctionBuildCommandUtils() {
+    }
+
+    @NonNull
+    public static String getBuildCommand(@NonNull BuildTool buildTool) {
+        if (buildTool == BuildTool.MAVEN) {
+            return MAVEN_PACKAGE_COMMAND;
+        } else {
+            return GRADLE_PACKAGE_COMMAND;
+        }
+    }
+
+    @NonNull
+    public static String getRunCommand(@NonNull BuildTool buildTool) {
+        if (buildTool == BuildTool.MAVEN) {
+            return "mvnw function:run";
+        } else {
+            return "gradlew runFunction";
+        }
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GoogleCloudFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GoogleCloudFunction.java
@@ -120,20 +120,12 @@ public class GoogleCloudFunction extends AbstractGoogleCloudFunction {
 
     @Override
     protected String getRunCommand(BuildTool buildTool) {
-        if (buildTool == BuildTool.MAVEN) {
-            return "mvnw function:run";
-        } else {
-            return "gradlew runFunction";
-        }
+        return GcpCloudFunctionBuildCommandUtils.getRunCommand(buildTool);
     }
 
     @Override
     protected String getBuildCommand(BuildTool buildTool) {
-        if (buildTool == BuildTool.MAVEN) {
-            return "mvnw clean package";
-        } else {
-            return "gradlew clean shadowJar";
-        }
+        return GcpCloudFunctionBuildCommandUtils.getBuildCommand(buildTool);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GoogleCloudRawFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GoogleCloudRawFunction.java
@@ -22,8 +22,8 @@ import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
+import io.micronaut.starter.feature.CodeContributingFeature;
 import io.micronaut.starter.feature.FeatureContext;
-import io.micronaut.starter.feature.chatbots.ChatBotsFeature;
 import io.micronaut.starter.feature.function.gcp.template.gcpFunctionReadme;
 import io.micronaut.starter.feature.function.gcp.template.raw.gcpRawBackgroundFunctionGroovy;
 import io.micronaut.starter.feature.function.gcp.template.raw.gcpRawBackgroundFunctionJava;
@@ -67,7 +67,7 @@ public class GoogleCloudRawFunction extends AbstractGoogleCloudFunction {
     public void apply(GeneratorContext generatorContext) {
         super.apply(generatorContext);
         ApplicationType type = generatorContext.getApplicationType();
-        if (type == ApplicationType.FUNCTION && generatorContext.isFeatureMissing(ChatBotsFeature.class)) {
+        if (type == ApplicationType.FUNCTION && generatorContext.isFeatureMissing(CodeContributingFeature.class)) {
             Project project = generatorContext.getProject();
             String sourceFile = generatorContext.getSourcePath("/{packagePath}/Function");
             generatorContext.addTemplate(

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GoogleCloudRawFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GoogleCloudRawFunction.java
@@ -23,6 +23,7 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.chatbots.ChatBotsFeature;
 import io.micronaut.starter.feature.function.gcp.template.gcpFunctionReadme;
 import io.micronaut.starter.feature.function.gcp.template.raw.gcpRawBackgroundFunctionGroovy;
 import io.micronaut.starter.feature.function.gcp.template.raw.gcpRawBackgroundFunctionJava;
@@ -35,8 +36,6 @@ import io.micronaut.starter.feature.function.gcp.template.raw.gcpRawFunctionSpoc
 import io.micronaut.starter.feature.json.JacksonDatabindFeature;
 import io.micronaut.starter.feature.other.ShadePlugin;
 import io.micronaut.starter.options.BuildTool;
-import io.micronaut.starter.options.Language;
-import io.micronaut.starter.template.RockerTemplate;
 import jakarta.inject.Singleton;
 
 import java.util.Optional;
@@ -68,27 +67,16 @@ public class GoogleCloudRawFunction extends AbstractGoogleCloudFunction {
     public void apply(GeneratorContext generatorContext) {
         super.apply(generatorContext);
         ApplicationType type = generatorContext.getApplicationType();
-        if (type == ApplicationType.FUNCTION) {
-            Language language = generatorContext.getLanguage();
+        if (type == ApplicationType.FUNCTION && generatorContext.isFeatureMissing(ChatBotsFeature.class)) {
             Project project = generatorContext.getProject();
             String sourceFile = generatorContext.getSourcePath("/{packagePath}/Function");
-            switch (language) {
-                case GROOVY:
-                    generatorContext.addTemplate("function", new RockerTemplate(
-                            sourceFile,
-                            gcpRawBackgroundFunctionGroovy.template(project)));
-                break;
-                case KOTLIN:
-                    generatorContext.addTemplate("function", new RockerTemplate(
-                            sourceFile,
-                            gcpRawBackgroundFunctionKotlin.template(project)));
-                break;
-                case JAVA:
-                default:
-                    generatorContext.addTemplate("function", new RockerTemplate(
-                            sourceFile,
-                            gcpRawBackgroundFunctionJava.template(project)));
-            }
+            generatorContext.addTemplate(
+                    "function",
+                    sourceFile,
+                    gcpRawBackgroundFunctionJava.template(project),
+                    gcpRawBackgroundFunctionKotlin.template(project),
+                    gcpRawBackgroundFunctionGroovy.template(project)
+            );
 
             applyTestTemplate(generatorContext, project, "Function");
             addDependencies(generatorContext);

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/BaseChatBotSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/BaseChatBotSpec.groovy
@@ -1,11 +1,30 @@
 package io.micronaut.starter.feature.chatbots
 
 import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
 
 abstract class BaseChatBotSpec extends ApplicationContextSpec implements CommandOutputFixture {
+
+    abstract List<ApplicationType> getSupportedApplicationTypes()
 
     abstract Class<ChatBotsFeature> getFeature()
 
     abstract String getFeatureName()
+
+    void 'example chat commands are generated in #language'(Language language) {
+        when:
+        ApplicationType applicationType = getSupportedApplicationTypes().contains(ApplicationType.FUNCTION) ? ApplicationType.FUNCTION : getSupportedApplicationTypes().stream().findFirst().orElseThrow()
+        def output = generate(applicationType, new Options(language), [featureName])
+
+        then:
+        output.containsKey("src/main/$language.name/example/micronaut/AboutCommandHandler.$language.extension".toString())
+        output.containsKey("src/main/$language.name/example/micronaut/FinalCommandHandler.$language.extension".toString())
+        output.containsKey("src/main/resources/botcommands/about.md")
+
+        where:
+        language << Language.values()
+    }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/BaseChatBotSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/BaseChatBotSpec.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.starter.feature.chatbots
+
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.fixture.CommandOutputFixture
+
+abstract class BaseChatBotSpec extends ApplicationContextSpec implements CommandOutputFixture {
+
+    abstract Class<ChatBotsFeature> getFeature()
+
+    abstract String getFeatureName()
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/BaseTelegramChatBotSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/BaseTelegramChatBotSpec.groovy
@@ -2,13 +2,12 @@ package io.micronaut.starter.feature.chatbots.telegram
 
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.chatbots.BaseChatBotSpec
+
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 
 abstract class BaseTelegramChatBotSpec extends BaseChatBotSpec {
-
-    abstract List<ApplicationType> getSupportedApplicationTypes()
 
     void 'feature #supportMsg ApplicationType #type'(ApplicationType type, boolean supports) {
         expect:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/BaseTelegramChatBotSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/BaseTelegramChatBotSpec.groovy
@@ -1,0 +1,51 @@
+package io.micronaut.starter.feature.chatbots.telegram
+
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.chatbots.BaseChatBotSpec
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
+
+abstract class BaseTelegramChatBotSpec extends BaseChatBotSpec {
+
+    abstract List<ApplicationType> getSupportedApplicationTypes()
+
+    void 'feature #supportMsg ApplicationType #type'(ApplicationType type, boolean supports) {
+        expect:
+        beanContext.getBean(feature).supports(type) == supports
+
+        where:
+        type << ApplicationType.values()
+        supports = type in supportedApplicationTypes
+        supportMsg = supports ? 'supports' : 'does not support'
+    }
+
+    void 'configuration is generated for #applicationType apps'() {
+        when:
+        def output = generate(applicationType, [featureName])
+        def cfg = output["src/main/resources/application.properties"]
+
+        then:
+        cfg.contains("micronaut.chatbots.folder=botcommands")
+        cfg.contains("micronaut.chatbots.telegram.bots.example.token=WEBHOOK_TOKEN")
+        cfg.contains("micronaut.chatbots.telegram.bots.example.at-username=@MyMicronautExampleBot")
+
+        where:
+        applicationType << supportedApplicationTypes
+    }
+
+    void 'example chat commands are generated in #language for #applicationType apps'(Language language, ApplicationType applicationType) {
+        when:
+        def output = generate(applicationType, new Options(language, TestFramework.JUNIT), [featureName])
+
+        then:
+        output.containsKey("src/main/$language.name/example/micronaut/AboutCommandHandler.$language.extension".toString())
+        output.containsKey("src/main/$language.name/example/micronaut/FinalCommandHandler.$language.extension".toString())
+        output.containsKey("src/main/resources/botcommands/about.md")
+        output.containsKey(language.getTestSourcePath("/example/micronaut/AboutCommandHandlerTest"))
+        output.containsKey("src/test/resources/mockAboutCommand.json")
+
+        where:
+        [language, applicationType] << [Language.values(), supportedApplicationTypes].combinations()
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramAwsChatBotSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramAwsChatBotSpec.groovy
@@ -1,12 +1,22 @@
 package io.micronaut.starter.feature.chatbots.telegram
 
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.aws.AwsLambdaFeatureValidator
+import io.micronaut.starter.feature.aws.Cdk
 import io.micronaut.starter.feature.chatbots.ChatBotsFeature
+import io.micronaut.starter.feature.function.Cloud
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
+import spock.lang.Shared
 
 class TelegramAwsChatBotSpec extends BaseTelegramChatBotSpec {
+
+    @Override
+    List<ApplicationType> getSupportedApplicationTypes() {
+        [ApplicationType.FUNCTION]
+    }
 
     @Override
     Class<ChatBotsFeature> getFeature() {
@@ -18,9 +28,9 @@ class TelegramAwsChatBotSpec extends BaseTelegramChatBotSpec {
         TelegramAwsChatBot.NAME
     }
 
-    @Override
-    List<ApplicationType> getSupportedApplicationTypes() {
-        [ApplicationType.FUNCTION]
+    void 'chatbots-telegram-lambda feature is an AWS cloud feature'() {
+        expect:
+        Cloud.AWS == beanContext.getBean(feature).getCloud()
     }
 
     void 'test README contains docs for #buildTool'(BuildTool buildTool) {
@@ -34,7 +44,7 @@ class TelegramAwsChatBotSpec extends BaseTelegramChatBotSpec {
         readme.contains("When deployed to AWS Lambda, the lambda handler should be defined as `io.micronaut.chatbots.telegram.lambda.Handler`.")
         readme.contains("- [Micronaut Validation documentation](https://micronaut-projects.github.io/micronaut-validation/latest/guide/)")
         readme.contains("- [Micronaut AWS Lambda Function documentation](https://micronaut-projects.github.io/micronaut-aws/latest/guide/index.html#lambda)")
-        readme.contains("- [Micronaut Telegram ChatBot as Lambda documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/)")
+        readme.contains("- [Micronaut Telegram ChatBot as AWS Lambda function documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/)")
 
         where:
         buildTool << BuildTool.values()
@@ -52,9 +62,21 @@ class TelegramAwsChatBotSpec extends BaseTelegramChatBotSpec {
         readme.contains("## How to deploy")
         readme.contains("- [Micronaut Validation documentation](https://micronaut-projects.github.io/micronaut-validation/latest/guide/)")
         readme.contains("- [Micronaut AWS Lambda Function documentation](https://micronaut-projects.github.io/micronaut-aws/latest/guide/index.html#lambda)")
-        readme.contains("- [Micronaut Telegram ChatBot as Lambda documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/)")
+        readme.contains("- [Micronaut Telegram ChatBot as AWS Lambda function documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/)")
         readme.contains("## Feature aws-cdk documentation")
         readme.contains("- [https://docs.aws.amazon.com/cdk/v2/guide/home.html](https://docs.aws.amazon.com/cdk/v2/guide/home.html)")
+
+        where:
+        buildTool << BuildTool.values()
+    }
+
+    void 'Handler is is set to io.micronaut.chatbots.telegram.lambda.Handler in CDK when features chatbots-telegram-lambda and aws-cdk'() {
+        when:
+        Options options = new Options(Language.JAVA, TestFramework.JUNIT, BuildTool.GRADLE_KOTLIN, AwsLambdaFeatureValidator.firstSupportedJdk())
+        Map<String, String> output = generate(ApplicationType.FUNCTION, options, [TelegramAwsChatBot.NAME, Cdk.NAME])
+
+        then:
+        output.'infra/src/main/java/example/micronaut/AppStack.java'.contains('io.micronaut.chatbots.telegram.lambda.Handler')
 
         where:
         buildTool << BuildTool.values()

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramAwsChatBotSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramAwsChatBotSpec.groovy
@@ -1,0 +1,62 @@
+package io.micronaut.starter.feature.chatbots.telegram
+
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.chatbots.ChatBotsFeature
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+
+class TelegramAwsChatBotSpec extends BaseTelegramChatBotSpec {
+
+    @Override
+    Class<ChatBotsFeature> getFeature() {
+        TelegramAwsChatBot
+    }
+
+    @Override
+    String getFeatureName() {
+        TelegramAwsChatBot.NAME
+    }
+
+    @Override
+    List<ApplicationType> getSupportedApplicationTypes() {
+        [ApplicationType.FUNCTION]
+    }
+
+    void 'test README contains docs for #buildTool'(BuildTool buildTool) {
+        when:
+        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool), [featureName])
+        def readme = output["README.md"]
+
+        then:
+        readme.contains("Telegram ChatBot")
+        readme.contains("## Lambda handler class")
+        readme.contains("When deployed to AWS Lambda, the lambda handler should be defined as `io.micronaut.chatbots.telegram.lambda.Handler`.")
+        readme.contains("- [Micronaut Validation documentation](https://micronaut-projects.github.io/micronaut-validation/latest/guide/)")
+        readme.contains("- [Micronaut AWS Lambda Function documentation](https://micronaut-projects.github.io/micronaut-aws/latest/guide/index.html#lambda)")
+        readme.contains("- [Micronaut Telegram ChatBot as Lambda documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/)")
+
+        where:
+        buildTool << BuildTool.values()
+    }
+
+    void 'test README contains docs for #buildTool with CDK'(BuildTool buildTool) {
+        when:
+        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool), [featureName, 'aws-cdk'])
+        def readme = output["README.md"]
+
+        then:
+        readme.contains("Telegram ChatBot")
+        readme.contains("## Lambda handler class")
+        readme.contains("The Cdk project defined in `infra` is already configured to use `io.micronaut.chatbots.telegram.lambda.Handler` as the handler for your Lambda function.")
+        readme.contains("## How to deploy")
+        readme.contains("- [Micronaut Validation documentation](https://micronaut-projects.github.io/micronaut-validation/latest/guide/)")
+        readme.contains("- [Micronaut AWS Lambda Function documentation](https://micronaut-projects.github.io/micronaut-aws/latest/guide/index.html#lambda)")
+        readme.contains("- [Micronaut Telegram ChatBot as Lambda documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/)")
+        readme.contains("## Feature aws-cdk documentation")
+        readme.contains("- [https://docs.aws.amazon.com/cdk/v2/guide/home.html](https://docs.aws.amazon.com/cdk/v2/guide/home.html)")
+
+        where:
+        buildTool << BuildTool.values()
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramAzureChatBotSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramAzureChatBotSpec.groovy
@@ -2,9 +2,12 @@ package io.micronaut.starter.feature.chatbots.telegram
 
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.chatbots.ChatBotsFeature
+import io.micronaut.starter.feature.function.Cloud
+import io.micronaut.starter.feature.function.azure.AzureBuildCommandUtils
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
+import spock.lang.Shared
 
 class TelegramAzureChatBotSpec extends BaseTelegramChatBotSpec {
 
@@ -23,6 +26,11 @@ class TelegramAzureChatBotSpec extends BaseTelegramChatBotSpec {
         [ApplicationType.FUNCTION]
     }
 
+    void 'chatbots-telegram-azure-function feature is an Azure cloud feature'() {
+        expect:
+        Cloud.AZURE == beanContext.getBean(feature).getCloud()
+    }
+
     void 'test README contains docs for #buildTool and command "#command"'(BuildTool buildTool, String command) {
         when:
         def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool), [featureName])
@@ -34,10 +42,10 @@ class TelegramAzureChatBotSpec extends BaseTelegramChatBotSpec {
         readme.contains("- [Micronaut Azure Function documentation](https://micronaut-projects.github.io/micronaut-azure/latest/guide/index.html#simpleAzureFunctions)")
         readme.contains("- [https://docs.microsoft.com/azure](https://docs.microsoft.com/azure)")
         readme.contains("- [Micronaut Validation documentation](https://micronaut-projects.github.io/micronaut-validation/latest/guide/)")
-        readme.contains("- [Micronaut Telegram ChatBot as Azure Function documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/)")
+        readme.contains("- [Micronaut Telegram ChatBot as an Azure Function documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/)")
 
         where:
         buildTool << BuildTool.values()
-        command = buildTool.isGradle() ? TelegramAzureChatBot.GRADLE_AZURE_DEPLOY_COMMAND : TelegramAzureChatBot.MAVEN_AZURE_DEPLOY_COMMAND
+        command = buildTool.isGradle() ? AzureBuildCommandUtils.GRADLE_AZURE_DEPLOY_COMMAND : AzureBuildCommandUtils.MAVEN_AZURE_DEPLOY_COMMAND
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramAzureChatBotSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramAzureChatBotSpec.groovy
@@ -1,0 +1,43 @@
+package io.micronaut.starter.feature.chatbots.telegram
+
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.chatbots.ChatBotsFeature
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+
+class TelegramAzureChatBotSpec extends BaseTelegramChatBotSpec {
+
+    @Override
+    Class<ChatBotsFeature> getFeature() {
+        TelegramAzureChatBot
+    }
+
+    @Override
+    String getFeatureName() {
+        TelegramAzureChatBot.NAME
+    }
+
+    @Override
+    List<ApplicationType> getSupportedApplicationTypes() {
+        [ApplicationType.FUNCTION]
+    }
+
+    void 'test README contains docs for #buildTool and command "#command"'(BuildTool buildTool, String command) {
+        when:
+        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool), [featureName])
+        def readme = output["README.md"]
+
+        then:
+        readme.contains("Telegram ChatBot")
+        readme.contains("./$command")
+        readme.contains("- [Micronaut Azure Function documentation](https://micronaut-projects.github.io/micronaut-azure/latest/guide/index.html#simpleAzureFunctions)")
+        readme.contains("- [https://docs.microsoft.com/azure](https://docs.microsoft.com/azure)")
+        readme.contains("- [Micronaut Validation documentation](https://micronaut-projects.github.io/micronaut-validation/latest/guide/)")
+        readme.contains("- [Micronaut Telegram ChatBot as Azure Function documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/)")
+
+        where:
+        buildTool << BuildTool.values()
+        command = buildTool.isGradle() ? TelegramAzureChatBot.GRADLE_AZURE_DEPLOY_COMMAND : TelegramAzureChatBot.MAVEN_AZURE_DEPLOY_COMMAND
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramGcpChatBotSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramGcpChatBotSpec.groovy
@@ -1,0 +1,42 @@
+package io.micronaut.starter.feature.chatbots.telegram
+
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.chatbots.ChatBotsFeature
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+
+class TelegramGcpChatBotSpec extends BaseTelegramChatBotSpec {
+
+    @Override
+    Class<ChatBotsFeature> getFeature() {
+        TelegramGcpChatBot
+    }
+
+    @Override
+    String getFeatureName() {
+        TelegramGcpChatBot.NAME
+    }
+
+    @Override
+    List<ApplicationType> getSupportedApplicationTypes() {
+        [ApplicationType.FUNCTION]
+    }
+
+    void 'test README contains docs for #buildTool and command "#command"'(BuildTool buildTool, String command) {
+        when:
+        def output = generate(ApplicationType.FUNCTION, new Options(Language.JAVA, buildTool), [featureName])
+        def readme = output["README.md"]
+
+        then:
+        readme.contains("Telegram ChatBot")
+        readme.contains("./$command")
+        readme.contains("- [Micronaut Google Cloud Function documentation](https://micronaut-projects.github.io/micronaut-gcp/latest/guide/index.html#simpleFunctions)")
+        readme.contains("- [Micronaut Validation documentation](https://micronaut-projects.github.io/micronaut-validation/latest/guide/)")
+        readme.contains("- [Micronaut Telegram ChatBot as Google Cloud Function documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/)")
+
+        where:
+        buildTool << BuildTool.values()
+        command = buildTool.isGradle() ? TelegramGcpChatBot.GRADLE_PACKAGE_COMMAND : TelegramGcpChatBot.MAVEN_PACKAGE_COMMAND
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramGcpChatBotSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramGcpChatBotSpec.groovy
@@ -1,6 +1,12 @@
 package io.micronaut.starter.feature.chatbots.telegram
 
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.function.Cloud
+import io.micronaut.starter.feature.function.gcp.GcpCloudFunctionBuildCommandUtils
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+import spock.lang.Shared
 import io.micronaut.starter.feature.chatbots.ChatBotsFeature
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
@@ -18,9 +24,13 @@ class TelegramGcpChatBotSpec extends BaseTelegramChatBotSpec {
         TelegramGcpChatBot.NAME
     }
 
-    @Override
     List<ApplicationType> getSupportedApplicationTypes() {
         [ApplicationType.FUNCTION]
+    }
+
+    void 'chatbots-telegram-gcp-function feature is an GCP cloud feature'() {
+        expect:
+        Cloud.GCP == beanContext.getBean(feature).getCloud()
     }
 
     void 'test README contains docs for #buildTool and command "#command"'(BuildTool buildTool, String command) {
@@ -33,10 +43,10 @@ class TelegramGcpChatBotSpec extends BaseTelegramChatBotSpec {
         readme.contains("./$command")
         readme.contains("- [Micronaut Google Cloud Function documentation](https://micronaut-projects.github.io/micronaut-gcp/latest/guide/index.html#simpleFunctions)")
         readme.contains("- [Micronaut Validation documentation](https://micronaut-projects.github.io/micronaut-validation/latest/guide/)")
-        readme.contains("- [Micronaut Telegram ChatBot as Google Cloud Function documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/)")
+        readme.contains("- [Micronaut Telegram ChatBot as a Google Cloud Function documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/)")
 
         where:
         buildTool << BuildTool.values()
-        command = buildTool.isGradle() ? TelegramGcpChatBot.GRADLE_PACKAGE_COMMAND : TelegramGcpChatBot.MAVEN_PACKAGE_COMMAND
+        command = buildTool.isGradle() ? GcpCloudFunctionBuildCommandUtils.GRADLE_PACKAGE_COMMAND : GcpCloudFunctionBuildCommandUtils.MAVEN_PACKAGE_COMMAND
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramHttpChatBotSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramHttpChatBotSpec.groovy
@@ -1,0 +1,40 @@
+package io.micronaut.starter.feature.chatbots.telegram
+
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.chatbots.ChatBotsFeature
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+
+class TelegramHttpChatBotSpec extends BaseTelegramChatBotSpec {
+
+    @Override
+    Class<ChatBotsFeature> getFeature() {
+        TelegramHttpChatBot
+    }
+
+    @Override
+    String getFeatureName() {
+        TelegramHttpChatBot.NAME
+    }
+
+    @Override
+    List<ApplicationType> getSupportedApplicationTypes() {
+        [ApplicationType.FUNCTION, ApplicationType.DEFAULT]
+    }
+
+    void 'test README contains docs for #buildTool'(BuildTool buildTool) {
+        when:
+        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, buildTool), [featureName])
+        def readme = output["README.md"]
+
+        then:
+        readme.contains("Telegram ChatBot")
+        readme.contains("This project has a dependency on `micronaut-chatbots-telegram-http` which has added a controller to your application with the path `/telegram`.")
+        readme.contains("- [Micronaut Validation documentation](https://micronaut-projects.github.io/micronaut-validation/latest/guide/)")
+        readme.contains("- [Micronaut Telegram ChatBot as a controller documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/)")
+
+        where:
+        buildTool << BuildTool.values()
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramHttpChatBotSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/chatbots/telegram/TelegramHttpChatBotSpec.groovy
@@ -9,6 +9,11 @@ import io.micronaut.starter.options.Options
 class TelegramHttpChatBotSpec extends BaseTelegramChatBotSpec {
 
     @Override
+    List<ApplicationType> getSupportedApplicationTypes() {
+        [ApplicationType.DEFAULT]
+    }
+
+    @Override
     Class<ChatBotsFeature> getFeature() {
         TelegramHttpChatBot
     }
@@ -16,11 +21,6 @@ class TelegramHttpChatBotSpec extends BaseTelegramChatBotSpec {
     @Override
     String getFeatureName() {
         TelegramHttpChatBot.NAME
-    }
-
-    @Override
-    List<ApplicationType> getSupportedApplicationTypes() {
-        [ApplicationType.FUNCTION, ApplicationType.DEFAULT]
     }
 
     void 'test README contains docs for #buildTool'(BuildTool buildTool) {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureBuildCommandUtilsSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureBuildCommandUtilsSpec.groovy
@@ -1,0 +1,18 @@
+package io.micronaut.starter.feature.function.azure
+
+import io.micronaut.starter.options.BuildTool
+import spock.lang.Specification
+
+class AzureBuildCommandUtilsSpec extends Specification {
+
+    void "for #buildTool build command is #expected"(String expected, BuildTool buildTool) {
+        expect:
+        expected == AzureBuildCommandUtils.getBuildCommand(buildTool)
+
+        where:
+        expected                              | buildTool
+        'mvnw package azure-functions:deploy' | BuildTool.MAVEN
+        'gradlew azureFunctionsDeploy'        | BuildTool.GRADLE
+        'gradlew azureFunctionsDeploy'        | BuildTool.GRADLE_KOTLIN
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/gcp/GcpCloudFunctionBuildCommandUtilsSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/gcp/GcpCloudFunctionBuildCommandUtilsSpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.starter.feature.function.gcp
+
+import io.micronaut.starter.options.BuildTool
+import spock.lang.Specification
+
+class GcpCloudFunctionBuildCommandUtilsSpec extends Specification {
+
+    void "for #buildTool build command is #expected"(String expected, BuildTool buildTool) {
+        expect:
+        expected == GcpCloudFunctionBuildCommandUtils.getBuildCommand(buildTool)
+
+        where:
+        expected | buildTool
+        'mvnw clean package' | BuildTool.MAVEN
+        'gradlew shadowJar' | BuildTool.GRADLE
+        'gradlew shadowJar' | BuildTool.GRADLE_KOTLIN
+    }
+
+    void "for #buildTool run command is #expected"(String expected, BuildTool buildTool) {
+        expect:
+        expected == GcpCloudFunctionBuildCommandUtils.getRunCommand(buildTool)
+
+        where:
+        expected | buildTool
+        'mvnw function:run' | BuildTool.MAVEN
+        'gradlew runFunction' | BuildTool.GRADLE
+        'gradlew runFunction' | BuildTool.GRADLE_KOTLIN
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/chatbots/TelegramAwsChatBotFunctionSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/chatbots/TelegramAwsChatBotFunctionSpec.groovy
@@ -1,0 +1,49 @@
+package io.micronaut.starter.core.test.feature.chatbots
+
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.aws.Cdk
+import io.micronaut.starter.feature.chatbots.telegram.TelegramAwsChatBot
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
+import io.micronaut.starter.test.CommandSpec
+
+class TelegramAwsChatBotFunctionSpec extends CommandSpec {
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "telegramAwsChatBotFunctionSpec"
+    }
+
+    void "#testFramework test #feature feature in #language with #buildTool"(BuildTool buildTool, Language language, TestFramework testFramework) {
+        when:
+        generateProject(language, buildTool, [feature], ApplicationType.FUNCTION, testFramework)
+
+        then:
+        String result = executeBuild(buildTool, "test")
+
+        then:
+        println result
+        result.contains("BUILD SUCCESS")
+
+        where:
+        [buildTool, language, testFramework] <<  [BuildTool.values(), Language.values(), TestFramework.values()].combinations()
+        feature = TelegramAwsChatBot.NAME
+    }
+
+    void "#testFramework test #feature feature with Cdk in #language with #buildTool"(BuildTool buildTool, Language language, TestFramework testFramework) {
+        when:
+        generateProject(language, buildTool, [feature, Cdk.NAME], ApplicationType.FUNCTION, testFramework)
+
+        then:
+        String result = executeBuild(buildTool, "test")
+
+        then:
+        println result
+        result.contains("BUILD SUCCESS")
+
+        where:
+        [buildTool, language, testFramework] <<  [BuildTool.values(), Language.values(), TestFramework.values()].combinations()
+        feature = TelegramAwsChatBot.NAME
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/chatbots/TelegramAzureChatBotFunctionSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/chatbots/TelegramAzureChatBotFunctionSpec.groovy
@@ -1,0 +1,32 @@
+package io.micronaut.starter.core.test.feature.chatbots
+
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.chatbots.telegram.TelegramAzureChatBot
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
+import io.micronaut.starter.test.CommandSpec
+
+class TelegramAzureChatBotFunctionSpec extends CommandSpec {
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "telegramAzureChatBotFunctionSpec"
+    }
+
+    void "#testFramework test #feature feature in #language with #buildTool"(BuildTool buildTool, Language language, TestFramework testFramework) {
+        when:
+        generateProject(language, buildTool, [feature], ApplicationType.FUNCTION, testFramework)
+
+        then:
+        String result = executeBuild(buildTool, "test")
+
+        then:
+        println result
+        result.contains("BUILD SUCCESS")
+
+        where:
+        [buildTool, language, testFramework] <<  [BuildTool.values(), Language.values(), TestFramework.values()].combinations()
+        feature = TelegramAzureChatBot.NAME
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/chatbots/TelegramControllerChatBotSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/chatbots/TelegramControllerChatBotSpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.starter.core.test.feature.chatbots
+
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.chatbots.telegram.TelegramGcpChatBot
+import io.micronaut.starter.feature.chatbots.telegram.TelegramHttpChatBot
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
+import io.micronaut.starter.test.CommandSpec
+
+class TelegramControllerChatBotSpec extends CommandSpec {
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "telegramHttpChatBotSpec"
+    }
+
+    void "#testFramework test #feature feature in #language with #buildTool"(BuildTool buildTool, Language language, TestFramework testFramework) {
+        when:
+        generateProject(language, buildTool, [feature], ApplicationType.DEFAULT, testFramework)
+
+        then:
+        String result = executeBuild(buildTool, "test")
+
+        then:
+        println result
+        result.contains("BUILD SUCCESS")
+
+        where:
+        [buildTool, language, testFramework] <<  [BuildTool.values(), Language.values(), TestFramework.values()].combinations()
+        feature = TelegramHttpChatBot.NAME
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/chatbots/TelegramGcpChatBotFunctionSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/chatbots/TelegramGcpChatBotFunctionSpec.groovy
@@ -1,0 +1,32 @@
+package io.micronaut.starter.core.test.feature.chatbots
+
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.chatbots.telegram.TelegramGcpChatBot
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
+import io.micronaut.starter.test.CommandSpec
+
+class TelegramGcpChatBotFunctionSpec extends CommandSpec {
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "telegramGcpChatBotFunctionSpec"
+    }
+
+    void "#testFramework test #feature feature in #language with #buildTool"(BuildTool buildTool, Language language, TestFramework testFramework) {
+        when:
+        generateProject(language, buildTool, [feature], ApplicationType.FUNCTION, testFramework)
+
+        then:
+        String result = executeBuild(buildTool, "test")
+
+        then:
+        println result
+        result.contains("BUILD SUCCESS")
+
+        where:
+        [buildTool, language, testFramework] <<  [BuildTool.values(), Language.values(), TestFramework.values()].combinations()
+        feature = TelegramGcpChatBot.NAME
+    }
+}


### PR DESCRIPTION
This adds features for Telegram chatbots based on

- Azure
- Lambdas
- Gcp
- Http

When used, the generated README explains how to set up and deploy the bot.

As part of the feature, an example `about` command is added as well as a
command that catches any input that is unrecognised.