### PR TITLE
Pin MySQL to 8.2 in generated projects

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/HibernateReactiveFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/HibernateReactiveFeature.java
@@ -61,9 +61,13 @@ public abstract class HibernateReactiveFeature extends EaseTestingFeature implem
             generatorContext.getConfiguration().put(JPA_DEFAULT_PROPERTIES_HIBERNATE_CONNECTION_PASSWORD,
                     migrationFeature.map(f -> "${datasources.default.password}").orElse(dbFeature.getDefaultPassword()));
         } else {
-            optionalDbType.ifPresent(type ->
-                    generatorContext.getConfiguration().put(JPA_HIBERNATE_PROPERTIES_CONNECTION + ".db-type", type.toString())
-            );
+            optionalDbType.ifPresent(type -> {
+                generatorContext.getConfiguration().put(JPA_HIBERNATE_PROPERTIES_CONNECTION + ".db-type", type.toString());
+                // MySql 8.3 doesn't work with TestContainers 1.19.3 https://github.com/testcontainers/testcontainers-java/issues/8130
+                if (type == DbType.MYSQL) {
+                    generatorContext.getConfiguration().addNested("test-resources.containers.mysql.image-name", "mysql:8.2");
+                }
+            });
         }
         if (optionalDbType.isPresent()) {
             DbType dbType = optionalDbType.get();

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/HibernateReactiveFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/HibernateReactiveFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/MySQL.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/MySQL.java
@@ -16,12 +16,14 @@
 package io.micronaut.starter.feature.database;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.database.jdbc.JdbcFeature;
 import io.micronaut.starter.feature.testresources.DbType;
 import io.micronaut.starter.feature.testresources.TestResources;
 import jakarta.inject.Singleton;
 
+import java.util.Map;
 import java.util.Optional;
 
 @Singleton
@@ -108,6 +110,16 @@ public class MySQL extends MySQLCompatibleFeature {
     @NonNull
     public Optional<Dependency.Builder> getR2DbcDependency() {
         return Optional.of(DEPENDENCY_R2DBC_MYSQL);
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalConfig(GeneratorContext generatorContext) {
+        if (generatorContext.isFeaturePresent(TestResources.class)) {
+            // MySql 8.3 doesn't work with TestContainers 1.19.3 https://github.com/testcontainers/testcontainers-java/issues/8130
+            return Map.of("test-resources.containers.mysql.image-name", "mysql:8.2");
+        } else {
+            return super.getAdditionalConfig(generatorContext);
+        }
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/MySQL.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/MySQL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java
@@ -153,7 +153,7 @@ public class TestContainers implements Feature {
     @NonNull
     private static Optional<String> r2dbcUrlForDatabaseDriverFeature(@NonNull DatabaseDriverFeature driverFeature) {
         if (driverFeature instanceof MySQL) {
-            return Optional.of("r2dbc:tc:mysql:///db?TC_IMAGE_TAG=8");
+            return Optional.of("r2dbc:tc:mysql:///db?TC_IMAGE_TAG=8.2");
         } else if (driverFeature instanceof PostgreSQL) {
             return Optional.of("r2dbc:tc:postgresql:///db?TC_IMAGE_TAG=12");
         } else if (driverFeature instanceof MariaDB) {
@@ -167,7 +167,7 @@ public class TestContainers implements Feature {
     @NonNull
     private static Optional<String> urlForDatabaseDriverFeature(@NonNull DatabaseDriverFeature driverFeature) {
         if (driverFeature instanceof MySQL) {
-            return Optional.of("jdbc:tc:mysql:8:///db");
+            return Optional.of("jdbc:tc:mysql:8.2:///db");
 
         } else if (driverFeature instanceof PostgreSQL) {
             return Optional.of("jdbc:tc:postgresql:14:///postgres");

--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbc.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/r2dbc/R2dbc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/testcontainers/TestcontainersSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/testcontainers/TestcontainersSpec.groovy
@@ -10,8 +10,6 @@ import io.micronaut.starter.template.RockerWritable
 import io.micronaut.starter.test.BuildToolCombinations
 import io.micronaut.starter.test.CommandSpec
 import io.micronaut.starter.util.VersionInfo
-import spock.lang.Retry
-import spock.lang.Unroll
 
 // Required so Groovy recognizes these as a class
 import io.micronaut.starter.core.test.feature.testcontainers.bookRepository
@@ -19,7 +17,7 @@ import io.micronaut.starter.core.test.feature.testcontainers.book
 import io.micronaut.starter.core.test.feature.testcontainers.bookRepositoryTest
 
 import java.util.stream.Collectors
-@Retry // sometimes CI gets connection failure/reset resolving dependencies from Maven central
+
 class TestcontainersSpec extends CommandSpec {
 
     @Override
@@ -27,7 +25,6 @@ class TestcontainersSpec extends CommandSpec {
         return "testcontainers"
     }
 
-    @Unroll
     void "test running tests with testcontainers with #buildTool and #driverFeature.getName()"(BuildTool buildTool, DatabaseDriverFeature driverFeature) {
         setup:
         boolean skip = driverFeature.name == "oracle-cloud-atp" && VersionInfo.getJavaVersion() == JdkVersion.JDK_8
@@ -58,9 +55,7 @@ class TestcontainersSpec extends CommandSpec {
         where:
         [buildTool, driverFeature] << [
                 BuildToolCombinations.buildTools,
-                beanContext.streamOfType(DatabaseDriverFeature)
-                        .filter({ f ->  !f.embedded() })
-                        .collect(Collectors.toList())
+                beanContext.getBeansOfType(DatabaseDriverFeature).findAll { !it.embedded() }
         ].combinations()
     }
 }


### PR DESCRIPTION
MySQL 8.3 (latest at time of writing) doesn't work with TestContainers 1.19.3

This PR pins to 8.2 and does some chores on the touched files

Commited so we can just revert https://github.com/micronaut-projects/micronaut-starter/commit/2bc6ce150baee23c0dd0f83ab0b874bad5b515dd when it's fixed