### PR TITLE
fix: Fix docker base image for Java 21

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautBuildPlugin.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautBuildPlugin.java
@@ -42,10 +42,13 @@ import io.micronaut.starter.feature.security.SecurityJWT;
 import io.micronaut.starter.feature.security.SecurityOAuth2;
 import io.micronaut.starter.feature.testresources.TestResources;
 import io.micronaut.starter.feature.testresources.TestResourcesAdditionalModulesProvider;
+import io.micronaut.starter.options.JdkVersion;
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration;
 import io.micronaut.starter.options.Options;
 import jakarta.inject.Singleton;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -59,6 +62,10 @@ public class MicronautBuildPlugin implements BuildPluginFeature, DefaultFeature 
     public static final String GRAALVM_GRADLE_DOCS_URL = "https://graalvm.github.io/native-build-tools/latest/gradle-plugin.html";
     public static final String AOT_KEY_SECURITY_JWKS = "micronaut.security.jwks.enabled";
     public static final String AOT_KEY_SECURITY_OPENID = "micronaut.security.openid-configuration.enabled";
+
+    public static final Map<JdkVersion, String> BASE_IMAGES = Map.of(
+            JdkVersion.JDK_21, "eclipse-temurin:21-jre-jammy"
+    );
 
     protected final CoordinateResolver coordinateResolver;
 
@@ -82,7 +89,7 @@ public class MicronautBuildPlugin implements BuildPluginFeature, DefaultFeature 
             generatorContext.addBuildPlugin(gradlePlugin(generatorContext));
         }
     }
