### PR TITLE
Change default mysql r2dbc dependency to io.asyncer:r2dbc-mysql

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/database/MySQL.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/database/MySQL.java
@@ -30,7 +30,7 @@ public class MySQL extends MySQLCompatibleFeature {
     public static final String NAME = "mysql";
 
     private static final Dependency.Builder DEPENDENCY_R2DBC_MYSQL = Dependency.builder()
-            .groupId("dev.miku")
+            .groupId("io.asyncer")
                     .artifactId("r2dbc-mysql")
                     .runtime();
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/DataR2dbcSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/database/r2dbc/DataR2dbcSpec.groovy
@@ -94,6 +94,23 @@ class DataR2dbcSpec extends ApplicationContextSpec implements CommandOutputFixtu
         !verifier.hasDependency('io.micronaut.sql', 'micronaut-jdbc-hikari')
     }
 
+    void "test dependencies are present for gradle and mysql r2dbc"() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .features(["data-r2dbc", "mysql"])
+                .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(BuildTool.GRADLE, template)
+
+        then:
+        jdbcFeature.name == 'jdbc-hikari'
+        verifier.hasDependency('io.micronaut.data', 'micronaut-data-processor', Scope.ANNOTATION_PROCESSOR)
+        verifier.hasDependency('io.micronaut.data', 'micronaut-data-r2dbc')
+        !verifier.hasDependency('io.micronaut.r2dbc', 'micronaut-r2dbc-core')
+        verifier.hasDependency('io.asyncer', 'r2dbc-mysql', Scope.RUNTIME)
+        !verifier.hasDependency('com.mysql', 'mysql-connector-j', Scope.RUNTIME)
+        !verifier.hasDependency('io.micronaut.sql', 'micronaut-jdbc-hikari')
+    }
+
     void "test dependencies are present for gradle with TestContainers and #featureClassName"(Class<DatabaseDriverFeature> db) {
         when:
         def feature = beanContext.getBean(db)


### PR DESCRIPTION
We added support while ago https://github.com/micronaut-projects/micronaut-r2dbc/pull/369 for new r2dbc mysql library that should replace the old one and now we should use it as default in starter