### PR TITLE
Convert JdkVersion from enum to class

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -8,4 +8,5 @@
     <suppress checks="FileLength"
               files="DefaultBeanContext.java|BeanDefinitionWriter.java|DefaultHttpClient.java"/>
     <suppress files="[\\/]generated-src[\\/]|RockerSubs.java" checks="[a-zA-Z0-9]*"/>
+    <suppress checks="DeclarationOrder" files="JdkVersion.java"/> <!-- private INSTANCES has to be before the public constants, otherwise the constructors fail with NPE -->
 </suppressions>

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
@@ -21,8 +21,8 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.ProjectGenerator;
-import io.micronaut.starter.feature.architecture.Arm;
 import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.architecture.Arm;
 import io.micronaut.starter.feature.architecture.CpuArchitecture;
 import io.micronaut.starter.feature.architecture.X86;
 import io.micronaut.starter.feature.aws.AmazonApiGateway;
@@ -60,6 +60,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static picocli.CommandLine.Help.Ansi.AUTO;
 
 @CommandLine.Command(name = CreateLambdaBuilderCommand.NAME, description = "A guided walk-through to create an lambda function")
 @Prototype
@@ -148,13 +150,19 @@ public class CreateLambdaBuilderCommand extends BuilderCommand {
 
     protected JdkVersion getJdkVersion(LambdaDeployment deployment, LineReader reader) {
         JdkVersion[] versions = jdkVersionsForDeployment(deployment);
+        JdkVersion defaultOption = versions.length > 0 ? versions[0] : JdkVersion.JDK_17;
         out("Choose the target JDK. (enter for default)");
-        return getEnumOption(
-                versions,
-                jdkVersion -> Integer.toString(jdkVersion.majorVersion()),
-                versions.length > 0 ? versions[0] : JdkVersion.JDK_17,
-                reader
-        );
+
+        for (int i = 0; i < versions.length; i++) {
+            out(AUTO.string("@|blue " + (versions[i].equals(defaultOption) ? '*' : ' ') + (i + 1) + ")|@ " + versions[i].majorVersion()));
+        }
+        int option = getOption(reader, versions.length);
+        out("");
+        if (option == -1) {
+            return defaultOption;
+        }
+        int choice = option - 1;
+        return versions[choice];
     }
 
     JdkVersion[] jdkVersionsForDeployment(LambdaDeployment deployment) {

--- a/starter-core/build.gradle
+++ b/starter-core/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     api "io.github.java-diff-utils:java-diff-utils:4.10"
     api "org.eclipse.jgit:org.eclipse.jgit:6.5.0.202303070854-r"
     api("org.yaml:snakeyaml")
+    api 'io.micronaut.serde:micronaut-serde-api'
     implementation("com.typesafe:config:1.4.2")
     implementation("io.micronaut.testresources:micronaut-test-resources-build-tools")
     implementation 'org.apache.commons:commons-compress:1.25.0'

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pom.rocker.raw
@@ -18,7 +18,6 @@
 @import io.micronaut.starter.feature.messaging.SharedTestResourceFeature
 @import io.micronaut.starter.feature.migration.MigrationFeature
 @import io.micronaut.starter.feature.testresources.TestResources
-@import io.micronaut.starter.options.JdkVersion
 @import io.micronaut.starter.util.VersionInfo
 
 @args (

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pomGeneric.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/templates/pomGeneric.rocker.raw
@@ -6,7 +6,6 @@
 @import io.micronaut.starter.build.maven.MavenDependency
 @import io.micronaut.starter.feature.Features
 @import io.micronaut.starter.feature.build.maven.templates.dependency
-@import io.micronaut.starter.options.JdkVersion
 @import io.micronaut.starter.util.VersionInfo
 
 @args (

--- a/starter-core/src/main/java/io/micronaut/starter/feature/buildless/Buildless.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/buildless/Buildless.java
@@ -29,9 +29,9 @@ import jakarta.inject.Singleton;
 @Singleton
 public class Buildless implements CommunityFeature, GradleSpecificFeature {
     public static final String NAME = "buildless";
+    static final String BUILDLESS_PLUGIN_ARTIFACT = "buildless-plugin-gradle";
     private static final String FEATURE_NAME_BUILDLESS = "buildless";
     private static final String BUILDLESS_PLUGIN_ID = "build.less";
-    static final String BUILDLESS_PLUGIN_ARTIFACT = "buildless-plugin-gradle";
 
     @Override
     public String getName() {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
@@ -122,13 +122,13 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
     @NonNull
     private Optional<String> javaVersionValue(GeneratorContext generatorContext) {
         if (generatorContext.getBuildTool().isGradle()) {
-            if (generatorContext.getJdkVersion() == JdkVersion.JDK_17) {
+            if (JdkVersion.JDK_17.equals(generatorContext.getJdkVersion())) {
                 return Optional.of("Java 17");
             } else {
                 return Optional.empty();
             }
         }
-        if (generatorContext.getJdkVersion() == JdkVersion.JDK_17) {
+        if (JdkVersion.JDK_17.equals(generatorContext.getJdkVersion())) {
             return Optional.of("17");
         } else {
             return Optional.empty();

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureFunctionFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AzureFunctionFeatureValidator.java
@@ -28,7 +28,7 @@ import java.util.Set;
 public class AzureFunctionFeatureValidator implements FeatureValidator {
 
     public static boolean supports(JdkVersion jdkVersion) {
-        return jdkVersion == JdkVersion.JDK_8 || jdkVersion == JdkVersion.JDK_11 || jdkVersion == JdkVersion.JDK_17;
+        return JdkVersion.JDK_8.equals(jdkVersion) || JdkVersion.JDK_11.equals(jdkVersion) || JdkVersion.JDK_17.equals(jdkVersion);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GoogleCloudFunctionFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/gcp/GoogleCloudFunctionFeatureValidator.java
@@ -29,7 +29,7 @@ import java.util.Set;
 public class GoogleCloudFunctionFeatureValidator implements FeatureValidator {
 
     private static boolean supports(JdkVersion jdkVersion) {
-        return jdkVersion == JdkVersion.JDK_11 || jdkVersion == JdkVersion.JDK_17;
+        return JdkVersion.JDK_11.equals(jdkVersion) || JdkVersion.JDK_17.equals(jdkVersion);
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/github/workflows/templates/buildAndPushImage.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/github/workflows/templates/buildAndPushImage.rocker.raw
@@ -1,5 +1,4 @@
 @import io.micronaut.starter.options.BuildTool
-@import io.micronaut.starter.options.JdkVersion
 
 @args (
 BuildTool buildTool,

--- a/starter-core/src/main/java/io/micronaut/starter/options/JdkVersion.java
+++ b/starter-core/src/main/java/io/micronaut/starter/options/JdkVersion.java
@@ -15,8 +15,11 @@
  */
 package io.micronaut.starter.options;
 
-import java.util.Arrays;
-import java.util.List;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * JDK versions.
@@ -24,43 +27,73 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0.0
  */
-public enum JdkVersion {
-    JDK_8(8),
-    JDK_9(9),
-    JDK_10(10),
-    JDK_11(11),
-    JDK_12(12),
-    JDK_13(13),
-    JDK_14(14),
-    JDK_15(15),
-    JDK_16(16),
-    JDK_17(17),
-    JDK_18(18),
-    JDK_19(19),
-    JDK_20(20),
-    JDK_21(21);
+@Serdeable
+public final class JdkVersion {
 
-    private static final List<Integer> SUPPORTED_JDKS = Arrays.stream(JdkVersion.values()).map(JdkVersion::majorVersion).toList();
+    private static final Map<Integer, JdkVersion> INSTANCES = new TreeMap<>();
 
-    private final int majorVersion;
+    public static final JdkVersion JDK_8 = new JdkVersion(8);
+    public static final JdkVersion JDK_9 = new JdkVersion(9);
+    public static final JdkVersion JDK_10 = new JdkVersion(10);
+    public static final JdkVersion JDK_11 = new JdkVersion(11);
+    public static final JdkVersion JDK_12 = new JdkVersion(12);
+    public static final JdkVersion JDK_13 = new JdkVersion(13);
+    public static final JdkVersion JDK_14 = new JdkVersion(14);
+    public static final JdkVersion JDK_15 = new JdkVersion(15);
+    public static final JdkVersion JDK_16 = new JdkVersion(16);
+    public static final JdkVersion JDK_17 = new JdkVersion(17);
+    public static final JdkVersion JDK_18 = new JdkVersion(18);
+    public static final JdkVersion JDK_19 = new JdkVersion(19);
+    public static final JdkVersion JDK_20 = new JdkVersion(20);
+    public static final JdkVersion JDK_21 = new JdkVersion(21);
 
-    JdkVersion(int majorVersion) {
+    int majorVersion;
+
+    public JdkVersion(int majorVersion) {
         this.majorVersion = majorVersion;
+        INSTANCES.put(majorVersion, this);
+    }
+
+    /**
+     * @return the name
+     */
+    public String name() {
+        return "JDK_" + majorVersion;
+    }
+
+    @Override
+    public String toString() {
+        return name();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof JdkVersion other && other.majorVersion == majorVersion;
+    }
+
+    @Override
+    public int hashCode() {
+        return majorVersion;
     }
 
     public static JdkVersion valueOf(int majorVersion) {
-        return Arrays
-                .stream(JdkVersion.values())
+        return INSTANCES.values().stream()
                 .filter(jdkVersion -> jdkVersion.majorVersion == majorVersion)
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Unsupported JDK version: " + majorVersion + ". Supported values are " + SUPPORTED_JDKS));
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Unsupported JDK version: " + majorVersion + ". Supported values are " + INSTANCES.keySet()));
     }
 
     public int majorVersion() {
         return majorVersion;
     }
 
-    public boolean greaterThanEqual(JdkVersion jdk) {
+    // for serialization
+    int getMajorVersion() {
+        return majorVersion;
+    }
+
+    public boolean greaterThanEqual(@NonNull JdkVersion jdk) {
         return majorVersion >= jdk.majorVersion;
     }
 }


### PR DESCRIPTION
Changing from an enum allows adding new instances via the constructor (e.g. when using starter as a library) without recompiling.