### PR TITLE
fix: Fix create-chatbot command in native image

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/ChatBots.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/ChatBots.java
@@ -21,6 +21,7 @@ import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.validator.MicronautValidationFeature;
 import io.micronaut.starter.feature.validator.ValidationFeature;
 import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.template.RockerTemplate;
 
 /**
  * Base class for chatbot features.
@@ -65,7 +66,7 @@ public abstract class ChatBots implements ChatBotsFeature {
     protected abstract ChatBotType getChatBotType();
 
     @NonNull
-    protected abstract String rootReadMeTemplate(@NonNull GeneratorContext generatorContext);
+    protected abstract RockerTemplate rootReadMeTemplate(@NonNull GeneratorContext generatorContext);
 
     @NonNull
     protected abstract String getBuildCommand(@NonNull BuildTool buildTool);

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/basecamp/BasecampAwsChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/basecamp/BasecampAwsChatBot.java
@@ -31,6 +31,7 @@ import io.micronaut.starter.feature.function.HandlerClassFeature;
 import io.micronaut.starter.feature.function.awslambda.AwsLambda;
 import io.micronaut.starter.feature.validator.MicronautValidationFeature;
 import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.template.RockerTemplate;
 import jakarta.inject.Singleton;
 
 /**
@@ -97,10 +98,11 @@ public class BasecampAwsChatBot extends ChatBotsBasecamp implements AwsFeature, 
     }
 
     @Override
-    public String rootReadMeTemplate(GeneratorContext generatorContext) {
-        return generatorContext.isFeaturePresent(Cdk.class) ?
-            awsCdkReadme.class.getName().replace(".", "/") + ".rocker.raw" :
-            awsReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    public RockerTemplate rootReadMeTemplate(GeneratorContext generatorContext) {
+        return new RockerTemplate(generatorContext.isFeaturePresent(Cdk.class)
+                ? awsCdkReadme.template(generatorContext.getProject(), generatorContext.getFeatures(), getBuildCommand(generatorContext.getBuildTool()))
+                : awsReadme.template(generatorContext.getProject(), generatorContext.getFeatures(), getBuildCommand(generatorContext.getBuildTool()))
+        );
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/basecamp/BasecampAzureChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/basecamp/BasecampAzureChatBot.java
@@ -28,6 +28,7 @@ import io.micronaut.starter.feature.function.azure.AzureMicronautRuntimeFeature;
 import io.micronaut.starter.feature.function.azure.AzureRawFunction;
 import io.micronaut.starter.feature.validator.MicronautValidationFeature;
 import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.template.RockerTemplate;
 import jakarta.inject.Singleton;
 
 /**
@@ -98,7 +99,7 @@ public class BasecampAzureChatBot extends ChatBotsBasecamp implements AzureCloud
     }
 
     @Override
-    public String rootReadMeTemplate(GeneratorContext generatorContext) {
-        return azureReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    public RockerTemplate rootReadMeTemplate(GeneratorContext generatorContext) {
+        return new RockerTemplate(azureReadme.template(generatorContext.getProject(), generatorContext.getFeatures(), getBuildCommand(generatorContext.getBuildTool())));
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/basecamp/BasecampGcpChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/basecamp/BasecampGcpChatBot.java
@@ -28,6 +28,7 @@ import io.micronaut.starter.feature.function.gcp.GcpMicronautRuntimeFeature;
 import io.micronaut.starter.feature.function.gcp.GoogleCloudRawFunction;
 import io.micronaut.starter.feature.validator.MicronautValidationFeature;
 import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.template.RockerTemplate;
 import jakarta.inject.Singleton;
 
 /**
@@ -97,7 +98,7 @@ public class BasecampGcpChatBot extends ChatBotsBasecamp implements GcpCloudFeat
     }
 
     @Override
-    protected String rootReadMeTemplate(GeneratorContext generatorContext) {
-        return gcpReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    public RockerTemplate rootReadMeTemplate(GeneratorContext generatorContext) {
+        return new RockerTemplate(gcpReadme.template(generatorContext.getProject(), generatorContext.getFeatures(), getBuildCommand(generatorContext.getBuildTool())));
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/basecamp/BasecampHttpChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/basecamp/BasecampHttpChatBot.java
@@ -98,8 +98,8 @@ public class BasecampHttpChatBot extends ChatBotsBasecamp {
     }
 
     @Override
-    protected String rootReadMeTemplate(GeneratorContext generatorContext) {
-        return controllerReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    public RockerTemplate rootReadMeTemplate(GeneratorContext generatorContext) {
+        return new RockerTemplate(controllerReadme.template(generatorContext.getProject(), generatorContext.getFeatures(), getBuildCommand(generatorContext.getBuildTool())));
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/basecamp/ChatBotsBasecamp.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/basecamp/ChatBotsBasecamp.java
@@ -93,12 +93,7 @@ abstract class ChatBotsBasecamp extends ChatBots {
             );
         }
 
-        generatorContext.addHelpTemplate(new RockerWritable(basecampReadme.template(
-                rootReadMeTemplate(generatorContext),
-                generatorContext.getProject(),
-                generatorContext.getFeatures(),
-                getBuildCommand(generatorContext.getBuildTool()))
-        ));
+        generatorContext.addHelpTemplate(new RockerWritable(basecampReadme.template(rootReadMeTemplate(generatorContext))));
 
         generatorContext.addTemplate(
                 "final-command-handler",

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/basecamp/template/basecampReadme.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/basecamp/template/basecampReadme.rocker.raw
@@ -1,19 +1,12 @@
-@import com.fizzed.rocker.Rocker
-@import io.micronaut.starter.application.Project
-@import io.micronaut.starter.feature.Features
+@import io.micronaut.starter.template.RockerTemplate
 
-@args(
-    String platformTemplate,
-    Project project,
-    Features features,
-    String buildCommand
-)
+@args(RockerTemplate platformTemplate)
 
 # Basecamp ChatBot
 
 Follow the instructions in the [Micronaut ChatBot Documentation](https://micronaut-projects.github.io/micronaut-chatbots/latest/guide/) to create a Basecamp ChatBot.
 
-@Rocker.template(platformTemplate, project, features, buildCommand)
+@platformTemplate.renderModel()
 
 You can then create a Basecamp webhook by running the following command:
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/ChatBotsTelegram.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/ChatBotsTelegram.java
@@ -101,12 +101,7 @@ abstract class ChatBotsTelegram extends ChatBots {
             );
         }
 
-        generatorContext.addHelpTemplate(new RockerWritable(telegramReadme.template(
-                rootReadMeTemplate(generatorContext),
-                generatorContext.getProject(),
-                generatorContext.getFeatures(),
-                getBuildCommand(generatorContext.getBuildTool()))
-        ));
+        generatorContext.addHelpTemplate(new RockerWritable(telegramReadme.template(rootReadMeTemplate(generatorContext))));
 
         generatorContext.addTemplate(
                 "final-command-handler",

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramAwsChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramAwsChatBot.java
@@ -31,6 +31,7 @@ import io.micronaut.starter.feature.function.HandlerClassFeature;
 import io.micronaut.starter.feature.function.awslambda.AwsLambda;
 import io.micronaut.starter.feature.validator.MicronautValidationFeature;
 import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.template.RockerTemplate;
 import jakarta.inject.Singleton;
 
 /**
@@ -97,10 +98,11 @@ public class TelegramAwsChatBot extends ChatBotsTelegram implements AwsFeature, 
     }
 
     @Override
-    public String rootReadMeTemplate(GeneratorContext generatorContext) {
-        return generatorContext.isFeaturePresent(Cdk.class) ?
-            awsCdkReadme.class.getName().replace(".", "/") + ".rocker.raw" :
-            awsReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    public RockerTemplate rootReadMeTemplate(GeneratorContext generatorContext) {
+        return new RockerTemplate(generatorContext.isFeaturePresent(Cdk.class)
+                ? awsCdkReadme.template(generatorContext.getProject(), generatorContext.getFeatures(), getBuildCommand(generatorContext.getBuildTool()))
+                : awsReadme.template(generatorContext.getProject(), generatorContext.getFeatures(), getBuildCommand(generatorContext.getBuildTool()))
+        );
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramAzureChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramAzureChatBot.java
@@ -28,6 +28,7 @@ import io.micronaut.starter.feature.function.azure.AzureMicronautRuntimeFeature;
 import io.micronaut.starter.feature.function.azure.AzureRawFunction;
 import io.micronaut.starter.feature.validator.MicronautValidationFeature;
 import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.template.RockerTemplate;
 import jakarta.inject.Singleton;
 
 /**
@@ -98,7 +99,7 @@ public class TelegramAzureChatBot extends ChatBotsTelegram implements AzureCloud
     }
 
     @Override
-    public String rootReadMeTemplate(GeneratorContext generatorContext) {
-        return azureReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    public RockerTemplate rootReadMeTemplate(GeneratorContext generatorContext) {
+        return new RockerTemplate(azureReadme.template(generatorContext.getProject(), generatorContext.getFeatures(), getBuildCommand(generatorContext.getBuildTool())));
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramGcpChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramGcpChatBot.java
@@ -28,6 +28,7 @@ import io.micronaut.starter.feature.function.gcp.GcpMicronautRuntimeFeature;
 import io.micronaut.starter.feature.function.gcp.GoogleCloudRawFunction;
 import io.micronaut.starter.feature.validator.MicronautValidationFeature;
 import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.template.RockerTemplate;
 import jakarta.inject.Singleton;
 
 /**
@@ -96,7 +97,7 @@ public class TelegramGcpChatBot extends ChatBotsTelegram implements GcpCloudFeat
     }
 
     @Override
-    protected String rootReadMeTemplate(GeneratorContext generatorContext) {
-        return gcpReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    public RockerTemplate rootReadMeTemplate(GeneratorContext generatorContext) {
+        return new RockerTemplate(gcpReadme.template(generatorContext.getProject(), generatorContext.getFeatures(), getBuildCommand(generatorContext.getBuildTool())));
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramHttpChatBot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/TelegramHttpChatBot.java
@@ -98,8 +98,8 @@ public class TelegramHttpChatBot extends ChatBotsTelegram {
     }
 
     @Override
-    protected String rootReadMeTemplate(GeneratorContext generatorContext) {
-        return controllerReadme.class.getName().replace(".", "/") + ".rocker.raw";
+    public RockerTemplate rootReadMeTemplate(GeneratorContext generatorContext) {
+        return new RockerTemplate(controllerReadme.template(generatorContext.getProject(), generatorContext.getFeatures(), getBuildCommand(generatorContext.getBuildTool())));
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/template/telegramReadme.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/chatbots/telegram/template/telegramReadme.rocker.raw
@@ -1,13 +1,6 @@
-@import com.fizzed.rocker.Rocker
-@import io.micronaut.starter.application.Project
-@import io.micronaut.starter.feature.Features
+@import io.micronaut.starter.template.RockerTemplate
 
-@args(
-    String platformTemplate,
-    Project project,
-    Features features,
-    String buildCommand
-)
+@args(RockerTemplate platformTemplate)
 
 # Telegram ChatBot
 
@@ -15,7 +8,7 @@ Follow the instructions in the [Micronaut ChatBot Documentation](https://microna
 
 Once you have a username and HTTP auth key for your new bot, edit the application config in this project to set the bot username and make up a WEBHOOK_TOKEN so you can ensure it's Telegram that's calling your bot.
 
-@Rocker.template(platformTemplate, project, features, buildCommand)
+@platformTemplate.renderModel()
 
 You can then set up the Telegram webhook by running the following command:
 

--- a/starter-core/src/main/java/io/micronaut/starter/template/RockerTemplate.java
+++ b/starter-core/src/main/java/io/micronaut/starter/template/RockerTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.micronaut.starter.template;
 
 import com.fizzed.rocker.RockerModel;
+import com.fizzed.rocker.RockerOutput;
 
 import java.io.OutputStream;
 
@@ -59,5 +60,9 @@ public class RockerTemplate extends DefaultTemplate {
 
     public RockerWritable getWritable() {
         return writable;
+    }
+
+    public RockerOutput renderModel() {
+        return writable.getModel().render();
     }
 }

--- a/test-suite-graal/build.gradle
+++ b/test-suite-graal/build.gradle
@@ -10,16 +10,11 @@ repositories {
 
 dependencies {
     implementation(project(":starter-api"))
+    implementation(project(":micronaut-cli"))
     implementation(project(":starter-web-netty"))
     testImplementation("io.micronaut.test:micronaut-test-junit5")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
     testImplementation("ch.qos.logback:logback-classic")
-}
-
-configurations.all {
-    resolutionStrategy {
-        force "io.micronaut:micronaut-core-bom:$micronautCoreVersion"
-        force "io.micronaut:micronaut-inject-groovy:$micronautCoreVersion"
-    }
 }
 
 configurations.all {

--- a/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/CommandSupplier.java
+++ b/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/CommandSupplier.java
@@ -1,0 +1,6 @@
+package io.micronaut.starter.cli.command;
+
+interface CommandSupplier {
+
+    String nextCommand();
+}

--- a/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/CreateChatBotBuilderCommandTest.java
+++ b/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/CreateChatBotBuilderCommandTest.java
@@ -1,0 +1,98 @@
+package io.micronaut.starter.cli.command;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.starter.application.OperatingSystem;
+import io.micronaut.starter.application.generator.ProjectGenerator;
+import io.micronaut.starter.feature.architecture.Arm;
+import io.micronaut.starter.feature.architecture.X86;
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.options.JdkVersion;
+import io.micronaut.starter.options.Language;
+import io.micronaut.starter.options.TestFramework;
+import io.micronaut.starter.util.NameUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.HashSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CreateChatBotBuilderCommandTest {
+
+    static ApplicationContext applicationContext;
+
+    @BeforeAll
+    static void setUp() {
+        applicationContext = ApplicationContext.run();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (applicationContext != null) {
+            applicationContext.close();
+        }
+    }
+
+    static Stream<CreateChatbotCommandCliOptions> provideCliOptions() {
+        return Stream.of(CreateChatBotBuilderCommand.ChatBotType.values())
+                .flatMap(chatBotType -> Stream.of(CreateChatBotBuilderCommand.ChatBotDeployment.values())
+                        .flatMap(applicationType -> Stream.of(applicationContext.getBean(Arm.class), applicationContext.getBean(X86.class))
+                                .flatMap(cpuArchitecture -> Stream.of(false, true)
+                                        .flatMap(cdk -> Stream.of(Language.JAVA, Language.GROOVY, Language.KOTLIN)
+                                                .flatMap(language -> Stream.of(TestFramework.JUNIT, TestFramework.SPOCK, TestFramework.KOTEST)
+                                                        .flatMap(testFramework -> Stream.of(BuildTool.GRADLE, BuildTool.GRADLE_KOTLIN, BuildTool.MAVEN)
+                                                                .flatMap(buildTool ->
+                                                                        (applicationType == CreateChatBotBuilderCommand.ChatBotDeployment.AZURE ? Stream.of(JdkVersion.JDK_17) : Stream.of(JdkVersion.JDK_17, JdkVersion.JDK_21))
+                                                                                .map(javaVersion ->
+                                                                                        new CreateChatbotCommandCliOptions(
+                                                                                                chatBotType,
+                                                                                                applicationType,
+                                                                                                cpuArchitecture,
+                                                                                                cdk,
+                                                                                                language,
+                                                                                                testFramework,
+                                                                                                buildTool,
+                                                                                                javaVersion
+                                                                                        )
+                                                                                )
+                                                                )
+                                                        )
+                                                )
+                                        )
+                                )
+                        )
+                );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideCliOptions")
+    void testCliOptions(CreateChatbotCommandCliOptions cliOptions) {
+        CreateChatBotBuilderCommand command = applicationContext.getBean(CreateChatBotBuilderCommand.class);
+        ProjectGenerator projectGenerator = applicationContext.getBean(ProjectGenerator.class);
+
+        GenerateOptions options = command.createGenerateOptions(new StubbedLineReader(cliOptions));
+
+        assertEquals(cliOptions.getExpectedApplicationType(), options.getApplicationType());
+        assertEquals(new HashSet<>(cliOptions.getFeatures()), options.getFeatures());
+        assertEquals(cliOptions.language, options.getOptions().getLanguage());
+        assertEquals(cliOptions.buildTool, options.getOptions().getBuildTool());
+        assertEquals(cliOptions.testFramework, options.getOptions().getTestFramework());
+        assertEquals(cliOptions.javaVersion, options.getOptions().getJavaVersion());
+
+        assertDoesNotThrow(() -> projectGenerator.generate(
+                        options.getApplicationType(),
+                        NameUtils.parse("foo"),
+                        options.getOptions(),
+                        OperatingSystem.LINUX,
+                        cliOptions.getFeatures(),
+                        new TemplateResolvingOutputHandler(),
+                        new LoggingConsoleOutput()
+                )
+        );
+    }
+
+}

--- a/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/CreateChatbotCommandCliOptions.java
+++ b/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/CreateChatbotCommandCliOptions.java
@@ -1,0 +1,120 @@
+package io.micronaut.starter.cli.command;
+
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.feature.architecture.Arm;
+import io.micronaut.starter.feature.architecture.CpuArchitecture;
+import io.micronaut.starter.feature.aws.LambdaFunctionUrl;
+import io.micronaut.starter.feature.chatbots.basecamp.BasecampAwsChatBot;
+import io.micronaut.starter.feature.chatbots.basecamp.BasecampAzureChatBot;
+import io.micronaut.starter.feature.chatbots.basecamp.BasecampGcpChatBot;
+import io.micronaut.starter.feature.chatbots.basecamp.BasecampHttpChatBot;
+import io.micronaut.starter.feature.chatbots.telegram.TelegramAwsChatBot;
+import io.micronaut.starter.feature.chatbots.telegram.TelegramAzureChatBot;
+import io.micronaut.starter.feature.chatbots.telegram.TelegramGcpChatBot;
+import io.micronaut.starter.feature.chatbots.telegram.TelegramHttpChatBot;
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.options.JdkVersion;
+import io.micronaut.starter.options.Language;
+import io.micronaut.starter.options.TestFramework;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class CreateChatbotCommandCliOptions implements CommandSupplier {
+
+    final CreateChatBotBuilderCommand.ChatBotType chatBotType;
+    final CreateChatBotBuilderCommand.ChatBotDeployment applicationType;
+    final CpuArchitecture cpuArchitecture;
+    final boolean cdk;
+    final Language language;
+    final TestFramework testFramework;
+    final BuildTool buildTool;
+    final JdkVersion javaVersion;
+    int index = 0;
+
+    CreateChatbotCommandCliOptions(
+            CreateChatBotBuilderCommand.ChatBotType chatBotType,
+            CreateChatBotBuilderCommand.ChatBotDeployment applicationType,
+            CpuArchitecture cpuArchitecture,
+            boolean cdk,
+            Language language,
+            TestFramework testFramework,
+            BuildTool buildTool,
+            JdkVersion javaVersion
+    ) {
+        this.chatBotType = chatBotType;
+        this.applicationType = applicationType;
+        this.cpuArchitecture = cpuArchitecture;
+        this.cdk = cdk;
+        this.language = language;
+        this.testFramework = testFramework;
+        this.buildTool = buildTool;
+        this.javaVersion = javaVersion;
+    }
+
+    List<String> getFeatures() {
+        return switch (applicationType) {
+            case LAMBDA -> {
+                String type = chatBotType == CreateChatBotBuilderCommand.ChatBotType.BASECAMP ? BasecampAwsChatBot.NAME : TelegramAwsChatBot.NAME;
+                yield cdk ? List.of(type, cpuArchitecture.getName(), LambdaFunctionUrl.NAME) : List.of(type, cpuArchitecture.getName());
+            }
+            case AZURE ->
+                    List.of(chatBotType == CreateChatBotBuilderCommand.ChatBotType.BASECAMP ? BasecampAzureChatBot.NAME : TelegramAzureChatBot.NAME);
+            case GCP ->
+                    List.of(chatBotType == CreateChatBotBuilderCommand.ChatBotType.BASECAMP ? BasecampGcpChatBot.NAME : TelegramGcpChatBot.NAME);
+            case HTTP ->
+                    List.of(chatBotType == CreateChatBotBuilderCommand.ChatBotType.BASECAMP ? BasecampHttpChatBot.NAME : TelegramHttpChatBot.NAME);
+        };
+    }
+
+    ApplicationType getExpectedApplicationType() {
+        if (applicationType == CreateChatBotBuilderCommand.ChatBotDeployment.HTTP) {
+            return ApplicationType.DEFAULT;
+        }
+        return ApplicationType.FUNCTION;
+    }
+
+    List<String> getCliCommands() {
+        List<String> ret = new ArrayList<>();
+        ret.add("%d".formatted(chatBotType.ordinal() + 1));
+        ret.add("%d".formatted(applicationType.ordinal() + 1));
+        if (applicationType == CreateChatBotBuilderCommand.ChatBotDeployment.LAMBDA) {
+            ret.add(cpuArchitecture instanceof Arm ? "1" : "2");
+            ret.add(cdk ? "1" : "2");
+        }
+        ret.add("%d".formatted(language.ordinal() + 1));
+        ret.add("%d".formatted(testFramework.ordinal() + 1));
+        ret.add("%d".formatted(buildTool.ordinal() + 1));
+        ret.add(javaVersion == JdkVersion.JDK_17 ? "1" : "2");
+        return ret;
+    }
+
+    @Override
+    public String toString() {
+        if (applicationType == CreateChatBotBuilderCommand.ChatBotDeployment.LAMBDA) {
+            return "%s %s %s %s %s %s %s %s".formatted(
+                    chatBotType.name(),
+                    applicationType.name(),
+                    cpuArchitecture.getName(),
+                    cdk,
+                    language.name(),
+                    testFramework.name(),
+                    buildTool.name(),
+                    javaVersion.name()
+            );
+        } else {
+            return "%s %s %s %s %s %s".formatted(
+                    chatBotType.name(),
+                    applicationType.name(),
+                    language.name(),
+                    testFramework.name(),
+                    buildTool.name(),
+                    javaVersion.name()
+            );
+        }
+    }
+
+    public String nextCommand() {
+        return getCliCommands().get(index++);
+    }
+}

--- a/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/LoggingConsoleOutput.java
+++ b/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/LoggingConsoleOutput.java
@@ -1,0 +1,35 @@
+package io.micronaut.starter.cli.command;
+
+import io.micronaut.starter.io.ConsoleOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class LoggingConsoleOutput implements ConsoleOutput {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LoggingConsoleOutput.class);
+
+    @Override
+    public void out(String message) {
+        LOG.info(message);
+    }
+
+    @Override
+    public void err(String message) {
+        LOG.error(message);
+    }
+
+    @Override
+    public void warning(String message) {
+        LOG.warn(message);
+    }
+
+    @Override
+    public boolean showStacktrace() {
+        return false;
+    }
+
+    @Override
+    public boolean verbose() {
+        return false;
+    }
+}

--- a/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/NullOutputStream.java
+++ b/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/NullOutputStream.java
@@ -1,0 +1,12 @@
+package io.micronaut.starter.cli.command;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+class NullOutputStream extends OutputStream {
+
+    @Override
+    public void write(int b) throws IOException {
+        // do nothing
+    }
+}

--- a/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/StubbedLineReader.java
+++ b/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/StubbedLineReader.java
@@ -1,0 +1,261 @@
+package io.micronaut.starter.cli.command;
+
+import org.jline.keymap.KeyMap;
+import org.jline.reader.Binding;
+import org.jline.reader.Buffer;
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.Expander;
+import org.jline.reader.Highlighter;
+import org.jline.reader.History;
+import org.jline.reader.LineReader;
+import org.jline.reader.MaskingCallback;
+import org.jline.reader.ParsedLine;
+import org.jline.reader.Parser;
+import org.jline.reader.UserInterruptException;
+import org.jline.reader.Widget;
+import org.jline.terminal.MouseEvent;
+import org.jline.terminal.Terminal;
+import org.jline.utils.AttributedString;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Map;
+
+class StubbedLineReader implements LineReader {
+
+    private final CommandSupplier commandSupplier;
+
+    StubbedLineReader(CommandSupplier commandSupplier) {
+        this.commandSupplier = commandSupplier;
+    }
+
+    @Override
+    public Map<String, KeyMap<Binding>> defaultKeyMaps() {
+        return null;
+    }
+
+    @Override
+    public String readLine() throws UserInterruptException, EndOfFileException {
+        return null;
+    }
+
+    @Override
+    public String readLine(Character character) throws UserInterruptException, EndOfFileException {
+        return null;
+    }
+
+    @Override
+    public String readLine(String s) throws UserInterruptException, EndOfFileException {
+        return commandSupplier.nextCommand();
+    }
+
+    @Override
+    public String readLine(String s, Character character) throws UserInterruptException, EndOfFileException {
+        return null;
+    }
+
+    @Override
+    public String readLine(String s, Character character, String s1) throws UserInterruptException, EndOfFileException {
+        return null;
+    }
+
+    @Override
+    public String readLine(String s, String s1, Character character, String s2) throws UserInterruptException, EndOfFileException {
+        return null;
+    }
+
+    @Override
+    public String readLine(String s, String s1, MaskingCallback maskingCallback, String s2) throws UserInterruptException, EndOfFileException {
+        return null;
+    }
+
+    @Override
+    public void printAbove(String s) {
+
+    }
+
+    @Override
+    public void printAbove(AttributedString attributedString) {
+
+    }
+
+    @Override
+    public boolean isReading() {
+        return false;
+    }
+
+    @Override
+    public LineReader variable(String s, Object o) {
+        return null;
+    }
+
+    @Override
+    public LineReader option(Option option, boolean b) {
+        return null;
+    }
+
+    @Override
+    public void callWidget(String s) {
+
+    }
+
+    @Override
+    public Map<String, Object> getVariables() {
+        return null;
+    }
+
+    @Override
+    public Object getVariable(String s) {
+        return null;
+    }
+
+    @Override
+    public void setVariable(String s, Object o) {
+
+    }
+
+    @Override
+    public boolean isSet(Option option) {
+        return false;
+    }
+
+    @Override
+    public void setOpt(Option option) {
+
+    }
+
+    @Override
+    public void unsetOpt(Option option) {
+
+    }
+
+    @Override
+    public Terminal getTerminal() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Widget> getWidgets() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Widget> getBuiltinWidgets() {
+        return null;
+    }
+
+    @Override
+    public Buffer getBuffer() {
+        return null;
+    }
+
+    @Override
+    public String getAppName() {
+        return null;
+    }
+
+    @Override
+    public void runMacro(String s) {
+
+    }
+
+    @Override
+    public MouseEvent readMouseEvent() {
+        return null;
+    }
+
+    @Override
+    public History getHistory() {
+        return null;
+    }
+
+    @Override
+    public Parser getParser() {
+        return null;
+    }
+
+    @Override
+    public Highlighter getHighlighter() {
+        return null;
+    }
+
+    @Override
+    public Expander getExpander() {
+        return null;
+    }
+
+    @Override
+    public Map<String, KeyMap<Binding>> getKeyMaps() {
+        return null;
+    }
+
+    @Override
+    public String getKeyMap() {
+        return null;
+    }
+
+    @Override
+    public boolean setKeyMap(String s) {
+        return false;
+    }
+
+    @Override
+    public KeyMap<Binding> getKeys() {
+        return null;
+    }
+
+    @Override
+    public ParsedLine getParsedLine() {
+        return null;
+    }
+
+    @Override
+    public String getSearchTerm() {
+        return null;
+    }
+
+    @Override
+    public RegionType getRegionActive() {
+        return null;
+    }
+
+    @Override
+    public int getRegionMark() {
+        return 0;
+    }
+
+    @Override
+    public void addCommandsInBuffer(Collection<String> collection) {
+
+    }
+
+    @Override
+    public void editAndAddInBuffer(File file) throws Exception {
+
+    }
+
+    @Override
+    public String getLastBinding() {
+        return null;
+    }
+
+    @Override
+    public String getTailTip() {
+        return null;
+    }
+
+    @Override
+    public void setTailTip(String s) {
+
+    }
+
+    @Override
+    public void setAutosuggestion(SuggestionType suggestionType) {
+
+    }
+
+    @Override
+    public SuggestionType getAutosuggestion() {
+        return null;
+    }
+}

--- a/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/TemplateResolvingOutputHandler.java
+++ b/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/TemplateResolvingOutputHandler.java
@@ -1,0 +1,38 @@
+package io.micronaut.starter.cli.command;
+
+import io.micronaut.starter.io.OutputHandler;
+import io.micronaut.starter.template.Template;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+class TemplateResolvingOutputHandler implements OutputHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TemplateResolvingOutputHandler.class);
+    private final OutputStream outputStream = new NullOutputStream();
+
+    @Override
+    public boolean exists(String path) {
+        return false;
+    }
+
+    @Override
+    public void write(String path, Template contents) throws IOException {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Writing to path: {}", path);
+        }
+        // Force the contents to be rendered to shake out any rendering issues
+        contents.write(outputStream);
+    }
+
+    @Override
+    public String getOutputLocation() {
+        return "something";
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+}


### PR DESCRIPTION
We were using Rocker's dynamic rendering to create the README file for chatbots.

https://github.com/fizzed/rocker/blob/master/docs/SYNTAX.md#calling-other-templates

This fails when compiled to a native image as the original templates have been pruned by the compilation step.

This PR switched away from using dynamic templates, replacing them with our RockerTemplate class.

Closes #2314