### PR TITLE
Fix Kotlin DSL when specifying docker image names

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -114,36 +114,65 @@ tasks {
     }
 }
 
+
+    // Update these to match your region, tenancy and repo
+@if(gradleBuild.getDsl() == GradleDsl.KOTLIN) {
+    val region = "region-key"
+    val tenancy = "tenancy"
+    val repo = "my-app"
+} else {
+    String region = "region-key"
+    String tenancy = "tenancy"
+    String repo = "my-app"
+}
+
+
     dockerBuild {
         @if(features.getFeatures().stream().anyMatch(f -> f instanceof AbstractDockerRegistryWorkflow)) {
+            @if(gradleBuild.getDsl() == GradleDsl.KOTLIN) {
+        images.set(listOf("${System.getenv("DOCKER_IMAGE") ?: project.name}:${project.version}"))
+            } else {
         images = ["${System.env.DOCKER_IMAGE ?: project.name}:$project.version"]
+            }
         } else {
             @if(gradleBuild.getDsl() == GradleDsl.KOTLIN) {
-        images.set(listOf("[REGION].ocir.io/[TENANCY]/[REPO]/$project.name:$project.version"))
+        images.set(listOf("${region}.ocir.io/${tenancy}/${repo}/${project.name}:${project.version}"))
             } else {
-        images = ["[REGION].ocir.io/[TENANCY]/[REPO]/$project.name:$project.version"]
+        images = ["${region}.ocir.io/${tenancy}/${repo}/${project.name}:${project.version}"]
             }
         }
     }
 
     dockerBuildNative {
         @if(features.getFeatures().stream().anyMatch(f -> f instanceof AbstractDockerRegistryWorkflow)) {
+            @if(gradleBuild.getDsl() == GradleDsl.KOTLIN) {
+        images.set(listOf("${System.getenv("DOCKER_IMAGE") ?: project.name}:${project.version}"))
+            } else {
         images = ["${System.env.DOCKER_IMAGE ?: project.name}:$project.version"]
+            }
         } else {
             @if(gradleBuild.getDsl() == GradleDsl.KOTLIN) {
-        images.set(listOf("[REGION].ocir.io/[TENANCY]/[REPO]/$project.name-native:$project.version"))
+        images.set(listOf("${region}.ocir.io/${tenancy}/${repo}/${project.name}:${project.version}"))
             } else {
-        images = ["[REGION].ocir.io/[TENANCY]/[REPO]/$project.name-native:$project.version"]
+        images = ["${region}.ocir.io/${tenancy}/${repo}/${project.name}:${project.version}"]
             }
         }
     }
 } else if(features.getFeatures().stream().anyMatch(f -> f instanceof AbstractDockerRegistryWorkflow)) {
     dockerBuild {
+            @if(gradleBuild.getDsl() == GradleDsl.KOTLIN) {
+        images.set(listOf("${System.getenv("DOCKER_IMAGE") ?: project.name}:${project.version}"))
+            } else {
         images = ["${System.env.DOCKER_IMAGE ?: project.name}:$project.version"]
+            }
     }
 
     dockerBuildNative {
+            @if(gradleBuild.getDsl() == GradleDsl.KOTLIN) {
+        images.set(listOf("${System.getenv("DOCKER_IMAGE") ?: project.name}:${project.version}"))
+            } else {
         images = ["${System.env.DOCKER_IMAGE ?: project.name}:$project.version"]
+            }
     }
 }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/docker/DockerRegistryWorkflowSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/docker/DockerRegistryWorkflowSpec.groovy
@@ -3,8 +3,12 @@ package io.micronaut.starter.feature.github.workflows.docker
 import io.micronaut.starter.BeanContextSpec
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.fixture.CommandOutputFixture
-import io.micronaut.starter.options.*
-import spock.lang.Unroll
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
+import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
 
 class DockerRegistryWorkflowSpec extends BeanContextSpec implements CommandOutputFixture{
 
@@ -27,7 +31,6 @@ Add the following GitHub secrets:
 """)
     }
 
-    @Unroll
     void 'test github workflow is created for #buildTool'(BuildTool buildTool, String workflowName) {
         when:
         def output = generate(ApplicationType.DEFAULT,
@@ -57,20 +60,29 @@ Add the following GitHub secrets:
         maven.contains("DOCKER_IMAGE=`echo \"\${DOCKER_REGISTRY_URL}/\${DOCKER_REPOSITORY_PATH}/foo")
     }
 
-    void 'test docker image is configured in build.gradle'() {
+    void 'test docker image is configured in #buildFileName'(BuildTool buildTool) {
         when:
-        def output = generate([DockerRegistryWorkflow.NAME])
-        def gradle = output['build.gradle.kts']
+        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, buildTool), [DockerRegistryWorkflow.NAME])
+        def gradle = output[buildTool.buildFileName]
 
         then:
-        gradle
-        gradle.contains("""
+        if (buildTool == BuildTool.GRADLE) {
+            assert gradle.contains('''
     dockerBuild {
-        images = [\"\${System.env.DOCKER_IMAGE ?: project.name}:\$project.version"]
-    }""")
+        images = ["${System.env.DOCKER_IMAGE ?: project.name}:$project.version"]
+    }''')
+        } else {
+            assert gradle.contains('''
+    dockerBuild {
+        images.set(listOf("${System.getenv("DOCKER_IMAGE") ?: project.name}:${project.version}"))
+    }''')
+        }
+
+        where:
+        buildTool << BuildTool.valuesGradle()
+        buildFileName = buildTool.buildFileName
     }
 
