### PR TITLE
Fix Maven/Groovy builds with zipkin and jaeger

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MicronautDependencyUtils.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/MicronautDependencyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ public final class MicronautDependencyUtils {
     public static final String GROUP_ID_MICRONAUT_TESTRESOURCES = "io.micronaut.testresources";
     public static final String  GROUP_ID_MICRONAUT_JAXRS = "io.micronaut.jaxrs";
     public static final String GROUP_ID_MICRONAUT_MICROSTREAM = "io.micronaut.microstream";
+    public static final String ARTIFACT_ID_MICRONAUT_CORE_PROCESSOR = "micronaut-core-processor";
     public static final String ARTIFACT_ID_MICRONAUT_INJECT_JAVA = "micronaut-inject-java";
     public static final String GROUP_ID_MICRONAUT_AWS = "io.micronaut.aws";
     public static final String GROUP_ID_MICRONAUT_AZURE = "io.micronaut.azure";
@@ -257,6 +258,11 @@ public final class MicronautDependencyUtils {
     @NonNull
     public static Dependency.Builder injectJava() {
         return coreDependency().artifactId(ARTIFACT_ID_MICRONAUT_INJECT_JAVA);
+    }
+
+    @NonNull
+    public static Dependency.Builder coreProcessor() {
+        return coreDependency().artifactId(ARTIFACT_ID_MICRONAUT_CORE_PROCESSOR);
     }
 
     @NonNull

--- a/starter-core/src/main/java/io/micronaut/starter/feature/tracing/Jaeger.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/tracing/Jaeger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,22 @@ package io.micronaut.starter.feature.tracing;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.application.generator.GeneratorContext;
-import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.server.MicronautServerDependent;
 
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.options.Language;
 import jakarta.inject.Singleton;
 
 @Singleton
 public class Jaeger implements TracingFeature, MicronautServerDependent {
 
+    public static final String NAME = "tracing-jaeger";
+
     @NonNull
     @Override
     public String getName() {
-        return "tracing-jaeger";
+        return NAME;
     }
 
     @Override
@@ -47,10 +51,13 @@ public class Jaeger implements TracingFeature, MicronautServerDependent {
         generatorContext.getConfiguration().put("tracing.jaeger.enabled", true);
         generatorContext.getConfiguration().put("tracing.jaeger.sampler.probability", 0.1);
 
-        generatorContext.addDependency(Dependency.builder()
-                .groupId("io.micronaut.tracing")
+        generatorContext.addDependency(MicronautDependencyUtils.tracingDependency()
                 .artifactId("micronaut-tracing-jaeger")
                 .compile());
+
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN && generatorContext.getLanguage() == Language.GROOVY) {
+            generatorContext.addDependency(MicronautDependencyUtils.coreProcessor().compileOnly());
+        }
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/tracing/Zipkin.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/tracing/Zipkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,17 +20,20 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.server.MicronautServerDependent;
 
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.options.Language;
 import jakarta.inject.Singleton;
 
 @Singleton
 public class Zipkin implements TracingFeature, MicronautServerDependent {
 
+    public static final String NAME = "tracing-zipkin";
     private static final String ARTIFACT_ID_MICRONAUT_TRACING_BRAVE_HTTP = "micronaut-tracing-brave-http";
 
     @NonNull
     @Override
     public String getName() {
-        return "tracing-zipkin";
+        return NAME;
     }
 
     @Override
@@ -56,6 +59,10 @@ public class Zipkin implements TracingFeature, MicronautServerDependent {
         generatorContext.addDependency(MicronautDependencyUtils.tracingDependency()
                 .artifactId(ARTIFACT_ID_MICRONAUT_TRACING_BRAVE_HTTP)
                 .compile());
+
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN && generatorContext.getLanguage() == Language.GROOVY) {
+            generatorContext.addDependency(MicronautDependencyUtils.coreProcessor().compileOnly());
+        }
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/JaegerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/JaegerSpec.groovy
@@ -14,7 +14,7 @@ class JaegerSpec extends ApplicationContextSpec implements CommandOutputFixture 
 
     void 'test readme.md with feature tracing-jaeger contains links to micronaut docs'() {
         when:
-        Map output = generate(['tracing-jaeger'])
+        Map output = generate([Jaeger.NAME])
         String readme = output['README.md']
 
         then:
@@ -28,7 +28,7 @@ class JaegerSpec extends ApplicationContextSpec implements CommandOutputFixture 
         when:
         String template = new BuildBuilder(beanContext, GRADLE)
                 .language(language)
-                .features(['tracing-jaeger'])
+                .features([Jaeger.NAME])
                 .render()
 
         then:
@@ -43,7 +43,7 @@ class JaegerSpec extends ApplicationContextSpec implements CommandOutputFixture 
         when:
         String template = new BuildBuilder(beanContext, MAVEN)
                 .language(language)
-                .features(['tracing-jaeger'])
+                .features([Jaeger.NAME])
                 .render()
 
         then:
@@ -61,7 +61,7 @@ class JaegerSpec extends ApplicationContextSpec implements CommandOutputFixture 
 
     void 'test tracing-jaeger configuration'() {
         when:
-        GeneratorContext commandContext = buildGeneratorContext(['tracing-jaeger'])
+        GeneratorContext commandContext = buildGeneratorContext([Jaeger.NAME])
 
         then:
         commandContext.configuration.get('tracing.jaeger.enabled') == true

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/ZipkinSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/tracing/ZipkinSpec.groovy
@@ -15,7 +15,7 @@ class ZipkinSpec extends ApplicationContextSpec implements CommandOutputFixture 
 
     void 'test readme.md with feature tracing-zipkin contains links to micronaut docs'() {
         when:
-        Map output = generate(['tracing-zipkin'])
+        Map output = generate([Zipkin.NAME])
         String readme = output['README.md']
 
         then:
@@ -27,7 +27,7 @@ class ZipkinSpec extends ApplicationContextSpec implements CommandOutputFixture 
     @Unroll
     void 'test gradle tracing-zipkin feature for language=#language'(Language language, BuildTool buildTool) {
         given:
-        String feature = 'tracing-zipkin'
+        String feature = Zipkin.NAME
         when:
         String template = new BuildBuilder(beanContext, buildTool)
                 .features([feature])
@@ -44,7 +44,7 @@ class ZipkinSpec extends ApplicationContextSpec implements CommandOutputFixture 
 
     void 'test tracing-zipkin configuration'() {
         when:
-        GeneratorContext commandContext = buildGeneratorContext(['tracing-zipkin'])
+        GeneratorContext commandContext = buildGeneratorContext([Zipkin.NAME])
 
         then:
         commandContext.configuration.get('tracing.zipkin.enabled') == true

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/tracing/JaegerSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/tracing/JaegerSpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.starter.core.test.feature.tracing
+
+import io.micronaut.starter.feature.tracing.Jaeger
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.test.CommandSpec
+import io.micronaut.starter.test.LanguageBuildCombinations
+
+class JaegerSpec extends CommandSpec {
+
+    void 'test jaeger feature for #lang and #buildTool'(Language lang, BuildTool buildTool) {
+        given:
+        generateProject(lang, buildTool, [Jaeger.NAME])
+
+        when:
+        String output = executeBuild(buildTool, "test")
+
+        then:
+        output.contains("BUILD SUCCESS")
+
+        where:
+        [lang, buildTool] << LanguageBuildCombinations.combinations()
+    }
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "jaeger-tracing-app"
+    }
+}

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/tracing/ZipkinSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/tracing/ZipkinSpec.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.starter.core.test.feature.tracing
+
+import io.micronaut.starter.feature.tracing.Zipkin
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.test.CommandSpec
+import io.micronaut.starter.test.LanguageBuildCombinations
+
+class ZipkinSpec extends CommandSpec {
+
+    void 'test zipkin feature for #lang and #buildTool'(Language lang, BuildTool buildTool) {
+        given:
+        println dir
+        generateProject(lang, buildTool, [Zipkin.NAME])
+
+        when:
+        String output = executeBuild(buildTool, "test")
+
+        then:
+        output.contains("BUILD SUCCESS")
+
+        where:
+        [lang, buildTool] << LanguageBuildCombinations.combinations()
+    }
+
+    @Override
+    String getTempDirectoryPrefix() {
+        return "zipkin-tracing-app"
+    }
+}


### PR DESCRIPTION
We had an api dependency on micronaut-core-processor which meant it was ending up on the runtime classpath.

This was fixed here

https://github.com/micronaut-projects/micronaut-tracing/issues/553#event-12652214705

However for Maven and Groovy this causes a failure as it no longer ends up getting pulled onto the provided configuration.

Once this fix is released, we can remove the skips from the jaeger and zipkin guides here:

https://github.com/micronaut-projects/micronaut-guides/pull/1459/commits/798040a62c910ec8ac19852e89c68f79aa4c12f0#diff-429b78dd62241a22ac3b663ca2d045441a9326121c3b6bbf19f5859d94c2e3d8