### PR TITLE
ignore Oracle for maven tests

### DIFF
--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/DataHibernateReactiveSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/DataHibernateReactiveSpec.groovy
@@ -42,6 +42,7 @@ class DataHibernateReactiveSpec extends CommandSpec {
         db << featuresNames()
                 .stream()
                 .filter( f -> PredicateUtils.testFeatureIfMacOS(List.of(Oracle.NAME, SQLServer.NAME)).test(f))
+                .filter(f -> f != Oracle.NAME)
                 .toList()
     }
 

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/HibernateReactiveJpaSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/database/HibernateReactiveJpaSpec.groovy
@@ -40,6 +40,7 @@ class HibernateReactiveJpaSpec extends CommandSpec {
         where:
         db << featuresNames().stream()
                 .filter( f -> PredicateUtils.testFeatureIfMacOS(List.of(Oracle.NAME, SQLServer.NAME)).test(f))
+                .filter(f -> f != Oracle.NAME)
                 .toList()
     }
 


### PR DESCRIPTION
https://ge.micronaut.io/s/gyuljzfugjef4

```
java.util.concurrent.CompletionException: java.lang.NoClassDefFoundError: oracle/jdbc/OracleCommonPreparedStatement
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320)		at java.base/java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:936)		at java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:911)		at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)		at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162)		at io.vertx.core.Future.lambda$toCompletionStage$3(Future.java:583)		at io.vertx.core.impl.future.FutureImpl$4.onFailure(FutureImpl.java:188)		at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:81)		at io.vertx.core.impl.future.FutureImpl.tryFail(FutureImpl.java:265)		at io.vertx.sqlclient.impl.QueryResultBuilder.tryFail(QueryResultBuilder.java:94)
```