### PR TITLE
Add React SSR feature

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/starter/coordinates/CoordinatesSourceGenerator.java
+++ b/buildSrc/src/main/java/io/micronaut/starter/coordinates/CoordinatesSourceGenerator.java
@@ -98,6 +98,7 @@ public abstract class CoordinatesSourceGenerator extends DefaultTask {
         getFileOperations().delete(outputDirectory);
         Files.createDirectories(packageDirectory);
         try (PrintWriter writer = new PrintWriter(new FileWriter(new File(packageDirectory.toFile(), "StarterCoordinates.java")))) {
+            writer.println("// WARNING: Generated from gradle/templates.versions.toml - DO NOT EDIT.");
             writer.println("package " + packageName + ";");
             writer.println();
             writer.println("import java.util.HashMap;");

--- a/gradle/templates.versions.toml
+++ b/gradle/templates.versions.toml
@@ -69,6 +69,8 @@ spring-boot-gradle-plugin = "3.2.4"
 spring-dependency-management-plugin = "1.1.4"
 micronaut-starter-aws-cdk = "4.3.7"
 spring-boot-starter-parent="3.2.4"
+graaljs = "24.0.1"  # Once this is bumped past 24.1, you should be able to remove the disabling of Loom in the config properties in the React feature.
+frontend-maven-plugin = "1.15.0"
 
 [libraries]
 spring-boot-starter-parent = { module = "org.springframework.boot:spring-boot-starter-parent", version.ref = "spring-boot-starter-parent" }
@@ -142,6 +144,8 @@ scram-client = { module = "com.ongres.scram:client", version.ref = "scram-client
 slf4j-simple-logger = { module = "io.goodforgod:slf4j-simple-logger", version.ref = "slf4j-simple-logger" }
 zeebe-micronaut-client = { module = "info.novatec:micronaut-zeebe-client-feature", version.ref = "zeebe-micronaut-client" }
 buildless-gradle-plugin = { module = "build.less:buildless-plugin-gradle", version.ref = "buildless" }
+graaljs-community = { module = "org.graalvm.polyglot:js-community", version.ref = "graaljs" }
+frontend-maven-plugin = { module = "com.github.eirslett:frontend-maven-plugin", version.ref = "frontend-maven-plugin" }
 
 [plugins]
 # This is an exception to the rule!

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gitignore.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gitignore.rocker.raw
@@ -1,3 +1,5 @@
+@import io.micronaut.starter.feature.Features
+@args (Features features)
 Thumbs.db
 .DS_Store
 .gradle
@@ -13,3 +15,6 @@ out/
 .settings
 .classpath
 .factorypath
+@if (features.contains("views-react")) {
+src/js/node_modules
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/Gradle.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/Gradle.java
@@ -147,7 +147,7 @@ public class Gradle implements BuildFeature {
 
     @SuppressWarnings("java:S1172") // Unused parameter for extensibility
     protected RockerModel gitignore(GeneratorContext generatorContext) {
-        return gitignore.template();
+        return gitignore.template(generatorContext.getFeatures());
     }
 
     protected void addGradleProperties(GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/aotExtension.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/aotExtension.rocker.raw
@@ -2,8 +2,8 @@
 @import java.util.Map
 @args(Map<String, String> aotKeys)
     aot {
-    // Please review carefully the optimizations enabled below
-    // Check https://micronaut-projects.github.io/micronaut-aot/latest/guide/ for more details
+        // Please review carefully the optimizations enabled below
+        // Check https://micronaut-projects.github.io/micronaut-aot/latest/guide/ for more details
         optimizeServiceLoading = false
         convertYamlToJava = false
         precomputeOperations = true

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -252,6 +252,111 @@ protobuf {
 }
 }
 }
+
+
+@if (features.contains("views-react")) {
+// region JavaScript compilation
+@if(gradleBuild.getDsl() == GradleDsl.KOTLIN) {
+node {
+    download = true
+    version = "21.7.2"
+    nodeProjectDir = layout.projectDirectory.dir("src/main/js")
+}
+
+val builtJSDir = layout.buildDirectory.dir("js")
+
+val buildClientJS = tasks.register<NpxTask>("buildClientJS") {
+    dependsOn("npmInstall")
+    command = "webpack"
+    args = listOf("--mode", "production", "--config", "webpack.client.js")
+    inputs.dir(fileTree("src/main/js/").exclude(".cache"))
+
+    val outPath = builtJSDir.get().file("views/static/client.js")
+    environment = mapOf("BUILD_DIR" to outPath.asFile.absoluteFile.parent)
+    outputs.file(outPath)
+}
+
+val buildServerJS = tasks.register<NpxTask>("buildServerJS") {
+    dependsOn("npmInstall")
+    command = "webpack"
+    args = listOf("--mode", "production", "--config", "webpack.server.js")
+    inputs.dir(fileTree("src/main/js/").exclude(".cache"))
+
+    val outPath = builtJSDir.get().file("views/ssr-components.mjs")
+    environment = mapOf("BUILD_DIR" to outPath.asFile.absoluteFile.parent)
+    outputs.file(outPath)
+}
+
+val buildJS = tasks.register("buildJS") {
+    dependsOn(buildClientJS, buildServerJS)
+}
+
+tasks.named("processResources") {
+    dependsOn(buildJS)
+}
+
+tasks.named("inspectRuntimeClasspath") {
+    dependsOn(buildJS)
+}
+
+sourceSets {
+    main {
+        resources {
+            srcDir(builtJSDir)
+        }
+    }
+}
+} else {
+node {
+    download = true
+    version = "21.7.2"
+    nodeProjectDir = layout.projectDirectory.dir("src/main/js")
+}
+
+def builtJSDir = layout.buildDirectory.dir('js')
+
+def buildClientJS = tasks.register('buildClientJS', NpxTask) {
+    dependsOn npmInstall
+    command = 'webpack'
+    args = ['--mode', 'production', '--config', 'webpack.client.js']
+    inputs.dir(fileTree('src/main/js/').exclude('.cache'))
+
+    def outPath = builtJSDir.get().file('views/static/client.js')
+    environment = ['BUILD_DIR': outPath.asFile.absoluteFile.parent]
+    outputs.file(outPath)
+}
+
+def buildServerJS = tasks.register('buildServerJS', NpxTask) {
+    dependsOn npmInstall
+    command = 'webpack'
+    args = ['--mode', 'production', '--config', 'webpack.server.js']
+    inputs.dir(fileTree('src/main/js/').exclude('.cache'))
+
+    def outPath = builtJSDir.get().file('views/ssr-components.mjs')
+    environment = ['BUILD_DIR': outPath.asFile.absoluteFile.parent]
+    outputs.file(outPath)
+}
+
+def buildJS = tasks.register('buildJS') {
+    it.dependsOn(buildClientJS, buildServerJS)
+}
+
+processResources.dependsOn(buildJS)
+tasks.named('inspectRuntimeClasspath') {
+    dependsOn(buildJS)
+}
+
+sourceSets {
+    main {
+        resources {
+            srcDir(builtJSDir)
+        }
+    }
+}
+}
+// endregion
+
+}
 @gradleBuild.renderExtensions()
 
 @gradleBuild.renderSubstitutions()

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/Maven.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/maven/Maven.java
@@ -126,7 +126,7 @@ public class Maven implements BuildFeature {
 
     @SuppressWarnings("java:S1172") // Unused parameter for extension
     protected RockerModel gitIgnore(GeneratorContext generatorContext) {
-        return gitignore.template();
+        return gitignore.template(generatorContext.getFeatures());
     }
 
     @Override

--- a/starter-core/src/main/java/io/micronaut/starter/feature/view/React.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/view/React.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.feature.view;
+
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.*;
+import io.micronaut.starter.build.gradle.GradlePlugin;
+import io.micronaut.starter.build.maven.MavenPlugin;
+import io.micronaut.starter.feature.server.MicronautServerDependent;
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.options.Language;
+import io.micronaut.starter.template.RockerTemplate;
+import io.micronaut.starter.template.RockerWritable;
+import io.micronaut.starter.template.URLTemplate;
+import jakarta.inject.Singleton;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+@Singleton
+public class React implements ViewFeature, MicronautServerDependent {
+    private static final String ARTIFACT_ID = "micronaut-views-react";
+    private static final String[] FRONTEND_FILES = new String[]{
+            "package.json",
+            "client.js",
+            "server.js",
+            "webpack.client.js",
+            "webpack.server.js",
+            "components/App.js"
+    };
+
+    public static final String NODE_GRADLE_PLUGIN_VERSION = "7.0.2";
+
+    @Override
+    public String getName() {
+        return "views-react";
+    }
+
+    @Override
+    public String getTitle() {
+        return "React SSR";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Adds support for Server-Side View Rendering of ReactJS components using the GraalJS engine.";
+    }
+
+    @Override
+    public String getThirdPartyDocumentation() {
+        return "https://react.dev/reference/react-dom/server";
+    }
+
+    @Override
+    public String getMicronautDocumentation() {
+        return "https://micronaut-projects.github.io/micronaut-views/latest/guide/index.html#react";
+    }
+
+    @Override
+    public boolean isPreview() {
+        // June 2024: Module is brand new, it may still need to change once it's been used in anger.
+        return true;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        try {
+            generatorContext.addDependency(MicronautDependencyUtils.viewsDependency().artifactId(ARTIFACT_ID).compile());
+
+            if (generatorContext.getBuildTool().isGradle()) {
+                generatorContext.addDependency(Dependency.builder()
+                        .runtime()
+                        .groupId(StarterCoordinates.JS_COMMUNITY.getGroupId())
+                        .artifactId(StarterCoordinates.JS_COMMUNITY.getArtifactId())
+                        .version(StarterCoordinates.JS_COMMUNITY.getVersion())
+                        .pom()
+                        .build()
+                );
+
+                generatorContext.addBuildPlugin(
+                        GradlePlugin.builder()
+                                .id("com.github.node-gradle.node")
+                                .version(NODE_GRADLE_PLUGIN_VERSION)
+                                .buildImports("import com.github.gradle.node.npm.task.NpxTask")
+                                .build()
+                );
+            } else if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
+                // We spell out the individual dependencies here because the Starter dependency management code for
+                // Maven builds can't express the direct pom dependency needed by Truffle.
+                generatorContext.addDependency(Dependency.builder()
+                        .groupId("org.graalvm.js")
+                        .artifactId("js-language")
+                        .version(StarterCoordinates.JS_COMMUNITY.getVersion())
+                        .runtime()
+                );
+                generatorContext.addDependency(Dependency.builder()
+                        .groupId("org.graalvm.truffle")
+                        .artifactId("truffle-enterprise")
+                        .version(StarterCoordinates.JS_COMMUNITY.getVersion())
+                        .runtime()
+                );
+                generatorContext.addDependency(Dependency.builder()
+                        .groupId("org.graalvm.truffle")
+                        .artifactId("truffle-runtime")
+                        .version(StarterCoordinates.JS_COMMUNITY.getVersion())
+                        .runtime()
+                );
+                generatorContext.addDependency(Dependency.builder()
+                        .groupId("org.graalvm.polyglot")
+                        .artifactId("polyglot")
+                        .version(StarterCoordinates.JS_COMMUNITY.getVersion())
+                        .runtime()
+                );
+
+                Coordinate coordinate = generatorContext.resolveCoordinate("frontend-maven-plugin");
+                generatorContext.addBuildPlugin(
+                        MavenPlugin.builder()
+                                .artifactId(StarterCoordinates.FRONTEND_MAVEN_PLUGIN.getArtifactId())
+                                .extension(new RockerWritable(mvnPluginReact.template(coordinate.getGroupId(), coordinate.getArtifactId(), coordinate.getVersion())))
+                                .build()
+                );
+            }
+
+            // Set up the frontend project. These are *not* resources under views/ because they're raw inputs that will
+            // be minified and transpiled as part of the build pipeline.
+            var ourResourceURL = Thread.currentThread().getContextClassLoader().getResource("views/react").toString();
+            for (var fileName : FRONTEND_FILES) {
+                generatorContext.addTemplate(
+                        fileName,
+                        new URLTemplate("src/main/js/" + fileName, new URL(ourResourceURL + "/" + fileName))
+                );
+            }
+            var sourceFile = generatorContext.getSourcePath("/{packagePath}/AppController");
+
+            if (generatorContext.getLanguage() == Language.JAVA) {
+                generatorContext.addTemplate("AppController.java",
+                        new RockerTemplate(sourceFile, reactControllerJava.template(generatorContext.getProject())));
+            } else if (generatorContext.getLanguage() == Language.KOTLIN) {
+                generatorContext.addTemplate("AppController.kt",
+                        new RockerTemplate(sourceFile, reactControllerKotlin.template(generatorContext.getProject())));
+            }
+
+            // This will stop being necessary in Truffle 24.1
+            generatorContext.getConfiguration().addNested("micronaut.executors.blocking.virtual", "false");
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);   // Cannot happen.
+        }
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/view/mvnPluginReact.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/view/mvnPluginReact.rocker.raw
@@ -1,0 +1,46 @@
+@args(String groupID, String artifactID, String version)
+<plugin>
+    <groupId>@groupID</groupId>
+    <artifactId>@artifactID</artifactId>
+    <version>@version</version>
+
+    <executions>
+        <execution>
+            <id>install node and npm</id>
+            <goals><goal>install-node-and-npm</goal></goals>
+        </execution>
+
+        <execution>
+            <id>npm install</id>
+            <goals><goal>npm</goal></goals>
+        </execution>
+
+        <execution>
+            <id>webpack build server</id>
+            <goals><goal>webpack</goal></goals>
+            <configuration>
+                <arguments>--mode production --config webpack.server.js</arguments>
+                <environmentVariables>
+                    <BUILD_DIR>${project.build.outputDirectory}/views</BUILD_DIR>
+                </environmentVariables>
+            </configuration>
+        </execution>
+
+        <execution>
+            <id>webpack build client</id>
+            <goals><goal>webpack</goal></goals>
+            <configuration>
+                <arguments>--mode production --config webpack.client.js</arguments>
+                <environmentVariables>
+                    <BUILD_DIR>${project.build.outputDirectory}/views/static</BUILD_DIR>
+                </environmentVariables>
+            </configuration>
+        </execution>
+    </executions>
+
+    <configuration>
+        <nodeVersion>v21.7.2</nodeVersion>
+        <workingDirectory>src/main/js</workingDirectory>
+        <installDirectory>target</installDirectory>
+    </configuration>
+</plugin>

--- a/starter-core/src/main/java/io/micronaut/starter/feature/view/reactControllerJava.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/view/reactControllerJava.rocker.raw
@@ -1,0 +1,41 @@
+@import io.micronaut.starter.application.Project
+
+@args (
+Project project
+)
+
+@if (project.getPackageName() != null) {
+package @project.getPackageName();
+}
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.views.View;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+
+@@Controller
+public class AppController {
+    @@Serdeable.Serializable
+    public record CurrentTime(String now) {}
+
+    @@Introspected
+    public record InitialProps(String name) {
+    }
+
+    @@View("App")
+    @@Get
+    public HttpResponse<InitialProps> index() {
+        return HttpResponse.ok(new InitialProps("'your name goes here'"));
+    }
+
+    @@Get("/api/time")
+    public CurrentTime time() {
+        return new CurrentTime(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM).format(LocalDateTime.now()));
+    }
+}

--- a/starter-core/src/main/java/io/micronaut/starter/feature/view/reactControllerKotlin.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/view/reactControllerKotlin.rocker.raw
@@ -1,0 +1,40 @@
+@import io.micronaut.starter.application.Project
+
+@args (
+Project project
+)
+
+@if (project.getPackageName() != null) {
+package @project.getPackageName()
+}
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.HttpResponse
+import io.micronaut.serde.annotation.Serdeable
+import io.micronaut.views.View
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+@@Controller
+public class AppController {
+    @@Serdeable.Serializable
+    public data class CurrentTime(val now: String)
+
+    @@Introspected
+    public data class InitialProps(val name: String)
+
+    @@View("App")
+    @@Get
+    public fun index(): HttpResponse<InitialProps> {
+        return HttpResponse.ok(InitialProps("'your name goes here'"))
+    }
+
+    @@Get("/api/time")
+    public fun time(): CurrentTime {
+        return CurrentTime(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM).format(LocalDateTime.now()))
+    }
+}

--- a/starter-core/src/main/resources/views/react/client.js
+++ b/starter-core/src/main/resources/views/react/client.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import {hydrateRoot} from 'react-dom/client';
+
+const pageComponentName = Micronaut.rootComponent;
+
+import(`./components/${pageComponentName}.js`).then(module => {
+    const PageComponent = module[pageComponentName]
+    hydrateRoot(document, <PageComponent {...Micronaut.rootProps}/>)
+})

--- a/starter-core/src/main/resources/views/react/components/App.js
+++ b/starter-core/src/main/resources/views/react/components/App.js
@@ -1,0 +1,19 @@
+// App.js
+import React from 'react';
+
+function App({name, url}) {
+    return (
+        <html>
+        <head>
+            <title>Hello World!</title>
+            <meta charSet="UTF-8"/>
+        </head>
+        <body>
+            <p>Hello there {name}, I'm saying hi from SSR React!</p>
+            <p>URL is {url}</p>
+        </body>
+        </html>
+    );
+}
+
+export default App;

--- a/starter-core/src/main/resources/views/react/package.json
+++ b/starter-core/src/main/resources/views/react/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "Frontend code for your Micronaut app.",
+  "main": "client.js",
+  "author": "Your Name Here <you@example.com>",
+  "dependencies": {
+    "babel-loader": "^9.1.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "text-encoding": "^0.7.0",
+    "web-streams-polyfill": "^4.0.0",
+    "@babel/preset-env": "^7.24.3",
+    "@babel/preset-react": "^7.24.1",
+    "webpack": "^5.91.0",
+    "webpack-cli": "^5.1.4",
+    "node-polyfill-webpack-plugin": "^3.0.0"
+  }
+}

--- a/starter-core/src/main/resources/views/react/server.js
+++ b/starter-core/src/main/resources/views/react/server.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+
+// Page components
+import App from './components/App';
+
+export { React, ReactDOMServer, App };

--- a/starter-core/src/main/resources/views/react/webpack.client.js
+++ b/starter-core/src/main/resources/views/react/webpack.client.js
@@ -1,0 +1,30 @@
+const path = require('path');
+const webpack = require('webpack');
+
+module.exports = {
+    entry: ['./client.js'],
+    devtool: false,
+    output: {
+        path: path.resolve(process.env.BUILD_DIR) || path.resolve(__dirname, "../../../build/js"),
+        filename: 'client.js',
+    },
+    plugins: [
+        new webpack.DefinePlugin({
+            SERVER: false,
+        })
+    ],
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: ['@babel/preset-env', '@babel/preset-react']
+                    }
+                }
+            }
+        ]
+    }
+};

