### PR TITLE
Allow create-aws-lambda to select native and java 21

### DIFF
--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/BuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/BuilderCommand.java
@@ -148,7 +148,7 @@ public abstract class BuilderCommand extends BaseCommand implements Callable<Int
     }
 
     protected JdkVersion getJdkVersion(LineReader reader) {
-        List<String> candidates = new JdkVersionCandidates();
+        List<String> candidates = getJdkVersionCandidates();
         JdkVersion defaultOption = MicronautJdkVersionConfiguration.DEFAULT_OPTION;
         if (candidates.size() == 1) {
             return defaultOption;
@@ -160,6 +160,10 @@ public abstract class BuilderCommand extends BaseCommand implements Callable<Int
                 String.valueOf(defaultOption.majorVersion()),
                 reader
         )));
+    }
+
+    protected List<String> getJdkVersionCandidates() {
+        return new JdkVersionCandidates();
     }
 
     protected YesOrNo getYesOrNo(LineReader reader) {

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/command/CreateLambdaBuilderCommand.java
@@ -47,10 +47,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static picocli.CommandLine.Help.Ansi.AUTO;
 
 @CommandLine.Command(name = CreateLambdaBuilderCommand.NAME, description = "A guided walk-through to create an lambda function")
 @Prototype

--- a/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/CreateLambdaBuilderCommandSpec.groovy
+++ b/starter-cli/src/test/groovy/io/micronaut/starter/cli/command/CreateLambdaBuilderCommandSpec.groovy
@@ -113,11 +113,12 @@ class CreateLambdaBuilderCommandSpec extends Specification {
         cliOptions.language == options.options.language
         cliOptions.buildTool == options.options.buildTool
         cliOptions.testFramework == options.options.testFramework
-        cliOptions.javaVersion == options.options.javaVersion
+        cliOptions.javaVersion == options.options.javaVersion.asString()
 
         where:
         cliOptions << [CodingStyle.values(), LambdaDeployment.values()].combinations().collectMany { CodingStyle codingStyle, LambdaDeployment deployment ->
             combinations(
+                    command,
                     applicationContext,
                     codingStyle == CodingStyle.CONTROLLERS ?
                             CreateLambdaBuilderCommand.apiTriggerFeatures(ApplicationType.DEFAULT, applicationContext.getBeansOfType(Feature)) :
@@ -128,7 +129,7 @@ class CreateLambdaBuilderCommandSpec extends Specification {
         }
     }
 
-    static combinations(ApplicationContext ctx, List<Feature> triggerFeatures, CodingStyle codingStyle, LambdaDeployment deployment) {
+    static combinations(CreateLambdaBuilderCommand command, ApplicationContext ctx, List<Feature> triggerFeatures, CodingStyle codingStyle, LambdaDeployment deployment) {
         [
                 triggerFeatures,
                 [triggerFeatures],
@@ -139,8 +140,8 @@ class CreateLambdaBuilderCommandSpec extends Specification {
                 [CreateLambdaBuilderCommand.languagesForDeployment(deployment)],
                 [TestFramework.JUNIT, TestFramework.SPOCK, TestFramework.KOTEST],
                 [BuildTool.GRADLE, BuildTool.GRADLE_KOTLIN, BuildTool.MAVEN],
-                CreateLambdaBuilderCommand.jdkVersionsForDeployment(deployment),
-                [CreateLambdaBuilderCommand.jdkVersionsForDeployment(deployment)]
+                command.jdkVersionCandidates,
+                [command.jdkVersionCandidates]
         ].combinations().collect { new LambdaCliOptions(codingStyle, *it) }
     }
 
@@ -154,11 +155,11 @@ class CreateLambdaBuilderCommandSpec extends Specification {
         final Language language
         final TestFramework testFramework
         final BuildTool buildTool
-        final JdkVersion javaVersion
+        final String javaVersion
 
         final List<Feature> allApiFeatures
         final List<Language> allLanguages
-        final List<JdkVersion> allJdkVersions
+        final List<String> allJdkVersions
 
         LambdaCliOptions(
                 CodingStyle codingStyle,
@@ -171,8 +172,8 @@ class CreateLambdaBuilderCommandSpec extends Specification {
                 Language[] allLanguages,
                 TestFramework testFramework,
                 BuildTool buildTool,
-                JdkVersion javaVersion,
-                JdkVersion[] allJdkVersions
+                String javaVersion,
+                List<String> allJdkVersions
         ) {
             this.codingStyle = codingStyle
             this.apiFeature = apiFeatures
@@ -185,7 +186,7 @@ class CreateLambdaBuilderCommandSpec extends Specification {
             this.testFramework = testFramework
             this.buildTool = buildTool
             this.javaVersion = javaVersion
-            this.allJdkVersions = allJdkVersions.toList()
+            this.allJdkVersions = allJdkVersions
         }
 
         List<String> getFeatures() {

--- a/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/CreateLambdaCommandCliOptions.java
+++ b/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/CreateLambdaCommandCliOptions.java
@@ -27,11 +27,11 @@ class CreateLambdaCommandCliOptions implements CommandSupplier {
     final Language language;
     final TestFramework testFramework;
     final BuildTool buildTool;
-    final JdkVersion javaVersion;
+    final String javaVersion;
 
     final List<Feature> allApiFeatures;
     final List<Language> allLanguages;
-    final List<JdkVersion> allJdkVersions;
+    final List<String> allJdkVersions;
     @Nullable final String expectedExceptionMessage;
 
     private int index = 0;
@@ -47,8 +47,8 @@ class CreateLambdaCommandCliOptions implements CommandSupplier {
             Language[] allLanguages,
             TestFramework testFramework,
             BuildTool buildTool,
-            JdkVersion javaVersion,
-            JdkVersion[] allJdkVersions,
+            String javaVersion,
+            List<String> allJdkVersions,
             @Nullable String expectedExceptionMessage
     ) {
         this.codingStyle = codingStyle;
@@ -62,7 +62,7 @@ class CreateLambdaCommandCliOptions implements CommandSupplier {
         this.testFramework = testFramework;
         this.buildTool = buildTool;
         this.javaVersion = javaVersion;
-        this.allJdkVersions = Arrays.asList(allJdkVersions);
+        this.allJdkVersions = allJdkVersions;
         this.expectedExceptionMessage = expectedExceptionMessage;
     }
 

--- a/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/CreateLambdaCommandTest.java
+++ b/test-suite-graal/src/test/java/io/micronaut/starter/cli/command/CreateLambdaCommandTest.java
@@ -27,10 +27,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class CreateLambdaCommandTest {
 
     static ApplicationContext applicationContext;
+    static CreateLambdaBuilderCommand command;
 
     @BeforeAll
     static void setUp() {
         applicationContext = ApplicationContext.run();
+        command = applicationContext.getBean(CreateLambdaBuilderCommand.class);
     }
 
     @AfterAll
@@ -49,7 +51,7 @@ class CreateLambdaCommandTest {
                                                 .flatMap(language -> Stream.of(TestFramework.JUNIT, TestFramework.SPOCK, TestFramework.KOTEST)
                                                         .flatMap(testFramework -> Stream.of(BuildTool.GRADLE, BuildTool.GRADLE_KOTLIN, BuildTool.MAVEN)
                                                                 .flatMap(buildTool -> getAllApiFeatures(codingStyle).stream()
-                                                                        .flatMap(feature -> Stream.of(CreateLambdaBuilderCommand.jdkVersionsForDeployment(lambdaDeployment))
+                                                                        .flatMap(feature -> command.getJdkVersionCandidates().stream()
                                                                                 .map(jdkVersion -> new CreateLambdaCommandCliOptions(
                                                                                         codingStyle,
                                                                                         feature,
@@ -62,7 +64,7 @@ class CreateLambdaCommandTest {
                                                                                         testFramework,
                                                                                         buildTool,
                                                                                         jdkVersion,
-                                                                                        CreateLambdaBuilderCommand.jdkVersionsForDeployment(lambdaDeployment),
+                                                                                        command.getJdkVersionCandidates(),
                                                                                         invalid(feature, cdk, buildTool, lambdaDeployment)
                                                                                 ))
                                                                         )
@@ -105,7 +107,7 @@ class CreateLambdaCommandTest {
         assertEquals(cliOptions.language, options.getOptions().getLanguage());
         assertEquals(cliOptions.buildTool, options.getOptions().getBuildTool());
         assertEquals(cliOptions.testFramework, options.getOptions().getTestFramework());
-        assertEquals(cliOptions.javaVersion, options.getOptions().getJavaVersion());
+        assertEquals(cliOptions.javaVersion, options.getOptions().getJavaVersion().asString());
 
         if (cliOptions.expectedExceptionMessage != null) {
             IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> generate(projectGenerator, options));


### PR DESCRIPTION
the create-aws-lambda command was limited to Java 17 when native deployment was chosen.

This restriction no longer applies