-    @Unroll
     void 'test github gradle workflow java version for #version'(JdkVersion version){
         when:
         def output = generate(ApplicationType.DEFAULT,

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/docker/GraalVMDockerRegistryWorkflowSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/docker/GraalVMDockerRegistryWorkflowSpec.groovy
@@ -43,17 +43,27 @@ Add the following GitHub secrets:
         buildTool << BuildTool.values()
     }
 
-    void 'test docker image configured in build.gradle'() {
+    void 'test docker image is configured in #buildFileName'(BuildTool buildTool) {
         when:
-        def output = generate([GraalVMDockerRegistryWorkflow.NAME])
-        def gradle = output['build.gradle.kts']
+        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, buildTool), [GraalVMDockerRegistryWorkflow.NAME])
+        def gradle = output[buildTool.buildFileName]
 
         then:
-        gradle
-        gradle.contains("""
+        if (buildTool == BuildTool.GRADLE) {
+            assert gradle.contains('''
     dockerBuildNative {
-        images = [\"\${System.env.DOCKER_IMAGE ?: project.name}:\$project.version"]
-    }""")
+        images = ["${System.env.DOCKER_IMAGE ?: project.name}:$project.version"]
+    }''')
+        } else {
+            assert gradle.contains('''
+    dockerBuildNative {
+        images.set(listOf("${System.getenv("DOCKER_IMAGE") ?: project.name}:${project.version}"))
+    }''')
+        }
+
+        where:
+        buildTool << BuildTool.valuesGradle()
+        buildFileName = buildTool.buildFileName
     }
 
     void 'test push to docker workflow for maven'() {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/oci/OracleFunctionsWorkflowSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/github/workflows/oci/OracleFunctionsWorkflowSpec.groovy
@@ -3,9 +3,13 @@ package io.micronaut.starter.feature.github.workflows.oci
 import io.micronaut.starter.BeanContextSpec
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.fixture.CommandOutputFixture
-import io.micronaut.starter.options.*
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
+import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.util.VersionInfo
-import spock.lang.Unroll
 
 class OracleFunctionsWorkflowSpec extends BeanContextSpec implements CommandOutputFixture {
 
@@ -29,7 +33,6 @@ class OracleFunctionsWorkflowSpec extends BeanContextSpec implements CommandOutp
         readme.contains("Oracle Functions GraalVM GitHub Workflow")
     }
 
-    @Unroll
     void 'test github workflow is created for #buildTool with #jdkVersion'(BuildTool buildTool, JdkVersion jdkVersion) {
         when:
         def output = generate(ApplicationType.DEFAULT,
@@ -52,7 +55,6 @@ class OracleFunctionsWorkflowSpec extends BeanContextSpec implements CommandOutp
         ].combinations()
     }
 
-    @Unroll
     void 'test github graalvm workflow is created for #buildTool'(BuildTool buildTool) {
         when:
         def output = generate(ApplicationType.DEFAULT,
@@ -69,7 +71,6 @@ class OracleFunctionsWorkflowSpec extends BeanContextSpec implements CommandOutp
         buildTool << BuildTool.values()
     }
 
-    @Unroll
     void 'test http function pom.xml configuration for #feature'(String feature) {
         when:
         def output = generate(ApplicationType.DEFAULT,
@@ -118,28 +119,39 @@ class OracleFunctionsWorkflowSpec extends BeanContextSpec implements CommandOutp
 """)
     }
 
-    void 'test docker image is configured in build.gradle for #feature'(String feature) {
+    void 'test docker image is configured in #buildFileName for #feature'(BuildTool buildTool, String feature) {
         when:
-        def output = generate([feature])
-        def gradle = output['build.gradle.kts']
+        def output = generate(ApplicationType.DEFAULT, new Options(Language.JAVA, buildTool), [feature])
+        def gradle = output[buildTool.buildFileName]
 
         then:
-        gradle
-        gradle.contains("""
+        if (buildTool == BuildTool.GRADLE) {
+            assert gradle.contains('''
     dockerBuild {
-        images = [\"\${System.env.DOCKER_IMAGE ?: project.name}:\$project.version\"]
-    }""")
+        images = ["${System.env.DOCKER_IMAGE ?: project.name}:$project.version"]
+    }''')
 
-        gradle.contains("""
+            assert gradle.contains('''
     dockerBuildNative {
-        images = [\"\${System.env.DOCKER_IMAGE ?: project.name}:\$project.version\"]
-    }""")
+        images = ["${System.env.DOCKER_IMAGE ?: project.name}:$project.version"]
+    }''')
+        } else {
+            assert gradle.contains('''
+    dockerBuild {
+        images.set(listOf("${System.getenv("DOCKER_IMAGE") ?: project.name}:${project.version}"))
+    }''')
+
+            assert gradle.contains('''
+    dockerBuildNative {
+        images.set(listOf("${System.getenv("DOCKER_IMAGE") ?: project.name}:${project.version}"))
+    }''')
+        }
 
         where:
-        feature << [OracleFunctionsJavaWorkflow.NAME, OracleFunctionsGraalWorkflow.NAME]
+        [buildTool, feature] << [BuildTool.valuesGradle(), [OracleFunctionsJavaWorkflow.NAME, OracleFunctionsGraalWorkflow.NAME]].combinations()
+        buildFileName = buildTool.buildFileName
     }
 
-    @Unroll
     void 'test github gradle graal #graalVersion workflow for #jdkVersion'(JdkVersion jdkVersion,
                                                                            JdkVersion graalVersion) {
         given:


### PR DESCRIPTION
Previously we had 2 issues.

In some places we were using `$project.name` which resolves to `${project}.name` in Kotlin (so is incorrect)

In others, we were using `images = [ ... ]` which is not valid kotlin.

Changed the build rocker, and fixed and extended the tests to check both Kts and groovy DSL.

Closes #2231