--- a/starter-core/src/main/resources/views/react/webpack.server.js
+++ b/starter-core/src/main/resources/views/react/webpack.server.js
@@ -1,0 +1,48 @@
+const path = require('path');
+const webpack = require('webpack');
+
+// This targets the browser even though we run it server-side, because that's closer to GraalJS.
+module.exports = {
+    entry: ['web-streams-polyfill/dist/polyfill', './server.js'],
+    output: {
+        path: path.resolve(process.env.BUILD_DIR) || path.resolve(__dirname, "../../../build/js"),
+        filename: 'ssr-components.mjs',
+        module: true,
+        library: {
+            type: 'module',
+        },
+        // GraalJS uses `globalThis` instead of `window` for the global object.
+        globalObject: 'globalThis'
+    },
+    devtool: false,
+    experiments: {
+        outputModule: true
+    },
+    performance: {
+        hints: false,
+    },
+    plugins: [
+        new webpack.ProvidePlugin({
+            // GraalJS doesn't support TextEncoder yet. It's easy to add and here's a polyfill in the meantime.
+            TextEncoder: ['text-encoding', 'TextEncoder'],
+            TextDecoder: ['text-encoding', 'TextDecoder'],
+        }),
+        new webpack.DefinePlugin({
+            SERVER: true,
+        })
+    ],
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: ['@babel/preset-env', '@babel/preset-react']
+                    }
+                }
+            }
+        ]
+    }
+};


### PR DESCRIPTION
Please note that this PR is against the base 5.0.x branch

Adds support for the recently added React SSR view renderer. The generated project uses NPM plugins for Gradle and Maven to set up an integrated frontend/backend project with WebPack driven by the build, so it's a little more complex than a normal template renderer feature.