### PR TITLE
Add `create-chatbot` command to CLI

### DIFF
--- a/starter-cli/src/main/java/io/micronaut/starter/cli/MicronautStarter.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/MicronautStarter.java
@@ -26,6 +26,7 @@ import io.micronaut.starter.cli.command.BuildToolConverter;
 import io.micronaut.starter.cli.command.CodeGenCommand;
 import io.micronaut.starter.cli.command.CreateAppCommand;
 import io.micronaut.starter.cli.command.CreateBuilderCommand;
+import io.micronaut.starter.cli.command.CreateChatBotBuilderCommand;
 import io.micronaut.starter.cli.command.CreateCliCommand;
 import io.micronaut.starter.cli.command.CreateFunctionCommand;
 import io.micronaut.starter.cli.command.CreateGrpcCommand;
@@ -50,6 +51,7 @@ import java.util.function.BiFunction;
             "Application generation commands are:",
             "",
             "*  @|bold create-app|@ @|yellow NAME|@",
+            "*  @|bold create-chatbot|@ @|yellow NAME|@",
             "*  @|bold create-cli-app|@ @|yellow NAME|@",
             "*  @|bold create-function-app|@ @|yellow NAME|@",
             "*  @|bold create-grpc-app|@ @|yellow NAME|@",
@@ -61,6 +63,7 @@ import java.util.function.BiFunction;
         subcommands = {
                 // Creation commands
                 CreateAppCommand.class,
+                CreateChatBotBuilderCommand.class,
                 CreateCliCommand.class,
                 CreateFunctionCommand.class,
                 CreateGrpcCommand.class,

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/BuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/BuilderCommand.java
@@ -60,6 +60,9 @@ import static picocli.CommandLine.Help.Ansi.AUTO;
  */
 public abstract class BuilderCommand extends BaseCommand implements Callable<Integer> {
 
+    // Wrapped in a memoized Supplier, so it's not created at build time
+    public static final Supplier<String> PROMPT = SupplierUtil.memoized(() -> AUTO.string("@|blue > |@"));
+
     protected final ProjectGenerator projectGenerator;
     protected final List<Feature> features;
 
@@ -100,9 +103,6 @@ public abstract class BuilderCommand extends BaseCommand implements Callable<Int
         }
         return 0;
     }
-
-    // Wrapped in a memoized Supplier, so it's not created at build time
-    public static final Supplier<String> PROMPT = SupplierUtil.memoized(() -> AUTO.string("@|blue > |@"));
 
     protected List<String> getFeatures(ApplicationType applicationType, Terminal terminal, List<Feature> features) {
         AvailableFeatures availableFeatures = new BaseAvailableFeatures(features, applicationType);
@@ -159,6 +159,10 @@ public abstract class BuilderCommand extends BaseCommand implements Callable<Int
                 String.valueOf(defaultOption.majorVersion()),
                 reader
         )));
+    }
+
+    protected YesOrNo getYesOrNo(LineReader reader) {
+        return getEnumOption(YesOrNo.class, yesOrNo -> StringUtils.capitalize(yesOrNo.name().toLowerCase()), YesOrNo.YES, reader);
     }
 
     protected int getOption(LineReader reader, int max) throws UserInterruptException, EndOfFileException {

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/BuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/BuilderCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,20 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.Project;
+import io.micronaut.starter.application.generator.ProjectGenerator;
 import io.micronaut.starter.feature.AvailableFeatures;
 import io.micronaut.starter.feature.BaseAvailableFeatures;
 import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.io.FileSystemOutputHandler;
+import io.micronaut.starter.io.OutputHandler;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.JdkVersion;
 import io.micronaut.starter.options.Language;
 import io.micronaut.starter.options.MicronautJdkVersionConfiguration;
+import io.micronaut.starter.options.Options;
 import io.micronaut.starter.options.TestFramework;
 import io.micronaut.starter.util.NameUtils;
+import org.fusesource.jansi.AnsiConsole;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -35,10 +40,12 @@ import org.jline.reader.UserInterruptException;
 import org.jline.reader.impl.DefaultParser;
 import org.jline.reader.impl.completer.StringsCompleter;
 import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -52,6 +59,48 @@ import static picocli.CommandLine.Help.Ansi.AUTO;
  * @since 3.8.0
  */
 public abstract class BuilderCommand extends BaseCommand implements Callable<Integer> {
+
+    protected final ProjectGenerator projectGenerator;
+    protected final List<Feature> features;
+
+    protected BuilderCommand(ProjectGenerator projectGenerator, List<Feature> features) {
+        this.projectGenerator = projectGenerator;
+        this.features = features;
+    }
+
+    protected abstract GenerateOptions createGenerateOptions(LineReader reader);
+
+    @Override
+    public Integer call() throws Exception {
+        AnsiConsole.systemInstall();
+        try {
+            Terminal terminal = TerminalBuilder.terminal();
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .parser(new DefaultParser())
+                    .build();
+            GenerateOptions options = createGenerateOptions(reader);
+            Set<String> selectedFeatures = options.getFeatures();
+            selectedFeatures.addAll(getFeatures(options.getApplicationType(), terminal, features));
+            Project project = getProject(reader);
+            try (OutputHandler outputHandler = new FileSystemOutputHandler(project, false, this)) {
+                projectGenerator.generate(options.getApplicationType(),
+                        project,
+                        options.getOptions(),
+                        getOperatingSystem(),
+                        new ArrayList<>(selectedFeatures),
+                        outputHandler,
+                        this);
+                out("@|blue ||@ Application created at " + outputHandler.getOutputLocation());
+            }
+        } catch (UserInterruptException | EndOfFileException e) {
+            //no-op
+        } finally {
+            AnsiConsole.systemUninstall();
+        }
+        return 0;
+    }
+
     // Wrapped in a memoized Supplier, so it's not created at build time
     public static final Supplier<String> PROMPT = SupplierUtil.memoized(() -> AUTO.string("@|blue > |@"));
 
@@ -203,6 +252,23 @@ public abstract class BuilderCommand extends BaseCommand implements Callable<Int
                 err(e.getMessage());
             }
         }
