### PR TITLE
handle HTML request correctly

### DIFF
--- a/starter-api/src/main/java/io/micronaut/starter/api/ApplicationController.java
+++ b/starter-api/src/main/java/io/micronaut/starter/api/ApplicationController.java
@@ -41,7 +41,6 @@ import java.io.Writer;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/starter-api/src/main/java/io/micronaut/starter/api/diff/DiffOperations.java
+++ b/starter-api/src/main/java/io/micronaut/starter/api/diff/DiffOperations.java
@@ -24,8 +24,6 @@ import io.micronaut.starter.options.JdkVersion;
 import io.micronaut.starter.options.Language;
 import io.micronaut.starter.options.TestFramework;
 import io.swagger.v3.oas.annotations.Parameter;
-import org.reactivestreams.Publisher;
-
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.io.IOException;

--- a/starter-api/src/test/groovy/io/micronaut/starter/api/ApplicationControllerSpec.groovy
+++ b/starter-api/src/test/groovy/io/micronaut/starter/api/ApplicationControllerSpec.groovy
@@ -1,7 +1,13 @@
 package io.micronaut.starter.api
 
+import io.micronaut.context.annotation.Property
+import io.micronaut.core.util.StringUtils
 import io.micronaut.http.HttpHeaders
 import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.MutableHttpRequest
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Header
 import io.micronaut.http.client.HttpClient
@@ -10,6 +16,7 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification
 
+@Property(name = "micronaut.http.client.follow-redirects", value = StringUtils.FALSE)
 @MicronautTest
 class ApplicationControllerSpec extends Specification {
 
@@ -19,6 +26,35 @@ class ApplicationControllerSpec extends Specification {
 
     @Inject
     ApplicationTypeClient applicationTypeClient
+
+    void "home txt request"() {
+        given:
+        MutableHttpRequest<?> mutableHttpRequest = HttpRequest.GET("/").accept(MediaType.TEXT_PLAIN_TYPE)
+        when:
+        HttpResponse<?> response = client.toBlocking().exchange(mutableHttpRequest)
+
+        then:
+        HttpStatus.OK == response.status()
+    }
+
+    void "htmlRequest redirects"() {
+        given:
+        MutableHttpRequest<?> mutableHttpRequest = HttpRequest.GET("/");
+        mutableHttpRequest.getHeaders().add("Accept", "text/html,application/xhtml xml,application/xml;q=0.9,*/*;q=0.8")
+        mutableHttpRequest.getHeaders().add("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15")
+        mutableHttpRequest.getHeaders().add("Accept-Encoding", "gzip, deflate")
+        mutableHttpRequest.getHeaders().add("Accept-Language", "en-GB,en;q=0.9")
+        mutableHttpRequest.getHeaders().add("Sec-Fetch-Mode", "navigate")
+        mutableHttpRequest.getHeaders().add("Upgrade-Insecure-Requests", "1")
+        mutableHttpRequest.getHeaders().add("Sec-Fetch-Dest", "document")
+        mutableHttpRequest.getHeaders().add("Host", "localhost:8080");
+
+        when:
+        HttpResponse<?> response = client.toBlocking().exchange(mutableHttpRequest)
+
+        then:
+        HttpStatus.PERMANENT_REDIRECT == response.status()
+    }
 
     void "test versions"() {
         given:


### PR DESCRIPTION
@yawkat @dstepanov there is a regression which broken the redirection from 

https://launch.micronaut.io to https://micronaut.io/launch

This PR fixes it. I think the fix is the correct way of writing this controller but I am not sure if we want to support the old behaviour. 