### PR TITLE
fix class-name in functions controllers

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/AbstractFunctionFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/AbstractFunctionFeature.java
@@ -71,7 +71,7 @@ public abstract class AbstractFunctionFeature implements FunctionFeature, Micron
 
         if (type == ApplicationType.DEFAULT) {
 
-            final String className = StringUtils.capitalize(generatorContext.getProject().getPropertyName());
+            final String className = StringUtils.capitalize(generatorContext.getProject().getClassName());
             Project project = generatorContext.getProject().withClassName(className);
 
             Language language = generatorContext.getLanguage();

--- a/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleFunctionSpec.groovy
+++ b/test-cloud/src/test/groovy/io/micronaut/starter/core/test/cloud/oracecloud/CreateOracleFunctionSpec.groovy
@@ -1,12 +1,21 @@
 package io.micronaut.starter.core.test.cloud.oracecloud
 
 import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.application.OperatingSystem
+import io.micronaut.starter.application.generator.ProjectGenerator
+import io.micronaut.starter.io.ConsoleOutput
+import io.micronaut.starter.io.FileSystemOutputHandler
 import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
 import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.MicronautJdkVersionConfiguration
+import io.micronaut.starter.options.Options
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.ApplicationTypeCombinations
 import io.micronaut.starter.test.BuildToolCombinations
 import io.micronaut.starter.test.CommandSpec
+import io.micronaut.starter.util.NameUtils
+import io.micronaut.starter.util.VersionInfo
 import spock.lang.Retry
 
 @Retry // can fail on CI due to port binding race condition, so retry
@@ -33,6 +42,34 @@ class CreateOracleFunctionSpec extends CommandSpec{
         where:
         [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.DEFAULT], Language.values() as List<Language>, BuildTool.valuesGradle())
     }
+
+    void 'create-#applicationType with features oracle-function and "-" in the app name #lang and #build and test framework: #testFramework'(ApplicationType applicationType, Language lang, BuildTool build,
+                                                                                                                     TestFramework testFramework) {
+        given:
+        List<String> features = ['oracle-function']
+        JdkVersion jdkVersion = VersionInfo.getJavaVersion()
+        if (jdkVersion.greaterThanEqual(MicronautJdkVersionConfiguration.DEFAULT_OPTION)) {
+            jdkVersion = MicronautJdkVersionConfiguration.DEFAULT_OPTION
+        }
+        beanContext.getBean(ProjectGenerator).generate(applicationType,
+                NameUtils.parse("example.micronaut.foo-test"),
+                new Options(lang, testFramework, build, jdkVersion),
+                OperatingSystem.LINUX,
+                features,
+                new FileSystemOutputHandler(dir, ConsoleOutput.NOOP),
+                ConsoleOutput.NOOP
+        )
+
+        when:
+        String output = executeBuild(build, "testClasses")
+
+        then:
+        output.contains("BUILD SUCCESS")
+
+        where:
+        [applicationType, lang, build, testFramework] << ApplicationTypeCombinations.combinations([ApplicationType.DEFAULT], Language.values() as List<Language>, BuildTool.valuesGradle())
+    }
+
 
     void 'default application with features oracle-function, #serializationFeature, #lang and #build and test framework: #testFramework'(
             Language lang,

--- a/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
+++ b/test-utils/src/main/groovy/io/micronaut/starter/test/CommandSpec.groovy
@@ -131,7 +131,7 @@ abstract class CommandSpec extends Specification {
         if (addMicronautGradleEnterpriseFeature) {
             features += [MicronautGradleEnterprise.NAME]
         }
-        JdkVersion jdkVersion = VersionInfo.getJavaVersion();
+        JdkVersion jdkVersion = VersionInfo.getJavaVersion()
         if (jdkVersion.greaterThanEqual(maxJdkVersion)) {
             jdkVersion = maxJdkVersion
         }


### PR DESCRIPTION
Fixes issue when project name contains "-" and oracle cloud function feature is selected.

<img width="1455" alt="image" src="https://github.com/micronaut-projects/micronaut-starter/assets/44323106/b47466cb-9125-4e93-bab1-b6a409e1c60b">

<img width="1299" alt="image" src="https://github.com/micronaut-projects/micronaut-starter/assets/44323106/87dc24d3-7afd-40b2-bfbe-ec71c5d6e043">
