### PR TITLE
Remove duplicate annotation processor dependencies in groovy/maven projects

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MicronautDependencyUtils.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MicronautDependencyUtils.java
@@ -268,7 +268,30 @@ public final class MicronautDependencyUtils {
                     .groupId(groupId)
                     .artifactId(artifactId)
                     .annotationProcessor();
-            case MAVEN -> moduleMavenAnnotationProcessor(groupId, artifactId, propertyName, requiresPriority);
+            case MAVEN -> moduleMavenAnnotationProcessor(groupId, artifactId, propertyName, false, requiresPriority);
+        };
+    }
+
+    @NonNull
+    public static Dependency.Builder testAnnotationProcessor(@NonNull BuildTool buildTool,
+                                                             @NonNull String groupId,
+                                                             @NonNull String artifactId,
+                                                             @NonNull String propertyName) {
+        return testAnnotationProcessor(buildTool, groupId, artifactId, propertyName, false);
+    }
+
+    @NonNull
+    public static Dependency.Builder testAnnotationProcessor(@NonNull BuildTool buildTool,
+                                                         @NonNull String groupId,
+                                                         @NonNull String artifactId,
+                                                         @NonNull String propertyName,
+                                                         boolean requiresPriority) {
+        return switch (buildTool) {
+            case GRADLE, GRADLE_KOTLIN -> Dependency.builder()
+                    .groupId(groupId)
+                    .artifactId(artifactId)
+                    .testAnnotationProcessor();
+            case MAVEN -> moduleMavenAnnotationProcessor(groupId, artifactId, propertyName, true, requiresPriority);
         };
     }
 
