### PR TITLE
Selecting Java Version 21 generates build with jdk21 correctly.

### DIFF
--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/KaptSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/KaptSpec.groovy
@@ -145,4 +145,29 @@ class KaptSpec extends ApplicationContextSpec implements CommandOutputFixture {
         and: 'the config file is added in the right place'
         output.".mvn/jvm.config" == KotlinSupportFeature.JDK_21_KAPT_MODULES
     }
+
+    void 'Corrected jdk21 = jdk17 is specified in build = #buildTool for kapt'(BuildTool buildTool) {
+        when:
+        def output = generate(ApplicationType.DEFAULT, new Options(Language.KOTLIN, TestFramework.DEFAULT_OPTION, buildTool, JdkVersion.JDK_21),['kapt'])
+        def buildFile = buildTool == BuildTool.GRADLE ? output["build.gradle"] : output["build.gradle.kts"]
+
+        then:
+        buildFile
+        buildFile.contains('sourceCompatibility = JavaVersion.toVersion("17")')
+        !buildFile.contains('targetCompatibility = JavaVersion.toVersion("17")')
+        !buildFile.contains('targetCompatibility = JavaVersion.toVersion("21")')
+
+        where:
+        buildTool << BuildTool.valuesGradle()
+    }
+
+    void 'Corrected jdk21 = jdk17 is specified in Maven build for kapt'() {
+        when:
+        def output = generate(ApplicationType.DEFAULT, new Options(Language.KOTLIN, TestFramework.DEFAULT_OPTION, BuildTool.MAVEN, JdkVersion.JDK_21),['kapt'])
+        def buildFile = output["pom.xml"]
+
+        then:
+        buildFile
+        buildFile.contains('<jdk.version>17</jdk.version>')
+    }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/gradle/GradleSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/gradle/GradleSpec.groovy
@@ -12,6 +12,7 @@ import io.micronaut.starter.feature.build.gradle.templates.settingsGradle
 import io.micronaut.starter.feature.graalvm.GraalVMFeatureValidator
 import io.micronaut.starter.fixture.CommandOutputFixture
 import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
@@ -142,6 +143,30 @@ class GradleSpec extends BeanContextSpec implements CommandOutputFixture {
                 AwsLambdaFeatureValidator.supportedJdks(),
                 BuildTool.valuesGradle(),
                 ApplicationType.values().toList()
+        ].combinations()
+    }
+
+    void 'Selected jdk = #jdk is specified in build = #buildTool for lang = #lang'(
+            Language lang, JdkVersion jdk, BuildTool buildTool
+    ) {
+        when:
+        def output = generate(ApplicationType.DEFAULT, new Options(lang, TestFramework.DEFAULT_OPTION, buildTool, jdk))
+        def buildFile = buildTool == BuildTool.GRADLE ? output["build.gradle"] : output["build.gradle.kts"]
+
+        then:
+        buildFile
+        buildFile.contains("sourceCompatibility = JavaVersion.toVersion(\"${jdk.majorVersion()}\")")
+        if (lang == Language.KOTLIN) {
+            assert !buildFile.contains("targetCompatibility = JavaVersion.toVersion(\"${jdk.majorVersion()}\")")
+        } else {
+            assert buildFile.contains("targetCompatibility = JavaVersion.toVersion(\"${jdk.majorVersion()}\")")
+        }
+
+        where:
+        [lang, jdk, buildTool] << [
+                Language.values(),
+                [JdkVersion.JDK_17, JdkVersion.JDK_21],
+                BuildTool.valuesGradle()
         ].combinations()
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
@@ -198,4 +198,27 @@ class MavenSpec extends ApplicationContextSpec implements CommandOutputFixture {
     private static Options createOptions(Language language, BuildTool buildTool = BuildTool.DEFAULT_OPTION) {
         new Options(language, language.getDefaults().getTest(), buildTool, AwsLambdaFeatureValidator.firstSupportedJdk())
     }
+
+    void 'Selected jdk = #jdk is specified in Maven for lang = #lang'(
+            Language lang, JdkVersion jdk
+    ) {
+        when:
+        def output = generate(ApplicationType.DEFAULT, new Options(lang, TestFramework.DEFAULT_OPTION, BuildTool.MAVEN, jdk))
+        def buildFile =  output["pom.xml"]
+
+        then:
+        buildFile
+        if (lang == Language.KOTLIN) {
+            // has kapt so has to be 17
+            assert buildFile.contains("<jdk.version>17</jdk.version>")
+        } else {
+            assert buildFile.contains("<jdk.version>$jdk.majorVersion</jdk.version>")
+        }
+
+        where:
+        [lang, jdk] << [
+                Language.values(),
+                [JdkVersion.JDK_17, JdkVersion.JDK_21]
+        ].combinations()
+    }
 }


### PR DESCRIPTION
fixes #2321

This adds test to assert that build files are generated with the correct jdk version, based on what is selected in the starter-ui or via the Micronaut CLI. 