### PR TITLE
Fix KTS gradle script for azurefunction

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azurefunctions.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azurefunctions.rocker.raw
@@ -2,32 +2,25 @@
 @import io.micronaut.starter.build.gradle.GradleDsl;
 
 @args (Project project, GradleDsl dsl, String javaVersion)
-@if(dsl == GradleDsl.KOTLIN) {
-azurefunctions {
-  resourceGroup = "java-functions-group"
-  appName = "@project.getName()"
-  pricingTier = "Consumption"
-  setRuntime(closureOf<com.microsoft.azure.gradle.configuration.GradleRuntimeConfig> {
-    os("linux")
-@if(javaVersion != null) {
-    javaVersion("@javaVersion")
-}
-  })
-  localDebug = "transport=dt_socket,server=y,suspend=n,address=5005"
-}
-}
-@if(dsl == GradleDsl.GROOVY) {
 azurefunctions {
     resourceGroup = "java-functions-group"
     appName = "@project.getName()"
     pricingTier = "Consumption"
     region = "westus"
+@if(dsl == GradleDsl.KOTLIN) {
+    setRuntime(closureOf<com.microsoft.azure.gradle.configuration.GradleRuntimeConfig> {
+        os("linux")
+@if(javaVersion != null) {
+        javaVersion("@javaVersion")
+}
+    })
+} else {
     runtime {
         os = "linux"
 @if(javaVersion != null) {
-       javaVersion = "@javaVersion"
+        javaVersion = "@javaVersion"
 }
     }
-    localDebug = "transport=dt_socket,server=y,suspend=n,address=5005"
 }
+    localDebug = "transport=dt_socket,server=y,suspend=n,address=5005"
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/build/maven/MavenSpec.groovy
@@ -164,9 +164,9 @@ class MavenSpec extends ApplicationContextSpec implements CommandOutputFixture {
       <groupId>org.apache.groovy</groupId>
       <artifactId>groovy</artifactId>
 ''')
-        template.contains('''\
-    <groovyVersion>4.0.19</groovyVersion>
-''')
+        template.contains("""\
+    <groovyVersion>${VersionInfo.getBomVersion("groovy")}</groovyVersion>
+""")
     }
 
     @Unroll


### PR DESCRIPTION
It was missing region. This caused the plugin to NPE when you ran azureFunctionsRun

Also fixes the test which looks at the currnt version of Groovy (was failing as Groovy had been bumped but not the test)