### PR TITLE
Fix minor string typo

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAot.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/MicronautAot.java
@@ -154,7 +154,7 @@ public class MicronautAot implements DefaultFeature {
         }
         optimizations.add(new MicronautAotOptimization("scan.reactive.types.enabled", true, "Scans reactive types at build time instead of runtime"));
         optimizations.add(new MicronautAotOptimization("deduce.environment.enabled", true, "Deduces the environment at build time instead of runtime"));
-        optimizations.add(new MicronautAotOptimization("known.missing.types.enabled", true, "Checks of existence of some types at build time instead of runtime"));
+        optimizations.add(new MicronautAotOptimization("known.missing.types.enabled", true, "Checks for the existence of some types at build time instead of runtime"));
         optimizations.add(new MicronautAotOptimization("sealed.property.source.enabled", true, "Precomputes property sources at build time"));
 
         optimizations.add(new MicronautAotOptimization(


### PR DESCRIPTION
Hi everyone,

Here is a minor grammar fix, noticed when generating ``src/aot-jar.properties``. I just noticed my fork points to 4.5.x, I hope it's the right branch.

Cheers!

Loris