### PR TITLE
Set `amd64` macos runner

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,11 @@
       "matchUpdateTypes": ["patch"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    },
+    {
+      "matchDatasources": ["github-runner"],
+      "matchPackageNames": ["macos"],
+      "enabled": false
     }
   ]
 }

--- a/.github/workflows/mn-macos-snapshot.yml
+++ b/.github/workflows/mn-macos-snapshot.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   intel:
     name: Builds OS X Intel Native CLI
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
       - name: "⬇ Checkout the repository"
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
           asset_content_type: application/zip
   macos:
     name: Release OS X Intel Native CLI
-    runs-on: macos-14
+    runs-on: macos-13
     needs: [build]
     steps:
       - name: Checkout repository


### PR DESCRIPTION
solve https://github.com/micronaut-projects/micronaut-starter/issues/2673

- set the runner to `macos-13`.
    - `macos-13` uses `amd64`. [standard-github-hosted-runners-for-public-repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
- Configure Renovate not to update the `amd64` mac runner.

### References
- https://github.com/micronaut-projects/micronaut-starter/issues/2673
- https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
- https://docs.renovatebot.com/configuration-options/#packagerules
- https://docs.renovatebot.com/modules/datasource/github-runners/
- https://github.com/micronaut-projects/micronaut-starter/pull/2593