### PR TITLE
Switch to new Gradle Shadow plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:2.17.1"
     implementation "io.sdkman:gradle-sdkvendor-plugin:3.0.0"
     implementation "org.asciidoctor:asciidoctor-gradle-jvm:2.4.0"
-    implementation "com.github.johnrengelman:shadow:8.1.1"
+    implementation "com.gradleup.shadow:shadow-gradle-plugin:8.3.2"
     implementation "com.microsoft.azure:azure-functions-gradle-plugin:1.16.1"
 }
 

--- a/buildSrc/src/main/groovy/io.micronaut.internal.build.starter-cli-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.internal.build.starter-cli-module.gradle
@@ -2,7 +2,7 @@ plugins {
     id "io.micronaut.internal.starter.published-module"
     id "io.micronaut.internal.starter.convention"
     id "application"
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "io.micronaut.starter.rocker"
     id "io.sdkman.vendors"
 }

--- a/gradle/templates.versions.toml
+++ b/gradle/templates.versions.toml
@@ -34,7 +34,7 @@ gradle-enterprise = "3.18.1"
 gradle-enterprise-maven-custom-data = "1.13"
 gradle-enterprise-maven-extension = "1.22.1"
 gradle-jrebel-plugin = "1.1.10"
-gradle-shadow-plugin = "8.1.1"
+gradle-shadow-plugin = "8.3.2"
 jib-gradle-plugin = "2.8.0"
 jobrunr = "6.3.5"
 jruby = "9.4.5.0"