-    
+
     @NonNull
     protected GradlePlugin gradlePlugin(@NonNull GeneratorContext generatorContext) {
         GradlePlugin.Builder builder = null;
@@ -198,11 +205,19 @@ public class MicronautBuildPlugin implements BuildPluginFeature, DefaultFeature 
         if (generatorContext.getFeatures().contains(AwsLambda.FEATURE_NAME_AWS_LAMBDA) && (
                 (generatorContext.getApplicationType() == ApplicationType.FUNCTION && generatorContext.getFeatures().contains(FEATURE_NAME_GRAALVM)) ||
                         (generatorContext.getApplicationType() == ApplicationType.DEFAULT))) {
-            builder = builder.dockerNative(Dockerfile.builder().baseImage("amazonlinux:2023")
+            builder.dockerNative(Dockerfile.builder()
+                    .baseImage("amazonlinux:2023")
+                    .javaVersion(generatorContext.getJdkVersion().asString())
                     .arg("-XX:MaximumHeapSizePercent=80")
                     .arg("-Dio.netty.allocator.numDirectArenas=0")
                     .arg("-Dio.netty.noPreferDirect=true")
                     .build());
+        } else if (generatorContext.getJdkVersion() != MicronautJdkVersionConfiguration.DEFAULT_OPTION) {
+            String baseImageForJdkVersion = BASE_IMAGES.get(generatorContext.getJdkVersion());
+            if (baseImageForJdkVersion != null) {
+                builder.docker(Dockerfile.builder().baseImage(baseImageForJdkVersion).build());
+            }
+            builder.dockerNative(Dockerfile.builder().javaVersion(generatorContext.getJdkVersion().asString()).build());
         }
         return builder;
     }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/Dockerfile.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/Dockerfile.java
@@ -26,16 +26,25 @@ public class Dockerfile {
     private String baseImage;
 
     @Nullable
+    private String javaVersion;
+
+    @Nullable
     private List<String> args;
 
-    public Dockerfile(@NonNull String baseImage, @NonNull List<String> args) {
+    public Dockerfile(@Nullable String baseImage, @Nullable String javaVersion, @Nullable List<String> args) {
         this.baseImage = baseImage;
+        this.javaVersion = javaVersion;
         this.args = args;
     }
 
     @Nullable
     public String getBaseImage() {
         return baseImage;
+    }
+
+    @Nullable
+    public String getJavaVersion() {
+        return javaVersion;
     }
 
     @Nullable
@@ -51,11 +60,17 @@ public class Dockerfile {
     public static class Builder {
 
         private String baseImage;
+        private String javaVersion;
         private List<String> args;
 
         @NonNull
         public Builder baseImage(String baseImage) {
             this.baseImage = baseImage;
+            return this;
+        }
+
+        public Builder javaVersion(String javaVersion) {
+            this.javaVersion = javaVersion;
             return this;
         }
 
@@ -76,7 +91,7 @@ public class Dockerfile {
 
         @NonNull
         public Dockerfile build() {
-            return new Dockerfile(baseImage, args);
+            return new Dockerfile(baseImage, javaVersion, args);
         }
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dockerfileExtension.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dockerfileExtension.rocker.raw
@@ -1,0 +1,19 @@
+@import io.micronaut.starter.build.gradle.GradleDsl
+@import io.micronaut.starter.feature.build.gradle.Dockerfile
+@args(GradleDsl dsl, Dockerfile dockerfile)
+@if (dsl == GradleDsl.GROOVY) {
+@raw("tasks.named(\"dockerfile\") {\n")
+} else {
+@raw("tasks.named<io.micronaut.gradle.docker.MicronautDockerfile>(\"dockerfile\") {\n")
+}
+@if(dockerfile.getBaseImage() != null) {
+    baseImage("@(dockerfile.getBaseImage())")
+}
+@if (dockerfile.getArgs() != null) {
+    args(
+    @for (int i = 0; i < dockerfile.getArgs().size(); i++) {
+        "@(dockerfile.getArgs().get(i))"@if (i < (dockerfile.getArgs().size() -1)) {,}
+    }
+    )
+}
+@raw("}\n")

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dockerfileNativeExtension.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/dockerfileNativeExtension.rocker.raw
@@ -1,0 +1,30 @@
+@import io.micronaut.starter.build.gradle.GradleDsl
+@import io.micronaut.starter.feature.build.gradle.Dockerfile
+@args(GradleDsl dsl, Dockerfile dockerfileNative)
+@if (dsl == GradleDsl.GROOVY) {
+@raw("\ntasks.named(\"dockerfileNative\") {\n")
+} else {
+@raw("\ntasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>(\"dockerfileNative\") {\n")
+}
+@if(dockerfileNative.getBaseImage() != null) {
+@if (dsl == GradleDsl.GROOVY) {
+    baseImage = "@(dockerfileNative.getBaseImage())"
+} else {
+    baseImage.set("@(dockerfileNative.getBaseImage())")
+}
+}
+@if(dockerfileNative.getJavaVersion() != null) {
+@if (dsl == GradleDsl.GROOVY) {
+    jdkVersion = "@dockerfileNative.getJavaVersion()"
+} else {
+    jdkVersion.set("@dockerfileNative.getJavaVersion()")
+}
+}
+@if (dockerfileNative.getArgs() != null) {
+    args(
+    @for (int i = 0; i < dockerfileNative.getArgs().size(); i++) {
+        "@(dockerfileNative.getArgs().get(i))"@if (i < (dockerfileNative.getArgs().size() -1)) {,}
+    }
+    )
+}
+@raw("}\n")

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/micronautGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/micronautGradle.rocker.raw
@@ -74,49 +74,11 @@ micronaut {
 }
 
 @if(dockerfile != null) {
-dockerfile {
-@if(dockerfile.getBaseImage() != null) {
-    baseImage("@(dockerfile.getBaseImage())")
-}
-@if (dockerfile.getArgs() != null) {
-    args(
-    @for (int i = 0; i < dockerfile.getArgs().size(); i++) {
-        "@(dockerfile.getArgs().get(i))"@if (i < (dockerfile.getArgs().size() -1)) {,}
-    }
-    )
-}
-}
+@dockerfileExtension.template(dsl, dockerfile)
 }
 
 @if(dockerfileNative != null) {
-@if(build == BuildTool.GRADLE) {
-@raw("\ntasks.named(\"dockerfileNative\") {\n")
-}
-@if(build == BuildTool.GRADLE_KOTLIN) {
-@raw("\ntasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>(\"dockerfileNative\") {\n")
-}
-
-@if(dockerfileNative.getBaseImage() != null) {
-@if(build == BuildTool.GRADLE) {
-    baseImage = "@(dockerfileNative.getBaseImage())"
-    jdkVersion = "@javaVersion"
-}
-@if(build == BuildTool.GRADLE_KOTLIN) {
-    baseImage.set("@(dockerfileNative.getBaseImage())")
-    jdkVersion.set("@javaVersion")
-}
-}
-
-@if (dockerfileNative.getArgs() != null) {
-    args(
-    @for (int i = 0; i < dockerfileNative.getArgs().size(); i++) {
-        "@(dockerfileNative.getArgs().get(i))"@if (i < (dockerfileNative.getArgs().size() -1)) {,}
-    }
-    )
-}
-
-@raw("}\n")
-
+@dockerfileNativeExtension.template(dsl, dockerfileNative)
 }
 
 @if(dockerBuilderNativeImages != null) {

--- a/starter-core/src/main/java/io/micronaut/starter/options/JdkVersion.java
+++ b/starter-core/src/main/java/io/micronaut/starter/options/JdkVersion.java
@@ -118,4 +118,8 @@ public final class JdkVersion {
     public boolean greaterThanEqual(@NonNull JdkVersion jdk) {
         return majorVersion >= jdk.majorVersion;
     }
+
+    public String asString() {
+        return "" + majorVersion;
+    }
 }

--- a/test-core/src/test/groovy/io/micronaut/starter/core/test/GradleDockerConfigSpec.groovy
+++ b/test-core/src/test/groovy/io/micronaut/starter/core/test/GradleDockerConfigSpec.groovy
@@ -1,0 +1,50 @@
+package io.micronaut.starter.core.test
+
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.test.CommandSpec
+
+class GradleDockerConfigSpec extends CommandSpec {
+
+    void "basic dockerfile creation"(BuildTool buildTool, Integer javaVersion) {
+        when:
+        generateProjectForVersion(Language.JAVA, JdkVersion.valueOf(javaVersion), buildTool)
+
+        // dockerfileNative depends on compileJava so we need to exclude it (as if we're on Java 17, we can't compile a java 21 build)
+        def result = executeGradle("dockerfile", "dockerfileNative", "-x", "compileJava")
+
+        then:
+        result.output.contains("BUILD SUCCESS")
+        new File(dir, "build/docker/main/Dockerfile").text.contains("FROM $dockerBaseImage")
+        new File(dir, "build/docker/native-main/DockerfileNative").text.contains("FROM ghcr.io/graalvm/native-image-community:$javaVersion-ol9 AS graalvm")
+
+        where:
+        [buildTool, javaVersion] << [
+                BuildTool.valuesGradle(),
+                [17, 21]
+        ].combinations()
+        dockerBaseImage = javaVersion == 17 ? "eclipse-temurin:17-jre-focal" : "eclipse-temurin:21-jre-jammy"
+    }
+
+    void "test dockerfiles can be built"(BuildTool buildTool, String command) {
+        when:
+        generateProject(Language.JAVA, buildTool)
+
+        def result = executeGradle(command)
+
+        then:
+        result.output.contains("BUILD SUCCESS")
+
+        where:
+        [buildTool, command] << [
+                BuildTool.valuesGradle(),
+                ['dockerBuild', 'dockerBuildNative']
+        ].combinations()
+    }
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "gradleDockerConfigSpec"
+    }
+}

--- a/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
+++ b/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
@@ -144,6 +144,28 @@ abstract class CommandSpec extends Specification {
         )
     }
 
+    void generateProjectForVersion(
+            Language lang,
+            JdkVersion jdkVersion,
+            BuildTool buildTool = BuildTool.DEFAULT_OPTION,
+            List<String> features = [],
+            ApplicationType applicationType = ApplicationType.DEFAULT,
+            TestFramework testFramework = lang.getDefaults().test,
+            boolean addMicronautGradleEnterpriseFeature = true
+    ) {
+        if (addMicronautGradleEnterpriseFeature) {
+            features += [MicronautGradleEnterprise.NAME]
+        }
+        beanContext.getBean(ProjectGenerator).generate(applicationType,
+                NameUtils.parse("example.micronaut.foo"),
+                new Options(lang, testFramework, buildTool, jdkVersion),
+                io.micronaut.starter.application.OperatingSystem.LINUX,
+                features,
+                new FileSystemOutputHandler(dir, ConsoleOutput.NOOP),
+                ConsoleOutput.NOOP
+        )
+    }
+
     void generateProject(Project project,
                          Language lang,
                          BuildTool buildTool = BuildTool.DEFAULT_OPTION,


### PR DESCRIPTION
For 4.3.x

When using Java 21 for dockerimageNative we have to ensure we pass jdkVersion to get the right base image from the plugin. The dockerimage base image should also be adjusted accordingly.

Fixes #2281