@@ -276,13 +299,14 @@ public final class MicronautDependencyUtils {
     public static Dependency.Builder moduleMavenAnnotationProcessor(@NonNull String groupId,
                                                                     @NonNull String artifactId,
                                                                     @NonNull String propertyName,
+                                                                    boolean isTestScope,
                                                                     boolean requiresPriority) {
-        return Dependency.builder()
+        Dependency.Builder dependency = Dependency.builder()
                 .groupId(groupId)
                 .artifactId(artifactId)
-                .annotationProcessor(requiresPriority)
-                .versionProperty(propertyName)
-                .exclude(MICRONAUT_INJECT);
+                .versionProperty(propertyName);
+
+        return isTestScope ? dependency.testAnnotationProcessor(requiresPriority) : dependency.annotationProcessor(requiresPriority);
     }
 
     @NonNull

--- a/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/maven/MavenBuildCreator.java
@@ -53,7 +53,9 @@ public class MavenBuildCreator {
 
         for (Dependency dependency : generatorContext.getDependencies()) {
             if (dependency.getScope().getPhases().contains(Phase.ANNOTATION_PROCESSING)) {
-                if (dependency.getScope().getSource() == Source.MAIN) {
+                if (dependency.getScope().getSource() == Source.MAIN && generatorContext.getLanguage() != Language.GROOVY) {
+                    // Don't add these for Groovy projects: it results in multiple dependencies.
+                    // DependencyContext has already resolved Groovy annotation processors as dependencies
                     annotationProcessorsCoordinates.add(new DependencyCoordinate(dependency, true));
                     if (dependency.isAnnotationProcessorPriority()) {
                         combineAttribute = MavenCombineAttribute.OVERRIDE;

--- a/starter-core/src/main/java/io/micronaut/starter/feature/jaxrs/JaxRs.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/jaxrs/JaxRs.java
@@ -64,18 +64,17 @@ public class JaxRs implements Feature, MicronautServerDependent {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        Dependency.Builder jaxrs = Dependency.builder()
-                .groupId(MICRONAUT_JAX_RS_GROUP)
-                .artifactId(MICRONAUT_JAXRS_PROCESSOR)
-                .versionProperty(MICRONAUT_JAXRS_VERSION)
-                .template();
-
-        generatorContext.addDependency(MicronautDependencyUtils.annotationProcessor(generatorContext.getBuildTool(),
+        Dependency.Builder annotationProcessor = MicronautDependencyUtils.annotationProcessor(generatorContext.getBuildTool(),
                 MICRONAUT_JAX_RS_GROUP,
                 MICRONAUT_JAXRS_PROCESSOR,
-                MICRONAUT_JAXRS_VERSION));
+                MICRONAUT_JAXRS_VERSION);
+        Dependency.Builder testAnnotationProcessor = MicronautDependencyUtils.testAnnotationProcessor(generatorContext.getBuildTool(),
+                MICRONAUT_JAX_RS_GROUP,
+                MICRONAUT_JAXRS_PROCESSOR,
+                MICRONAUT_JAXRS_VERSION);
 
-        generatorContext.addDependency(jaxrs.testAnnotationProcessor());
+        generatorContext.addDependency(annotationProcessor);
+        generatorContext.addDependency(testAnnotationProcessor);
         generatorContext.addDependency(Dependency.builder()
                 .groupId(MICRONAUT_JAX_RS_GROUP)
                 .artifactId("micronaut-jaxrs-server")

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/jaxrs/JaxRsSecuritySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/jaxrs/JaxRsSecuritySpec.groovy
@@ -2,9 +2,12 @@ package io.micronaut.starter.feature.jaxrs
 
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
+import spock.lang.Issue
 import spock.lang.Unroll
 
 class JaxRsSecuritySpec extends ApplicationContextSpec implements CommandOutputFixture {
@@ -26,11 +29,12 @@ class JaxRsSecuritySpec extends ApplicationContextSpec implements CommandOutputF
                 .features(['security', JaxRs.NAME, 'kapt'])
                 .language(language)
                 .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(BuildTool.GRADLE, language, template)
 
         then:
-        template.contains('implementation("io.micronaut.jaxrs:micronaut-jaxrs-server-security")')
-        template.contains('implementation("io.micronaut.jaxrs:micronaut-jaxrs-server")')
-        template.contains("$scope(\"io.micronaut.jaxrs:micronaut-jaxrs-processor\")")
+        verifier.hasDependency("io.micronaut.jaxrs", "micronaut-jaxrs-server-security")
+        verifier.hasDependency("io.micronaut.jaxrs", "micronaut-jaxrs-server")
+        verifier.hasDependency("io.micronaut.jaxrs", "micronaut-jaxrs-processor", scope)
 
         where:
         language        | scope
@@ -50,93 +54,44 @@ class JaxRsSecuritySpec extends ApplicationContextSpec implements CommandOutputF
         !template.contains('implementation("io.micronaut.jaxrs:micronaut-jaxrs-server-security")')
     }
 
-    void 'test maven jax-rs-security feature'() {
+    void 'test maven jax-rs-security feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
                 .features(['security', JaxRs.NAME])
                 .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(BuildTool.MAVEN, language, template)
 
         then:
-        template.contains("""
-    <dependency>
-      <groupId>io.micronaut.jaxrs</groupId>
-      <artifactId>micronaut-jaxrs-server-security</artifactId>
-      <scope>compile</scope>
-    </dependency>
-""")
+        verifier.hasDependency("io.micronaut.jaxrs", "micronaut-jaxrs-server-security")
+        verifier.hasDependency("io.micronaut.jaxrs", "micronaut-jaxrs-server")
+        verifier.hasAnnotationProcessor("io.micronaut.jaxrs", "micronaut-jaxrs-processor")
 
-        template.contains("""
-    <dependency>
-      <groupId>io.micronaut.jaxrs</groupId>
-      <artifactId>micronaut-jaxrs-server</artifactId>
-      <scope>compile</scope>
-    </dependency>
-""")
-        template.contains("""
-            <path>
-              <groupId>io.micronaut.jaxrs</groupId>
-              <artifactId>micronaut-jaxrs-processor</artifactId>
-              <version>\${micronaut.jaxrs.version}</version>
-              <exclusions>
-                <exclusion>
-                  <groupId>io.micronaut</groupId>
-                  <artifactId>micronaut-inject</artifactId>
-                </exclusion>
-              </exclusions>
-            </path>
-""")
+        and:
+        if (language == Language.KOTLIN) {
+            assert verifier.hasTestAnnotationProcessor("io.micronaut.jaxrs", "micronaut-jaxrs-processor")
+        }
+        where:
+        language << Language.values()
+    }
 
+    @Issue("https://github.com/micronaut-projects/micronaut-starter/issues/2264")
+    void "test maven jax-rs feature for Groovy doesn't duplicate annotation processors"() {
         when:
-        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .language(Language.KOTLIN)
-                .features(['security', JaxRs.NAME])
-                .render()
-
-        then:
-        template.contains("""
-    <dependency>
-      <groupId>io.micronaut.jaxrs</groupId>
-      <artifactId>micronaut-jaxrs-server-security</artifactId>
-      <scope>compile</scope>
-    </dependency>
-""")
-
-        template.contains("""
-    <dependency>
-      <groupId>io.micronaut.jaxrs</groupId>
-      <artifactId>micronaut-jaxrs-server</artifactId>
-      <scope>compile</scope>
-    </dependency>
-""")
-        template.count('''\
-               <annotationProcessorPath>
-                 <groupId>io.micronaut.jaxrs</groupId>
-                 <artifactId>micronaut-jaxrs-processor</artifactId>
-                 <version>${micronaut.jaxrs.version}</version>
-               </annotationProcessorPath>
-''') == 2
-
-        when:
-        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .language(Language.GROOVY)
                 .features(['security', JaxRs.NAME])
                 .render()
 
         then:
-        template.contains("""
+        // duplicates were added for Groovy annotationProcessor scope, so avoid regression
+        template.count('''\
     <dependency>
       <groupId>io.micronaut.jaxrs</groupId>
-      <artifactId>micronaut-jaxrs-server-security</artifactId>
-      <scope>compile</scope>
+      <artifactId>micronaut-jaxrs-processor</artifactId>
+      <scope>provided</scope>
     </dependency>
-""")
-
-        template.contains("""
-    <dependency>
-      <groupId>io.micronaut.jaxrs</groupId>
-      <artifactId>micronaut-jaxrs-server</artifactId>
-      <scope>compile</scope>
-    </dependency>
-""")
+''') == 1
     }
+
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/jaxrs/JaxRsSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/jaxrs/JaxRsSpec.groovy
@@ -2,9 +2,12 @@ package io.micronaut.starter.feature.jaxrs
 
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
+import spock.lang.Issue
 import spock.lang.Unroll
 
 class JaxRsSpec extends ApplicationContextSpec  implements CommandOutputFixture {
@@ -26,10 +29,11 @@ class JaxRsSpec extends ApplicationContextSpec  implements CommandOutputFixture 
                 .features([JaxRs.NAME, 'kapt'])
                 .language(language)
                 .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(BuildTool.GRADLE, language, template)
 
         then:
-        template.contains('implementation("io.micronaut.jaxrs:micronaut-jaxrs-server")')
-        template.contains("$scope(\"io.micronaut.jaxrs:micronaut-jaxrs-processor\")")
+        verifier.hasDependency("io.micronaut.jaxrs", "micronaut-jaxrs-server")
+        verifier.hasDependency("io.micronaut.jaxrs", "micronaut-jaxrs-processor", scope)
 
         where:
         language        | scope
@@ -38,70 +42,43 @@ class JaxRsSpec extends ApplicationContextSpec  implements CommandOutputFixture 
         Language.GROOVY | "compileOnly"
     }
 
-    void 'test maven jax-rs feature'() {
+    void 'test maven jax-rs feature for language=#language'() {
         when:
         String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+                .language(language)
                 .features([JaxRs.NAME])
                 .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(BuildTool.MAVEN, language, template)
 
         then:
-        template.contains("""
-    <dependency>
-      <groupId>io.micronaut.jaxrs</groupId>
-      <artifactId>micronaut-jaxrs-server</artifactId>
-      <scope>compile</scope>
-    </dependency>
-""")
-        template.contains("""
-            <path>
-              <groupId>io.micronaut.jaxrs</groupId>
-              <artifactId>micronaut-jaxrs-processor</artifactId>
-              <version>\${micronaut.jaxrs.version}</version>
-              <exclusions>
-                <exclusion>
-                  <groupId>io.micronaut</groupId>
-                  <artifactId>micronaut-inject</artifactId>
-                </exclusion>
-              </exclusions>
-            </path>
-""")
+        verifier.hasDependency("io.micronaut.jaxrs", "micronaut-jaxrs-server")
+        verifier.hasAnnotationProcessor("io.micronaut.jaxrs", "micronaut-jaxrs-processor")
 
+        and:
+        if (language == Language.KOTLIN) {
+            assert verifier.hasTestAnnotationProcessor("io.micronaut.jaxrs", "micronaut-jaxrs-processor")
+        }
+        where:
+        language << Language.values()
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-starter/issues/2264")
+    void "test maven jax-rs feature for Groovy doesn't duplicate annotation processors"() {
         when:
-        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .language(Language.KOTLIN)
-                .features([JaxRs.NAME])
-                .render()
-
-        then:
-        template.contains("""
-    <dependency>
-      <groupId>io.micronaut.jaxrs</groupId>
-      <artifactId>micronaut-jaxrs-server</artifactId>
-      <scope>compile</scope>
-    </dependency>
-""")
-        template.count('''\
-               <annotationProcessorPath>
-                 <groupId>io.micronaut.jaxrs</groupId>
-                 <artifactId>micronaut-jaxrs-processor</artifactId>
-                 <version>${micronaut.jaxrs.version}</version>
-               </annotationProcessorPath>
-''') == 2
-
-        when:
-        template = new BuildBuilder(beanContext, BuildTool.MAVEN)
+        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
                 .language(Language.GROOVY)
                 .features([JaxRs.NAME])
                 .render()
 
         then:
-        template.contains("""
+        // duplicates were added for Groovy annotationProcessor scope, so avoid regression
+        template.count('''\
     <dependency>
       <groupId>io.micronaut.jaxrs</groupId>
-      <artifactId>micronaut-jaxrs-server</artifactId>
-      <scope>compile</scope>
+      <artifactId>micronaut-jaxrs-processor</artifactId>
+      <scope>provided</scope>
     </dependency>
-""")
-
+''') == 1
     }
+
 }


### PR DESCRIPTION
fixes #2264

- ensure that adding annotation processors for a Groovy/Maven project doesn't result in multiple dependencies
- as per @alvarosanchez, the `java-inject` excludes for Groovy annotation processor dependencies are no longer necessary
  - I smoke tested generated Groovy/Maven projects for `jax-rs` and `jax-rs` + `security`, and they passed the `verify` task