### PR TITLE
configuration for parameter store and secrets manager

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/awsparameterstore/AwsParameterStore.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awsparameterstore/AwsParameterStore.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.starter.feature.awsparameterstore;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.distributedconfig.DistributedConfigFeature;
 
 import jakarta.inject.Singleton;
@@ -24,6 +26,19 @@ import java.util.Map;
 
 @Singleton
 public class AwsParameterStore implements DistributedConfigFeature {
+    private static final String ARTIFACT_ID_MICRONAUT_AWS_PARAMETER_STORE = "micronaut-aws-parameter-store";
+    private static final Dependency.Builder DEPENDNCY_MICRONAUT_AWS_PARAMETER_STORE = MicronautDependencyUtils.awsDependency()
+            .artifactId(ARTIFACT_ID_MICRONAUT_AWS_PARAMETER_STORE)
+            .compile();
+    private static final String PROPERTY_AWS_CLIENT_SYSTEM_MANAGER_PARAMETERSTORE_ENABLED = "aws.client.system-manager.parameterstore.enabled";
+    private static final String PROPERTY_AWS_DISTRIBUTED_CONFIGURATION_SEARCH_ACTIVE_ENVIRONMENTS = "aws.distributed-configuration.search-active-environments";
+    private static final String PROPERTY_AWS_DISTRIBUTED_CONFIGURATION_SEARCH_COMMON_APPLICATION = "aws.distributed-configuration.search-common-application";
+
+    public static final Map<String, Object> PROPERTIES_AWS_DISTRIBUTED_CONFIGURATION = Map.of(
+            PROPERTY_AWS_CLIENT_SYSTEM_MANAGER_PARAMETERSTORE_ENABLED, true,
+        PROPERTY_AWS_DISTRIBUTED_CONFIGURATION_SEARCH_ACTIVE_ENVIRONMENTS, false,
+        PROPERTY_AWS_DISTRIBUTED_CONFIGURATION_SEARCH_COMMON_APPLICATION, false);
+
     @Override
     public String getTitle() {
         return "AWS Parameter Store Distributed Configuration";
@@ -41,13 +56,8 @@ public class AwsParameterStore implements DistributedConfigFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.addDependency(Dependency.builder()
-                .groupId("io.micronaut.aws")
-                .artifactId("micronaut-aws-parameter-store")
-                .compile());
-
-        Map<String, Object> config = populateBootstrapForDistributedConfiguration(generatorContext);
-        config.put("aws.client.system-manager.parameterstore.enabled", true);
+        addDependencies(generatorContext);
+        addBootstrapProperties(generatorContext);
     }
 
     @Override
@@ -58,5 +68,13 @@ public class AwsParameterStore implements DistributedConfigFeature {
     @Override
     public String getThirdPartyDocumentation() {
         return "https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html";
+    }
+
+    protected void addBootstrapProperties(@NonNull GeneratorContext generatorContext) {
+        populateBootstrapForDistributedConfiguration(generatorContext).putAll(PROPERTIES_AWS_DISTRIBUTED_CONFIGURATION);
+    }
+
+    protected void addDependencies(@NonNull GeneratorContext generatorContext) {
+        generatorContext.addDependency(DEPENDNCY_MICRONAUT_AWS_PARAMETER_STORE);
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/awssecretsmanager/AwsSecretsManager.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awssecretsmanager/AwsSecretsManager.java
@@ -15,11 +15,13 @@
  */
 package io.micronaut.starter.feature.awssecretsmanager;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
+import io.micronaut.starter.feature.awsparameterstore.AwsParameterStore;
 import io.micronaut.starter.feature.distributedconfig.DistributedConfigFeature;
 import jakarta.inject.Singleton;
-import java.util.Map;
 
 /**
  * @see <a href="https://micronaut-projects.github.io/micronaut-aws/latest/guide/#distributedconfigurationsecretsmanager">Micronaut AWS Secrets Manager</a>
@@ -28,6 +30,11 @@ import java.util.Map;
  */
 @Singleton
 public class AwsSecretsManager implements DistributedConfigFeature {
+    private static final String ARTIFACT_ID_MICRONAUT_AWS_SECRETSMANAGER = "micronaut-aws-secretsmanager";
+    private static final Dependency.Builder DEPENDENCY_MICRONAUT_AWS_SECRETSMANAGER = MicronautDependencyUtils.awsDependency()
+            .artifactId(ARTIFACT_ID_MICRONAUT_AWS_SECRETSMANAGER)
+            .compile();
+
     @Override
     public String getTitle() {
         return "AWS Secrets Manager";
@@ -45,12 +52,8 @@ public class AwsSecretsManager implements DistributedConfigFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.addDependency(Dependency.builder()
-                .groupId("io.micronaut.aws")
-                .artifactId("micronaut-aws-secretsmanager")
-                .compile());
-        Map<String, Object> config = populateBootstrapForDistributedConfiguration(generatorContext);
-        config.put("aws.client.system-manager.parameterstore.enabled", true);
+        addDependencies(generatorContext);
+        addBootstrapProperties(generatorContext);
     }
 
     @Override
@@ -61,5 +64,13 @@ public class AwsSecretsManager implements DistributedConfigFeature {
     @Override
     public String getThirdPartyDocumentation() {
         return "https://aws.amazon.com/secrets-manager/";
+    }
+
+    protected void addBootstrapProperties(@NonNull GeneratorContext generatorContext) {
+        populateBootstrapForDistributedConfiguration(generatorContext).putAll(AwsParameterStore.PROPERTIES_AWS_DISTRIBUTED_CONFIGURATION);
+    }
+
+    protected static void addDependencies(@NonNull GeneratorContext generatorContext) {
+        generatorContext.addDependency(DEPENDENCY_MICRONAUT_AWS_SECRETSMANAGER);
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/awssecretsmanager/AwsSecretsManagerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/awssecretsmanager/AwsSecretsManagerSpec.groovy
@@ -2,6 +2,9 @@ package io.micronaut.starter.feature.awssecretsmanager
 
 import io.micronaut.starter.ApplicationContextSpec
 import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Scope
 import io.micronaut.starter.feature.config.Yaml
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
@@ -27,51 +30,31 @@ class AwsSecretsManagerSpec extends ApplicationContextSpec implements CommandOut
 
         then:
         bootstrap
-        bootstrap.contains('''\
-micronaut:
-  application:
-    name: foo
-  config-client:
-    enabled: true
-''')
+        when:
+        Map<String, Object> bootstrapYml = new org.yaml.snakeyaml.Yaml().load(bootstrap)
+
+        then:
+        'foo' == bootstrapYml['micronaut']['application']['name']
+        true == bootstrapYml['micronaut']['config-client']['enabled']
+        true == bootstrapYml['aws']['client']['system-manager']['parameterstore']['enabled']
+        false == bootstrapYml['aws']['distributed-configuration']['search-active-environments']
+        false == bootstrapYml['aws']['distributed-configuration']['search-common-application']
     }
 
     @Unroll
-    void 'test gradle aws-secrets-manager feature for language=#language'() {
+    void 'test #buildTool aws-secrets-manager feature for language=#language'(BuildTool buildTool, Language language) {
         when:
-        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+        String template = new BuildBuilder(beanContext, buildTool)
                 .language(language)
                 .features(['aws-secrets-manager'])
                 .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, language, template)
 
         then:
-        template.count('implementation("io.micronaut.aws:micronaut-aws-secretsmanager")') == 1
-
-        and: 'micronaut-aws-secretsmanager exposes aws-sdk-v2 transitively'
-        !template.contains('implementation("io.micronaut.aws:aws-sdk-v2")')
+        verifier.hasDependency("io.micronaut.aws", "micronaut-aws-secretsmanager", Scope.COMPILE)
+        !verifier.hasDependency("io.micronaut.aws", ":aws-sdk-v2", Scope.COMPILE)
 
         where:
-        language << Language.values().toList()
-    }
-
-    @Unroll
-    void 'test maven aws-secrets-manager feature for language=#language'() {
-        when:
-        String template = new BuildBuilder(beanContext, BuildTool.MAVEN)
-                .language(language)
-                .features(['aws-secrets-manager'])
-                .render()
-
-        then:
-        template.count('''
-    <dependency>
-      <groupId>io.micronaut.aws</groupId>
-      <artifactId>micronaut-aws-secretsmanager</artifactId>
-      <scope>compile</scope>
-    </dependency>
-''') == 1
-
-        where:
-        language << Language.values().toList()
+        [buildTool, language] << [BuildTool.values(), Language.values().toList()].combinations()
     }
 }


### PR DESCRIPTION
Add default configuration:

```yaml
aws:
    distributed-configuration:
        search-active-environments:false
        search-common-application:false
```

When adding AWS Secrets Manager or AWS Parameter Store features, add this default configuration, which [reduces the number of search prefixes](https://github.com/micronaut-projects/micronaut-aws/pull/2033/files) and thus improves startup improvement.