### PR TITLE
Some fixes to the default ReactJS template.

### DIFF
--- a/gradle/templates.versions.toml
+++ b/gradle/templates.versions.toml
@@ -70,7 +70,7 @@ spring-boot-gradle-plugin = "3.3.0"
 spring-dependency-management-plugin = "1.1.4"
 micronaut-starter-aws-cdk = "4.3.7"
 spring-boot-starter-parent="3.3.0"
-graaljs = "24.0.1"  # Once this is bumped past 24.1, you should be able to remove the disabling of Loom in the config properties in the React feature.
+graaljs = "24.0.2"  # Once this is bumped past 24.1, you should be able to remove the disabling of Loom in the config properties in the React feature.
 frontend-maven-plugin = "1.15.0"
 
 [libraries]

--- a/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -246,6 +246,14 @@ protobuf {
 
 
 @if (features.contains("views-react")) {
+java {
+    // GraalJS for React server side rendering requires GraalVM.
+    toolchain {
+        vendor = JvmVendorSpec.GRAAL_VM
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 // region JavaScript compilation
 @if(gradleBuild.getDsl() == GradleDsl.KOTLIN) {
 node {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/view/React.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/view/React.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.feature.view;
 
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.*;
+import io.micronaut.starter.build.gradle.GradleFile;
 import io.micronaut.starter.build.gradle.GradlePlugin;
 import io.micronaut.starter.build.maven.MavenPlugin;
 import io.micronaut.starter.feature.server.MicronautServerDependent;
@@ -86,15 +87,25 @@ public class React implements ViewFeature, MicronautServerDependent {
                         .groupId(StarterCoordinates.JS_COMMUNITY.getGroupId())
                         .artifactId(StarterCoordinates.JS_COMMUNITY.getArtifactId())
                         .version(StarterCoordinates.JS_COMMUNITY.getVersion())
-                        .pom()
                         .build()
                 );
 
+                // This plugin teaches Gradle to download NodeJS and use it to run JS programs.
                 generatorContext.addBuildPlugin(
                         GradlePlugin.builder()
                                 .id("com.github.node-gradle.node")
                                 .version(NODE_GRADLE_PLUGIN_VERSION)
                                 .buildImports("import com.github.gradle.node.npm.task.NpxTask")
+                                .build()
+                );
+
+                // This teaches Gradle to download the right GraalVM automatically (community edition).
+                // For some reason Gradle won't do it out of the box :(
+                generatorContext.addBuildPlugin(
+                        GradlePlugin.builder()
+                                .id("org.gradle.toolchains.foojay-resolver-convention")
+                                .version("0.8.0")
+                                .gradleFile(GradleFile.SETTINGS)
                                 .build()
                 );
             } else if (generatorContext.getBuildTool() == BuildTool.MAVEN) {


### PR DESCRIPTION
1. Bump the graaljs library version. This avoids a confusing configuration error message that can occur with the default setup.
2. Don't use a POM dependency on GraalJS for Gradle, this is incorrect and can yield invalid "version mismatch" errors depending on your JVM.
3. Configure Gradle to download GraalVM automatically.

Together these should improve the rate at which projects work out of the box.