+    }
+
+    protected Options getOptions(LineReader reader) {
+        Language language = getLanguage(reader);
+        TestFramework testFramework = getTestFramework(reader, language);
+        BuildTool buildTool = getBuildTool(reader, language);
+        JdkVersion jdkVersion = getJdkVersion(reader);
+        return new Options(language, testFramework, buildTool, jdkVersion);
+    }
+
+    protected Language getLanguage(LineReader reader) {
+        out("Choose your preferred language. (enter for default)");
+        return getEnumOption(
+                Language.class,
+                language -> StringUtils.capitalize(language.getName()),
+                Language.DEFAULT_OPTION,
+                reader);
     }
 
     protected TestFramework getTestFramework(LineReader reader, Language language) {

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateBuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateBuilderCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,32 +16,17 @@
 package io.micronaut.starter.cli.command;
 
 import io.micronaut.context.annotation.Prototype;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.starter.application.ApplicationType;
-import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.ProjectGenerator;
 import io.micronaut.starter.feature.Feature;
-import io.micronaut.starter.io.FileSystemOutputHandler;
-import io.micronaut.starter.io.OutputHandler;
-import io.micronaut.starter.options.BuildTool;
-import io.micronaut.starter.options.JdkVersion;
-import io.micronaut.starter.options.Language;
 import io.micronaut.starter.options.Options;
-import io.micronaut.starter.options.TestFramework;
-import org.fusesource.jansi.AnsiConsole;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
-import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.UserInterruptException;
-import org.jline.reader.impl.DefaultParser;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
 import picocli.CommandLine.Command;
 
 import java.util.Collections;
 import java.util.List;
-
-import static picocli.CommandLine.Help.Ansi.AUTO;
 
 @Command(name = CreateBuilderCommand.NAME, description = "A guided walk-through to create an application")
 @Prototype
@@ -49,63 +34,16 @@ public class CreateBuilderCommand extends BuilderCommand {
 
     public static final String NAME = "create";
 
-    private final ProjectGenerator projectGenerator;
-    private final List<Feature> features;
-    private final String prompt = AUTO.string("@|blue > |@");
-
     public CreateBuilderCommand(ProjectGenerator projectGenerator,
                                 List<Feature> features) {
-        this.projectGenerator = projectGenerator;
-        this.features = features;
+        super(projectGenerator, features);
     }
 
     @Override
-    public Integer call() throws Exception {
-        AnsiConsole.systemInstall();
-        try {
-            Terminal terminal = TerminalBuilder.terminal();
-            LineReader reader = LineReaderBuilder.builder()
-                    .terminal(terminal)
-                    .parser(new DefaultParser())
-                    .build();
-            GenerateOptions generateOptions = createGenerateOptions(reader);
-            List<String> applicationFeatures = getFeatures(generateOptions.getApplicationType(), terminal, features);
-            Project project = getProject(reader);
-            try (OutputHandler outputHandler = new FileSystemOutputHandler(project, false, this)) {
-                projectGenerator.generate(generateOptions.getApplicationType(),
-                        project,
-                        generateOptions.getOptions(),
-                        getOperatingSystem(),
-                        applicationFeatures,
-                        outputHandler,
-                        this);
-                out("@|blue ||@ Application created at " + outputHandler.getOutputLocation());
-            }
-        } catch (UserInterruptException | EndOfFileException e) {
-            //no-op
-        } finally {
-            AnsiConsole.systemUninstall();
-        }
-        return 0;
-    }
-
     public GenerateOptions createGenerateOptions(LineReader reader) {
         ApplicationType applicationType = getApplicationType(reader);
-        Language language = getLanguage(reader);
-        TestFramework testFramework = getTestFramework(reader, language);
-        BuildTool buildTool = getBuildTool(reader, language);
-        JdkVersion jdkVersion = getJdkVersion(reader);
-        Options options = new Options(language, testFramework, buildTool, jdkVersion);
+        Options options = getOptions(reader);
         return new GenerateOptions(applicationType, options, Collections.emptySet());
-    }
-
-    protected Language getLanguage(LineReader reader) {
-        out("Choose your preferred language. (enter for default)");
-        return getEnumOption(
-                Language.class,
-                language -> StringUtils.capitalize(language.getName()),
-                Language.DEFAULT_OPTION,
-                reader);
     }
 
     protected ApplicationType getApplicationType(LineReader reader) throws UserInterruptException, EndOfFileException {

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateChatBotBuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateChatBotBuilderCommand.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.cli.command;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.ProjectGenerator;
+import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.architecture.CpuArchitecture;
+import io.micronaut.starter.feature.architecture.X86;
+import io.micronaut.starter.feature.aws.Cdk;
+import io.micronaut.starter.feature.aws.LambdaFunctionUrl;
+import io.micronaut.starter.feature.chatbots.telegram.TelegramAwsChatBot;
+import io.micronaut.starter.feature.chatbots.telegram.TelegramAzureChatBot;
+import io.micronaut.starter.feature.chatbots.telegram.TelegramGcpChatBot;
+import io.micronaut.starter.feature.chatbots.telegram.TelegramHttpChatBot;
+import io.micronaut.starter.options.Options;
+import org.jline.reader.LineReader;
+import picocli.CommandLine.Command;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Command(name = CreateChatBotBuilderCommand.NAME, description = "A guided walk-through to create a chat bot application")
+@Prototype
+public class CreateChatBotBuilderCommand extends BuilderCommand {
+
+    public static final String NAME = "create-chatbot";
+
+    public CreateChatBotBuilderCommand(
+            ProjectGenerator projectGenerator,
+            List<Feature> features
+    ) {
+        super(projectGenerator, features);
+    }
+
+    @Override
+    public GenerateOptions createGenerateOptions(LineReader reader) {
+        ChatBotType chatBotType = getChatBotType(reader);
+        Set<String> applicationFeatures = new HashSet<>();
+        ChatBotDeployment deployment = getDeployment(chatBotType, reader);
+        applicationFeatures.add(deployment.feature);
+        ApplicationType applicationType = deployment.applicationType;
+
+        if (deployment == ChatBotDeployment.LAMBDA) {
+            applicationFeatures.add(LambdaFunctionUrl.NAME);
+            getArchitecture(reader).ifPresent(applicationFeatures::add);
+            getCdk(reader).ifPresent(f -> applicationFeatures.add(f.getName()));
+        }
+
+        Options options = getOptions(reader);
+        return new GenerateOptions(applicationType, options, applicationFeatures);
+    }
+
+    private ChatBotType getChatBotType(LineReader reader) {
+        // We only have one for now...
+        return ChatBotType.TELEGRAM;
+    }
+
+    protected Optional<String> getArchitecture(LineReader reader) {
+        List<String> archFeatures = features
+                .stream()
+                .filter(CpuArchitecture.class::isInstance)
+                .map(Feature::getName)
+                .sorted()
+                .toList();
+        out("Choose your Lambda Architecture. (enter for " + X86.NAME + ")");
+        return Optional.ofNullable(
+                getListOption(
+                        archFeatures,
+                        o -> o,
+                        X86.NAME,
+                        reader
+                )
+        );
+    }
+
+    protected Optional<Feature> getCdk(LineReader reader) {
+        out("Do you want to generate infrastructure as code with CDK? (enter for yes)");
+        return getEnumOption(YesOrNo.class, yesOrNo -> StringUtils.capitalize(yesOrNo.name().toLowerCase()), YesOrNo.YES, reader) == YesOrNo.YES
+                ? features.stream().filter(Cdk.class::isInstance).findFirst()
+                : Optional.empty();
+    }
+
+    private ChatBotDeployment getDeployment(ChatBotType chatBotType, LineReader reader) {
+        out("Choose your preferred deployment. (enter for default)");
+        if (chatBotType == ChatBotType.TELEGRAM) {
+            return getEnumOption(ChatBotDeployment.class, f -> "%s - %s".formatted(f.title, f.description), ChatBotDeployment.LAMBDA, reader);
+        } else {
+            throw new IllegalArgumentException("Unsupported chat bot type: " + chatBotType);
+        }
+    }
+
+    private enum ChatBotType {
+        TELEGRAM("Telegram Chat bot");
+
+        private final String title;
+
+        ChatBotType(String title) {
+            this.title = title;
+        }
+    }
+
+    enum ChatBotDeployment {
+
+        LAMBDA("AWS Lambda", "Deploy to AWS Lambda", TelegramAwsChatBot.NAME, ApplicationType.FUNCTION),
+        AZURE("Azure Function", "Deploy to Azure as a Function", TelegramAzureChatBot.NAME, ApplicationType.FUNCTION),
+        GCP("Google Cloud Function", "Deploy to Google Cloud as a Function", TelegramGcpChatBot.NAME, ApplicationType.FUNCTION),
+        HTTP("HTTP", "Deploy as an HTTP Server", TelegramHttpChatBot.NAME, ApplicationType.DEFAULT);
+
+        private final String title;
+        private final String description;
+        private final String feature;
+        private final ApplicationType applicationType;
+
+        ChatBotDeployment(String title, String description, String feature, ApplicationType applicationType) {
+            this.title = title;
+            this.description = description;
+            this.feature = feature;
+            this.applicationType = applicationType;
+        }
+    }
+}

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateChatBotBuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateChatBotBuilderCommand.java
@@ -67,8 +67,8 @@ public class CreateChatBotBuilderCommand extends BuilderCommand {
     }
 
     private ChatBotType getChatBotType(LineReader reader) {
-        // We only have one for now...
-        return ChatBotType.TELEGRAM;
+        out("Choose your ChatBot type. (enter for " + ChatBotType.TELEGRAM.title + ")");
+        return getEnumOption(ChatBotType.class, f -> "%s - %s".formatted(f.title, f.description), ChatBotType.TELEGRAM, reader);
     }
 
     protected Optional<String> getArchitecture(LineReader reader) {
@@ -99,14 +99,16 @@ public class CreateChatBotBuilderCommand extends BuilderCommand {
         }
     }
 
-    private enum ChatBotType {
+    enum ChatBotType {
 
-        TELEGRAM("Telegram Chat bot");
+        TELEGRAM("Telegram", "A chat bot for the telegram messaging platform");
 
         private final String title;
+        private final String description;
 
-        ChatBotType(String title) {
+        ChatBotType(String title, String description) {
             this.title = title;
+            this.description = description;
         }
     }
 

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,9 @@ import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.starter.application.ApplicationType;
-import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.ProjectGenerator;
-import io.micronaut.starter.feature.architecture.Arm;
 import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.architecture.Arm;
 import io.micronaut.starter.feature.architecture.CpuArchitecture;
 import io.micronaut.starter.feature.architecture.X86;
 import io.micronaut.starter.feature.aws.AmazonApiGateway;
@@ -34,24 +33,14 @@ import io.micronaut.starter.feature.aws.LambdaTrigger;
 import io.micronaut.starter.feature.function.awslambda.AwsLambda;
 import io.micronaut.starter.feature.graalvm.GraalVM;
 import io.micronaut.starter.feature.graalvm.GraalVMFeatureValidator;
-import io.micronaut.starter.io.FileSystemOutputHandler;
-import io.micronaut.starter.io.OutputHandler;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.JdkVersion;
 import io.micronaut.starter.options.Language;
 import io.micronaut.starter.options.Options;
 import io.micronaut.starter.options.TestFramework;
-import org.fusesource.jansi.AnsiConsole;
-import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
-import org.jline.reader.LineReaderBuilder;
-import org.jline.reader.UserInterruptException;
-import org.jline.reader.impl.DefaultParser;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
 import picocli.CommandLine;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -67,49 +56,14 @@ public class CreateLambdaBuilderCommand extends BuilderCommand {
 
     public static final String NAME = "create-aws-lambda";
 
-    private final ProjectGenerator projectGenerator;
-    private final List<Feature> features;
-    private final GraalVMFeatureValidator graalVMFeatureValidator;
-
-    public CreateLambdaBuilderCommand(ProjectGenerator projectGenerator,
-                                      List<Feature> features,
-                                      GraalVMFeatureValidator graalVMFeatureValidator) {
-        this.projectGenerator = projectGenerator;
-        this.features = features;
-        this.graalVMFeatureValidator = graalVMFeatureValidator;
+    public CreateLambdaBuilderCommand(
+            ProjectGenerator projectGenerator,
+            List<Feature> features
+    ) {
+        super(projectGenerator, features);
     }
 
     @Override
-    public Integer call() throws Exception {
-        AnsiConsole.systemInstall();
-        try {
-            Terminal terminal = TerminalBuilder.terminal();
-            LineReader reader = LineReaderBuilder.builder()
-                    .terminal(terminal)
-                    .parser(new DefaultParser())
-                    .build();
-            GenerateOptions options = createGenerateOptions(reader);
-            Set<String> selectedFeatures = options.getFeatures();
-            selectedFeatures.addAll(getFeatures(options.getApplicationType(), terminal, features));
-            Project project = getProject(reader);
-            try (OutputHandler outputHandler = new FileSystemOutputHandler(project, false, this)) {
-                projectGenerator.generate(options.getApplicationType(),
-                        project,
-                        options.getOptions(),
-                        getOperatingSystem(),
-                        new ArrayList<>(selectedFeatures),
-                        outputHandler,
-                        this);
-                out("@|blue ||@ Application created at " + outputHandler.getOutputLocation());
-            }
-        } catch (UserInterruptException | EndOfFileException e) {
-            //no-op
-        } finally {
-            AnsiConsole.systemUninstall();
-        }
-        return 0;
-    }
-
     public GenerateOptions createGenerateOptions(LineReader reader) {
         Set<String> applicationFeatures = new HashSet<>();
         applicationFeatures.add(AwsLambda.FEATURE_NAME_AWS_LAMBDA);
@@ -160,7 +114,7 @@ public class CreateLambdaBuilderCommand extends BuilderCommand {
     JdkVersion[] jdkVersionsForDeployment(LambdaDeployment deployment) {
         switch (deployment) {
             case NATIVE_EXECUTABLE:
-                return new JdkVersion[] {
+                return new JdkVersion[]{
                         JdkVersion.JDK_17
                 };
             case FAT_JAR:
@@ -269,7 +223,7 @@ public class CreateLambdaBuilderCommand extends BuilderCommand {
                 reader) == YesOrNo.YES ?
                 features.stream()
                         .filter(Cdk.class::isInstance)
-                        .findFirst() : Optional.empty() ;
+                        .findFirst() : Optional.empty();
     }
 
     protected List<Feature> apiTriggerFeatures(ApplicationType applicationType, Collection<Feature> features) {

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
@@ -170,14 +170,14 @@ public class CreateLambdaBuilderCommand extends BuilderCommand {
     protected Optional<Feature> getArchitecture(LineReader reader) {
         List<Feature> cpuArchitecturesFeatures = features.stream()
                 .filter(CpuArchitecture.class::isInstance)
-                .collect(Collectors.toList());
+                .toList();
         String defaultCpuArchitecture = X86.NAME;
         out("Choose your Lambda Architecture. (enter for " + defaultCpuArchitecture + ")");
         String option = getListOption(
                 cpuArchitecturesFeatures.stream()
                         .map(Feature::getName)
                         .sorted()
-                        .collect(Collectors.toList()),
+                        .toList(),
                 o -> o,
                 defaultCpuArchitecture,
                 reader);
@@ -216,14 +216,9 @@ public class CreateLambdaBuilderCommand extends BuilderCommand {
 
     protected Optional<Feature> getCdk(LineReader reader) {
         out("Do you want to generate infrastructure as code with CDK? (enter for yes)");
-        return getEnumOption(
-                YesOrNo.class,
-                yesOrNo -> StringUtils.capitalize(yesOrNo.toString()),
-                YesOrNo.YES,
-                reader) == YesOrNo.YES ?
-                features.stream()
-                        .filter(Cdk.class::isInstance)
-                        .findFirst() : Optional.empty();
+        return getYesOrNo(reader) == YesOrNo.YES
+                ? features.stream().filter(Cdk.class::isInstance).findFirst()
+                : Optional.empty();
     }
 
     protected List<Feature> apiTriggerFeatures(ApplicationType applicationType, Collection<Feature> features) {

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/YesOrNo.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/YesOrNo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,4 @@ package io.micronaut.starter.cli.command;
 public enum YesOrNo {
     YES,
     NO;
-
-    @Override
-    public String toString() {
-        return this.name();
-    }
 }

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/YesOrNo.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/YesOrNo.java
@@ -20,6 +20,7 @@ package io.micronaut.starter.cli.command;
  * @since 3.8.0
  */
 public enum YesOrNo {
+
     YES,
     NO;
 }

--- a/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/CreateChatBotBuilderCommandSpec.groovy
+++ b/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/CreateChatBotBuilderCommandSpec.groovy
@@ -74,7 +74,7 @@ Choose the target JDK. (enter for default)
 >
      */
 
-    void "test prompt"(CliOptions cliOptions) {
+    void "test options #cliOptions.cliCommands -- #cliOptions"(CliOptions cliOptions) {
         given:
         CreateChatBotBuilderCommand command = applicationContext.getBean(CreateChatBotBuilderCommand)
 

--- a/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/CreateChatBotBuilderCommandSpec.groovy
+++ b/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/CreateChatBotBuilderCommandSpec.groovy
@@ -5,7 +5,6 @@ import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.architecture.Arm
 import io.micronaut.starter.feature.architecture.CpuArchitecture
 import io.micronaut.starter.feature.architecture.X86
-import io.micronaut.starter.feature.aws.Cdk
 import io.micronaut.starter.feature.aws.LambdaFunctionUrl
 import io.micronaut.starter.feature.chatbots.telegram.TelegramAwsChatBot
 import io.micronaut.starter.feature.chatbots.telegram.TelegramAzureChatBot
@@ -30,45 +29,44 @@ class CreateChatBotBuilderCommandSpec extends Specification {
         applicationContext = ApplicationContext.run();
     }
     /*
-        Choose your preferred deployment. (enter for default)
-        *1) AWS Lambda - Deploy to AWS Lambda
-         2) Azure Function - Deploy to Azure as a Function
-         3) Google Cloud Function - Deploy to Google Cloud as a Function
-         4) HTTP - Deploy as an HTTP Server
-        >
+Choose your preferred deployment. (enter for default)
+*1) AWS Lambda - Deploy to AWS Lambda
+ 2) Azure Function - Deploy to Azure as a Function
+ 3) Google Cloud Function - Deploy to Google Cloud as a Function
+ 4) HTTP - Deploy as an HTTP Server
+>
 
-        Choose your Lambda Architecture. (enter for x86)
-         1) arm
-        *2) x86
-        >
+Choose your Lambda Architecture. (enter for x86)
+ 1) Arm
+*2) X86
+>
 
-        Do you want to generate infrastructure as code with CDK? (enter for yes)
-        *1) Yes
-         2) No
-        >
+Do you want to generate infrastructure as code with CDK? (enter for yes)
+*1) Yes
+ 2) No
+>
 
-        Choose your preferred language. (enter for default)
-        *1) Java
-         2) Groovy
-         3) Kotlin
-        >
+Choose your preferred language. (enter for default)
+*1) Java
+ 2) Groovy
+ 3) Kotlin
+>
 
-        Choose your preferred test framework. (enter for default)
-        *1) JUnit
-         2) Spock
-         3) Kotest
-        >
+Choose your preferred test framework. (enter for default)
+*1) JUnit
+ 2) Spock
+ 3) Kotest
+>
 
-        Choose your preferred build tool. (enter for default)
-         1) Gradle (Groovy)
-        *2) Gradle (Kotlin)
-         3) Maven
-        >
+Choose your preferred build tool. (enter for default)
+ 1) Gradle (Groovy)
+*2) Gradle (Kotlin)
+ 3) Maven
+>
 
-        Choose the target JDK. (enter for default)
-        *1) 17
-         2) 21
-        >
+Choose the target JDK. (enter for default)
+*1) 17
+ 2) 21
      */
 
     void "test prompt"(CliOptions cliOptions) {
@@ -93,7 +91,7 @@ class CreateChatBotBuilderCommandSpec extends Specification {
         cliOptions << [
                 CreateChatBotBuilderCommand.ChatBotDeployment.values(),
                 [applicationContext.getBean(Arm), applicationContext.getBean(X86)],
-                [applicationContext.getBean(Cdk), null],
+                [true, false], // cdk
                 [Language.JAVA, Language.GROOVY, Language.KOTLIN],
                 [TestFramework.JUNIT, TestFramework.SPOCK, TestFramework.KOTEST],
                 [BuildTool.GRADLE, BuildTool.GRADLE_KOTLIN, BuildTool.MAVEN],
@@ -105,7 +103,7 @@ class CreateChatBotBuilderCommandSpec extends Specification {
     private static class CliOptions {
         final CreateChatBotBuilderCommand.ChatBotDeployment applicationType
         final CpuArchitecture cpuArchitecture
-        final Cdk cdk
+        final boolean cdk
         final Language language
         final TestFramework testFramework
         final BuildTool buildTool
@@ -114,7 +112,7 @@ class CreateChatBotBuilderCommandSpec extends Specification {
         CliOptions(
                 CreateChatBotBuilderCommand.ChatBotDeployment applicationType,
                 CpuArchitecture cpuArchitecture,
-                Cdk cdk,
+                boolean cdk,
                 Language language,
                 TestFramework testFramework,
                 BuildTool buildTool,
@@ -132,7 +130,7 @@ class CreateChatBotBuilderCommandSpec extends Specification {
         List<String> getFeatures() {
             switch (applicationType) {
                 case CreateChatBotBuilderCommand.ChatBotDeployment.LAMBDA:
-                    return [TelegramAwsChatBot.NAME, LambdaFunctionUrl.NAME, cpuArchitecture.getName()] + (cdk ? [Cdk.NAME] : [])
+                    return [TelegramAwsChatBot.NAME, cpuArchitecture.getName()] + (cdk ? [LambdaFunctionUrl.NAME] : [])
                 case CreateChatBotBuilderCommand.ChatBotDeployment.AZURE:
                     return [TelegramAzureChatBot.NAME]
                 case CreateChatBotBuilderCommand.ChatBotDeployment.GCP:
@@ -156,7 +154,7 @@ class CreateChatBotBuilderCommandSpec extends Specification {
             if (applicationType == CreateChatBotBuilderCommand.ChatBotDeployment.LAMBDA) {
                 ret += [
                         cpuArchitecture instanceof Arm ? "1" : "2",
-                        cdk instanceof Cdk ? "1" : "2",
+                        cdk ? "1" : "2",
                 ]
             }
             ret + [
@@ -170,9 +168,9 @@ class CreateChatBotBuilderCommandSpec extends Specification {
         @Override
         String toString() {
             if (applicationType == CreateChatBotBuilderCommand.ChatBotDeployment.LAMBDA) {
-                applicationType.name() + " " + cpuArchitecture.getName() + " " + cdk?.getName() + " " + language + " " + testFramework + " " + buildTool + " " + javaVersion
+                "${applicationType.name()} ${cpuArchitecture.getName()} cdk:${cdk} $language $testFramework $buildTool $javaVersion"
             } else {
-                applicationType.name() + " " + language + " " + testFramework + " " + buildTool + " " + javaVersion
+                "${applicationType.name()} $language $testFramework $buildTool $javaVersion"
             }
         }
     }

--- a/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/CreateChatBotBuilderCommandSpec.groovy
+++ b/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/CreateChatBotBuilderCommandSpec.groovy
@@ -1,0 +1,179 @@
+package io.micronaut.starter.cli.command
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.architecture.Arm
+import io.micronaut.starter.feature.architecture.CpuArchitecture
+import io.micronaut.starter.feature.architecture.X86
+import io.micronaut.starter.feature.aws.Cdk
+import io.micronaut.starter.feature.aws.LambdaFunctionUrl
+import io.micronaut.starter.feature.chatbots.telegram.TelegramAwsChatBot
+import io.micronaut.starter.feature.chatbots.telegram.TelegramAzureChatBot
+import io.micronaut.starter.feature.chatbots.telegram.TelegramGcpChatBot
+import io.micronaut.starter.feature.chatbots.telegram.TelegramHttpChatBot
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.TestFramework
+import org.jline.reader.LineReader
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class CreateChatBotBuilderCommandSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext applicationContext
+
+    def setupSpec() {
+        applicationContext = ApplicationContext.run();
+    }
+    /*
+        Choose your preferred deployment. (enter for default)
+        *1) AWS Lambda - Deploy to AWS Lambda
+         2) Azure Function - Deploy to Azure as a Function
+         3) Google Cloud Function - Deploy to Google Cloud as a Function
+         4) HTTP - Deploy as an HTTP Server
+        >
+
+        Choose your Lambda Architecture. (enter for x86)
+         1) arm
+        *2) x86
+        >
+
+        Do you want to generate infrastructure as code with CDK? (enter for yes)
+        *1) Yes
+         2) No
+        >
+
+        Choose your preferred language. (enter for default)
+        *1) Java
+         2) Groovy
+         3) Kotlin
+        >
+
+        Choose your preferred test framework. (enter for default)
+        *1) JUnit
+         2) Spock
+         3) Kotest
+        >
+
+        Choose your preferred build tool. (enter for default)
+         1) Gradle (Groovy)
+        *2) Gradle (Kotlin)
+         3) Maven
+        >
+
+        Choose the target JDK. (enter for default)
+        *1) 17
+         2) 21
+        >
+     */
+
+    void "test prompt"(CliOptions cliOptions) {
+        given:
+        CreateChatBotBuilderCommand command = applicationContext.getBean(CreateChatBotBuilderCommand)
+
+        when:
+        def reader = Stub(LineReader) {
+            readLine(BuilderCommand.PROMPT.get()) >>> cliOptions.cliCommands
+        }
+        GenerateOptions options = command.createGenerateOptions(reader)
+
+        then:
+        cliOptions.expectedApplicationType == options.applicationType
+        cliOptions.features ==~ options.features
+        cliOptions.language == options.options.language
+        cliOptions.buildTool == options.options.buildTool
+        cliOptions.testFramework == options.options.testFramework
+        cliOptions.javaVersion == options.options.javaVersion
+
+        where:
+        cliOptions << [
+                CreateChatBotBuilderCommand.ChatBotDeployment.values(),
+                [applicationContext.getBean(Arm), applicationContext.getBean(X86)],
+                [applicationContext.getBean(Cdk), null],
+                [Language.JAVA, Language.GROOVY, Language.KOTLIN],
+                [TestFramework.JUNIT, TestFramework.SPOCK, TestFramework.KOTEST],
+                [BuildTool.GRADLE, BuildTool.GRADLE_KOTLIN, BuildTool.MAVEN],
+                [JdkVersion.JDK_17, JdkVersion.JDK_21]
+        ].combinations().collect { new CliOptions(*it) }
+
+    }
+
+    private static class CliOptions {
+        final CreateChatBotBuilderCommand.ChatBotDeployment applicationType
+        final CpuArchitecture cpuArchitecture
+        final Cdk cdk
+        final Language language
+        final TestFramework testFramework
+        final BuildTool buildTool
+        final JdkVersion javaVersion
+
+        CliOptions(
+                CreateChatBotBuilderCommand.ChatBotDeployment applicationType,
+                CpuArchitecture cpuArchitecture,
+                Cdk cdk,
+                Language language,
+                TestFramework testFramework,
+                BuildTool buildTool,
+                JdkVersion javaVersion
+        ) {
+            this.applicationType = applicationType
+            this.cpuArchitecture = cpuArchitecture
+            this.cdk = cdk
+            this.language = language
+            this.testFramework = testFramework
+            this.buildTool = buildTool
+            this.javaVersion = javaVersion
+        }
+
+        List<String> getFeatures() {
+            switch (applicationType) {
+                case CreateChatBotBuilderCommand.ChatBotDeployment.LAMBDA:
+                    return [TelegramAwsChatBot.NAME, LambdaFunctionUrl.NAME, cpuArchitecture.getName()] + (cdk ? [Cdk.NAME] : [])
+                case CreateChatBotBuilderCommand.ChatBotDeployment.AZURE:
+                    return [TelegramAzureChatBot.NAME]
+                case CreateChatBotBuilderCommand.ChatBotDeployment.GCP:
+                    return [TelegramGcpChatBot.NAME]
+                case CreateChatBotBuilderCommand.ChatBotDeployment.HTTP:
+                    return [TelegramHttpChatBot.NAME]
+            }
+        }
+
+        ApplicationType getExpectedApplicationType() {
+            if (applicationType == CreateChatBotBuilderCommand.ChatBotDeployment.HTTP) {
+                return ApplicationType.DEFAULT
+            }
+            return ApplicationType.FUNCTION
+        }
+
+        List<String> getCliCommands() {
+            List<String> ret = [
+                    "${applicationType.ordinal() + 1}".toString()
+            ]
+            if (applicationType == CreateChatBotBuilderCommand.ChatBotDeployment.LAMBDA) {
+                ret += [
+                        cpuArchitecture instanceof Arm ? "1" : "2",
+                        cdk instanceof Cdk ? "1" : "2",
+                ]
+            }
+            ret + [
+                    "${language.ordinal() + 1}".toString(),
+                    "${testFramework.ordinal() + 1}".toString(),
+                    "${buildTool.ordinal() + 1}".toString(),
+                    javaVersion == JdkVersion.JDK_17 ? "1" : "2"
+            ]
+        }
+
+        @Override
+        String toString() {
+            if (applicationType == CreateChatBotBuilderCommand.ChatBotDeployment.LAMBDA) {
+                applicationType.name() + " " + cpuArchitecture.getName() + " " + cdk?.getName() + " " + language + " " + testFramework + " " + buildTool + " " + javaVersion
+            } else {
+                applicationType.name() + " " + language + " " + testFramework + " " + buildTool + " " + javaVersion
+            }
+        }
+    }
+}

--- a/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/CreateChatBotBuilderCommandSpec.groovy
+++ b/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/CreateChatBotBuilderCommandSpec.groovy
@@ -29,6 +29,10 @@ class CreateChatBotBuilderCommandSpec extends Specification {
         applicationContext = ApplicationContext.run();
     }
     /*
+Choose your ChatBot type. (enter for Telegram)
+*1) Telegram - A chat bot for the telegram messaging platform
+>
+
 Choose your preferred deployment. (enter for default)
 *1) AWS Lambda - Deploy to AWS Lambda
  2) Azure Function - Deploy to Azure as a Function
@@ -67,6 +71,7 @@ Choose your preferred build tool. (enter for default)
 Choose the target JDK. (enter for default)
 *1) 17
  2) 21
+>
      */
 
     void "test prompt"(CliOptions cliOptions) {
@@ -89,6 +94,7 @@ Choose the target JDK. (enter for default)
 
         where:
         cliOptions << [
+                CreateChatBotBuilderCommand.ChatBotType.values(),
                 CreateChatBotBuilderCommand.ChatBotDeployment.values(),
                 [applicationContext.getBean(Arm), applicationContext.getBean(X86)],
                 [true, false], // cdk
@@ -101,6 +107,8 @@ Choose the target JDK. (enter for default)
     }
 
     private static class CliOptions {
+
+        final CreateChatBotBuilderCommand.ChatBotType chatBotType
         final CreateChatBotBuilderCommand.ChatBotDeployment applicationType
         final CpuArchitecture cpuArchitecture
         final boolean cdk
@@ -110,6 +118,7 @@ Choose the target JDK. (enter for default)
         final JdkVersion javaVersion
 
         CliOptions(
+                CreateChatBotBuilderCommand.ChatBotType chatBotType,
                 CreateChatBotBuilderCommand.ChatBotDeployment applicationType,
                 CpuArchitecture cpuArchitecture,
                 boolean cdk,
@@ -118,6 +127,7 @@ Choose the target JDK. (enter for default)
                 BuildTool buildTool,
                 JdkVersion javaVersion
         ) {
+            this.chatBotType = chatBotType
             this.applicationType = applicationType
             this.cpuArchitecture = cpuArchitecture
             this.cdk = cdk
@@ -149,6 +159,7 @@ Choose the target JDK. (enter for default)
 
         List<String> getCliCommands() {
             List<String> ret = [
+                    "${chatBotType.ordinal() + 1}".toString(),
                     "${applicationType.ordinal() + 1}".toString()
             ]
             if (applicationType == CreateChatBotBuilderCommand.ChatBotDeployment.LAMBDA) {
@@ -168,9 +179,9 @@ Choose the target JDK. (enter for default)
         @Override
         String toString() {
             if (applicationType == CreateChatBotBuilderCommand.ChatBotDeployment.LAMBDA) {
-                "${applicationType.name()} ${cpuArchitecture.getName()} cdk:${cdk} $language $testFramework $buildTool $javaVersion"
+                "${chatBotType.name()} ${applicationType.name()} ${cpuArchitecture.getName()} cdk:${cdk} $language $testFramework $buildTool $javaVersion"
             } else {
-                "${applicationType.name()} $language $testFramework $buildTool $javaVersion"
+                "${chatBotType.name()} ${applicationType.name()} $language $testFramework $buildTool $javaVersion"
             }
         }
     }


### PR DESCRIPTION
This adds a new command `create-chatbot` to the `mn` cli tool.

I've extracted some common/repeated code up to the top level class.

I decided to not add `telegram` to the name at the moment, as more chatbots are coming and we should be able to use the same command....

```
./gradlew :micronaut-cli:build    
 java -jar starter-cli/build/libs/micronaut-cli-4.3.0-SNAPSHOT-all.jar create-chatbot
```