### PR TITLE
Make Picocli feature require Kapt for Kotlin projects. It is incompatible with KSP.

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/RequireKaptFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/RequireKaptFeature.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature;
+
+/**
+ * Some third party features apply annotation processors that are not compatible with Kotlin Symbol Processing (KSP)
+ * for Kotlin language projects. They require using the kapt compiler plugin (Kapt) instead. Note that Maven
+ * projects always use Kapt since Maven isn't compatible with KSP.
+ *
+ * @see io.micronaut.starter.feature.build.Kapt
+ * @see KotlinSymbolProcessing
+ * @see RequireKaptFeatureValidator
+ */
+public interface RequireKaptFeature extends Feature {
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/RequireKaptFeatureValidator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/RequireKaptFeatureValidator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature;
+
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.feature.validation.FeatureValidator;
+import io.micronaut.starter.options.Language;
+import io.micronaut.starter.options.Options;
+import jakarta.inject.Singleton;
+
+import java.util.Set;
+
+@Singleton
+public class RequireKaptFeatureValidator implements FeatureValidator {
+
+    @Override
+    public void validatePreProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+    }
+
+    @Override
+    public void validatePostProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+        if (options.getLanguage() == Language.KOTLIN) {
+            for (Feature feature : features) {
+                if (feature instanceof RequireKaptFeature) {
+                    if (features.stream().anyMatch(KotlinSymbolProcessing.class::isInstance)) {
+                        throw new IllegalArgumentException(
+                                String.format("Feature %s is incompatible with Kotlin KSP and requires Kapt instead.", feature.getName()));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/picocli/lang/kotlin/PicocliKotlinApplication.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/picocli/lang/kotlin/PicocliKotlinApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.Project;
 import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.feature.RequireKaptFeature;
 import io.micronaut.starter.feature.lang.kotlin.KotlinApplicationFeature;
 import io.micronaut.starter.template.RockerTemplate;
-
 import jakarta.inject.Singleton;
 
 @Singleton
-public class PicocliKotlinApplication implements KotlinApplicationFeature {
+public class PicocliKotlinApplication implements RequireKaptFeature, KotlinApplicationFeature {
 
     @Override
     @Nullable

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/gradle/GradleSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/gradle/GradleSpec.groovy
@@ -5,6 +5,7 @@ import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.build.Property
 import io.micronaut.starter.build.gradle.GradleBuild
 import io.micronaut.starter.feature.aws.AwsLambdaFeatureValidator
+import io.micronaut.starter.feature.build.Kapt
 import io.micronaut.starter.feature.build.MicronautBuildPlugin
 import io.micronaut.starter.feature.build.gradle.templates.gradleProperties
 import io.micronaut.starter.feature.build.gradle.templates.settingsGradle
@@ -126,7 +127,8 @@ class GradleSpec extends BeanContextSpec implements CommandOutputFixture {
             ApplicationType apptype, Language lang, BuildTool buildTool
     ) {
         when:
-        def output = generate(apptype, new Options(lang, TestFramework.DEFAULT_OPTION, buildTool, jdk))
+        def features = (apptype == ApplicationType.CLI && lang == Language.KOTLIN) ? [Kapt.NAME] : []
+        def output = generate(apptype, new Options(lang, TestFramework.DEFAULT_OPTION, buildTool, jdk), features)
         def readme = output["README.md"]
 
         then:

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateCliSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/create/CreateCliSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.starter.core.test.create
 
 
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.feature.build.Kapt
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.test.CommandSpec
@@ -21,7 +22,7 @@ class CreateCliSpec extends CommandSpec {
     void 'create-cli-app with #lang and #buildTool'(Language lang, BuildTool buildTool) {
         given:
         ApplicationType applicationType = ApplicationType.CLI
-        generateProject(lang, buildTool, [], applicationType)
+        generateProject(lang, buildTool, (lang == Language.KOTLIN) ? [Kapt.NAME] : [], applicationType)
 
         when:
         String output = null


### PR DESCRIPTION
see https://github.com/micronaut-projects/micronaut-picocli/issues/351

ping @sdelamo 
I introduced a `RequireKaptFeature` marker interface as you suggested. Note that it's not applicable to the `ProjectLombok` feature as you mentioned, because that is a Java-only feature and won't work with Kotlin projects anyway. I don't know if there are other 3rd party annotation processors that should be applied.