### PR TITLE
Add line ending as an input to the starter cooords task

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.internal.starter.coordinates.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.internal.starter.coordinates.gradle
@@ -6,6 +6,7 @@ def generateCoordinateUtils = tasks.register("generateCoordinateUtils", io.micro
     packageName = "io.micronaut.starter.build.dependencies"
     outputDirectory = layout.buildDirectory.dir("generated-sources/coordinates")
     versionCatalog = project.extensions.getByType(VersionCatalogsExtension).named("templateLibs")
+    lineSeparator = System.lineSeparator()
 }
 
 sourceSets.main.java.srcDir(generateCoordinateUtils)

--- a/buildSrc/src/main/java/io/micronaut/starter/coordinates/CoordinatesSourceGenerator.java
+++ b/buildSrc/src/main/java/io/micronaut/starter/coordinates/CoordinatesSourceGenerator.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 
 @CacheableTask
 public abstract class CoordinatesSourceGenerator extends DefaultTask {
+
     @Internal
     public abstract Property<VersionCatalog> getVersionCatalog();
 
@@ -71,6 +72,17 @@ public abstract class CoordinatesSourceGenerator extends DefaultTask {
 
     @Input
     public abstract Property<String> getPackageName();
+
+    /**
+     * The line separator to use.
+     * <p>
+     * We use this as a cache key, as otherwise we can cache the Windows CLI build, which results in checkstyle errors.
+     *
+     * @return The line separator
+     * @see <a href="https://ge.micronaut.io/s/wgjbaaupb3qsy/console-log?page=1#L49">A build with the issue</a>
+     */
+    @Input
+    public abstract Property<String> getLineSeparator();
 
     @OutputDirectory
     public abstract DirectoryProperty getOutputDirectory();


### PR DESCRIPTION
We ended up with the file created by the Windows CLI build as the cached version.

This triggers a checkstyle error when it's built on a non-windows machine.

This PR adds the line-ending as an input to the task, so the cache-key is dependent on it.