### PR TITLE
docs: instruction for opening OpenAPI spec as yaml file is wrong.

### DIFF
--- a/src/main/docs/guide/starterImpls/starterApi.adoc
+++ b/src/main/docs/guide/starterImpls/starterApi.adoc
@@ -9,7 +9,7 @@ $ ./gradlew starter-api:classes
 
 You can open the OPEN API specification in YAML format:
 
-[source, bash]
+[source, bash, subs="attributes"]
 ----
-$ open starter-api/build/classes/java/main/META-INF/swagger/micronaut-starter-1.0.yml
+$ open starter-api/build/classes/java/main/META-INF/swagger/micronaut-launch-{version}.yml
 ----


### PR DESCRIPTION
fixes #2343