@@ -106,7 +106,7 @@ gradle-enterprise = { module = "com.gradle:gradle-enterprise-gradle-plugin", ver
 gradle-enterprise-maven = { module = "com.gradle:gradle-enterprise-maven-extension", version.ref = "gradle-enterprise-maven-extension" }
 gradle-enterprise-maven-custom-data = { module = "com.gradle:common-custom-user-data-maven-extension", version.ref = "gradle-enterprise-maven-custom-data" }
 gradle-jrebel-plugin = { module = "gradle.plugin.org.zeroturnaround:gradle-jrebel-plugin", version.ref = "gradle-jrebel-plugin" }
-gradle-shadow-plugin = { module = "gradle.plugin.com.github.johnrengelman:shadow", version.ref = "gradle-shadow-plugin" }
+gradle-shadow-plugin = { module = "gradle.plugin.com.gradleup.shadow:shadow-gradle-plugin", version.ref = "gradle-shadow-plugin" }
 jib-gradle-plugin = { module = "gradle.plugin.com.google.cloud.tools:jib-gradle-plugin", version.ref = "jib-gradle-plugin" }
 jobrunr-micronaut = { module = "org.jobrunr:jobrunr-micronaut-feature", version.ref = "jobrunr" }
 jruby = { module = "org.jruby:jruby", version.ref = "jruby" }

--- a/gradle/templates.versions.toml
+++ b/gradle/templates.versions.toml
@@ -106,7 +106,7 @@ gradle-enterprise = { module = "com.gradle:gradle-enterprise-gradle-plugin", ver
 gradle-enterprise-maven = { module = "com.gradle:gradle-enterprise-maven-extension", version.ref = "gradle-enterprise-maven-extension" }
 gradle-enterprise-maven-custom-data = { module = "com.gradle:common-custom-user-data-maven-extension", version.ref = "gradle-enterprise-maven-custom-data" }
 gradle-jrebel-plugin = { module = "gradle.plugin.org.zeroturnaround:gradle-jrebel-plugin", version.ref = "gradle-jrebel-plugin" }
-gradle-shadow-plugin = { module = "gradle.plugin.com.gradleup.shadow:shadow-gradle-plugin", version.ref = "gradle-shadow-plugin" }
+gradle-shadow-plugin = { module = "com.gradleup.shadow:shadow-gradle-plugin", version.ref = "gradle-shadow-plugin" }
 jib-gradle-plugin = { module = "gradle.plugin.com.google.cloud.tools:jib-gradle-plugin", version.ref = "jib-gradle-plugin" }
 jobrunr-micronaut = { module = "org.jobrunr:jobrunr-micronaut-feature", version.ref = "jobrunr" }
 jruby = { module = "org.jruby:jruby", version.ref = "jruby" }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/other/ShadePlugin.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/other/ShadePlugin.java
@@ -77,10 +77,10 @@ public class ShadePlugin implements DefaultFeature, BuildPluginFeature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         if (generatorContext.getBuildTool().isGradle()) {
-            generatorContext.addHelpLink("Shadow Gradle Plugin", "https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow");
+            generatorContext.addHelpLink("Shadow Gradle Plugin", "https://plugins.gradle.org/plugin/com.gradleup.shadow");
             GradlePlugin.Builder builder = GradlePlugin.builder()
-                    .id("com.github.johnrengelman.shadow")
-                    .lookupArtifactId("shadow");
+                    .id("com.gradleup.shadow")
+                    .lookupArtifactId("shadow-gradle-plugin");
 
             generatorContext.addBuildPlugin(builder.build());
         }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureCloudFunctionSpec.groovy
@@ -69,7 +69,7 @@ class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOu
         build.contains('os = "linux"')
         !build.contains('implementation "io.micronaut:micronaut-http-server-netty"')
         !build.contains('implementation "io.micronaut:micronaut-http-client"')
-        !build.contains('"com.github.johnrengelman.shadow"')
+        !build.contains('"com.gradleup.shadow"')
         !build.contains('shadowJar')
         readme?.contains("Micronaut and Azure Function")
         output.containsKey("host.json")
@@ -108,7 +108,7 @@ class AzureCloudFunctionSpec extends ApplicationContextSpec implements CommandOu
         build.contains('os = "linux"')
         !build.contains('implementation "io.micronaut:micronaut-http-server-netty"')
         !build.contains('implementation "io.micronaut:micronaut-http-client"')
-        !build.contains('"com.github.johnrengelman.shadow"')
+        !build.contains('"com.gradleup.shadow"')
         !build.contains('shadowJar')
 
         when:

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/other/ShadePluginSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/other/ShadePluginSpec.groovy
@@ -17,13 +17,13 @@ class ShadePluginSpec extends ApplicationContextSpec  implements CommandOutputFi
 
         then:
         readme
-        readme.contains("[Shadow Gradle Plugin](https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow)")
+        readme.contains("[Shadow Gradle Plugin](https://plugins.gradle.org/plugin/com.gradleup.shadow)")
     }
 
     @Unroll
     void 'test shade plugin is applied by default for Gradle and language=#language type=#applicationType'(Language language, ApplicationType applicationType) {
         given:
-        String pluginId = 'com.github.johnrengelman.shadow'
+        String pluginId = 'com.gradleup.shadow'
         when:
         String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
                 .language(language)

--- a/starter-core/src/test/groovy/io/micronaut/starter/springboot/SpringBootStarterSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/springboot/SpringBootStarterSpec.groovy
@@ -30,7 +30,7 @@ class SpringBootStarterSpec extends ApplicationContextSpec implements CommandOut
         verifier.hasBuildPlugin("io.spring.dependency-management")
         !verifier.hasBuildPlugin("io.micronaut.application")
         !verifier.hasBuildPlugin("io.micronaut.library")
-        !verifier.hasBuildPlugin("com.github.johnrengelman.shadow")
+        !verifier.hasBuildPlugin("com.gradleup.shadow")
         verifier.hasDependency("org.springframework.boot", "spring-boot-starter", Scope.COMPILE)
         verifier.hasDependency("org.springframework.boot", "spring-boot-starter-test", Scope.TEST)
         template.contains("mavenCentral()")

--- a/starter-gcp-function/build.gradle
+++ b/starter-gcp-function/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "io.micronaut.internal.starter.convention"
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "application"
 }
 

--- a/starter-web-netty/build.gradle
+++ b/starter-web-netty/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "io.micronaut.internal.starter.convention"
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "io.micronaut.crac"
     id "io.micronaut.application"
 }


### PR DESCRIPTION
Previously this plugin was developed by johnrengelman and published under the ID com.github.johnrengelman.shadow before maintenance was transferred to the GradleUp organization to ensure future development

Functionally it's identical, but it doesn't have deprecation warnings like the old one started having

https://github.com/GradleUp/shadow
https://plugins.gradle.org/plugin/com.gradleup.shadow
https://gradleup.com/shadow/