### PR TITLE
For Maven, if a dependency with runtime and test, a compile dependency is added

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Dependency.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/Dependency.java
@@ -210,6 +210,20 @@ public final class Dependency implements Coordinate {
         return annotationProcessorPriority;
     }
 
+    public static Dependency of(Dependency dep, Scope scope) {
+        return new Dependency(scope,
+                dep.getGroupId(),
+                dep.getArtifactId(),
+                dep.getVersion(),
+                dep.getVersionProperty(),
+                dep.requiresLookup(),
+                dep.isAnnotationProcessorPriority(),
+                dep.getOrder(),
+                dep.isPom(),
+                dep.getExclusions(),
+                dep.getSubstitutions());
+    }
+
     public static class Builder {
 
         private Scope scope;

--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/DependencyContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/DependencyContext.java
@@ -75,8 +75,10 @@ public interface DependencyContext {
         dependenciesInTestClasspathWithoutDuplicates.removeIf(testDep -> {
             MavenCoordinate test = new MavenCoordinate(testDep.getGroupId(), testDep.getArtifactId(), testDep.getVersion());
             return dependenciesInMainClasspathWithoutDuplicates.stream()
-                    .filter(mainDep -> (mainDep.getScope().getPhases().contains(RUNTIME) && mainDep.getScope().getPhases().contains(COMPILATION)))
-                    .anyMatch(mainDep -> {
+                    .filter(mainDep ->
+                            (buildTool == BuildTool.MAVEN && mainDep.getScope().getPhases().contains(RUNTIME)) ||
+                            (mainDep.getScope().getPhases().contains(RUNTIME) && mainDep.getScope().getPhases().contains(COMPILATION))
+                    ).anyMatch(mainDep -> {
                         MavenCoordinate main = new MavenCoordinate(mainDep.getGroupId(), mainDep.getArtifactId(), mainDep.getVersion());
                         return main.equals(test);
                     });
@@ -84,37 +86,7 @@ public interface DependencyContext {
         List<Dependency> result = new ArrayList<>(dependenciesNotInMainOrTestClasspath);
         result.addAll(dependenciesInMainClasspathWithoutDuplicates);
         result.addAll(dependenciesInTestClasspathWithoutDuplicates);
-        result = result.stream().sorted(Dependency.COMPARATOR).toList();
-        return filteredMavenRuntimeTestDependencies(result, buildTool);
-    }
-
-    private static List<Dependency> filteredMavenRuntimeTestDependencies(List<Dependency> dependencies, BuildTool buildTool) {
-        if (buildTool.isGradle()) {
-            return dependencies;
-        }
-        List<Dependency> result = new ArrayList<>();
-
-        Set<MavenCoordinate> coordinatesAdded = new HashSet<>();
-        for (Dependency d : dependencies) {
-            MavenCoordinate coord = new MavenCoordinate(d.getGroupId(), d.getArtifactId(), d.getVersion());
-            if (d.getScope() == Scope.RUNTIME &&
-                    dependencies.stream().anyMatch(dep ->
-                            dep.getScope() == Scope.TEST &&
-                                    dep.getGroupId().equals(d.getGroupId()) &&
-                                    dep.getArtifactId().equals(d.getArtifactId()))) {
-                result.add(Dependency.of(d, Scope.COMPILE));
-                coordinatesAdded.add(coord);
-            } else if (d.getScope() == Scope.TEST &&
-                    d.getGroupId().equals(d.getGroupId()) &&
-                    d.getArtifactId().equals(d.getArtifactId())) {
-                if (!coordinatesAdded.contains(coord)) {
-                    result.add(d);
-                }
-            } else {
-                result.add(d);
-            }
-        }
-        return result;
+        return result.stream().sorted(Dependency.COMPARATOR).toList();
     }
 
     private static List<Dependency> filterDuplicates(List<Dependency> dependencies) {

--- a/starter-core/src/main/java/io/micronaut/starter/build/dependencies/DependencyContext.java
+++ b/starter-core/src/main/java/io/micronaut/starter/build/dependencies/DependencyContext.java
@@ -19,11 +19,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.Language;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Predicate;
 
 import static io.micronaut.starter.build.dependencies.Phase.COMPILATION;
@@ -88,7 +84,37 @@ public interface DependencyContext {
         List<Dependency> result = new ArrayList<>(dependenciesNotInMainOrTestClasspath);
         result.addAll(dependenciesInMainClasspathWithoutDuplicates);
         result.addAll(dependenciesInTestClasspathWithoutDuplicates);
-        return result.stream().sorted(Dependency.COMPARATOR).toList();
+        result = result.stream().sorted(Dependency.COMPARATOR).toList();
+        return filteredMavenRuntimeTestDependencies(result, buildTool);
+    }
+
+    private static List<Dependency> filteredMavenRuntimeTestDependencies(List<Dependency> dependencies, BuildTool buildTool) {
+        if (buildTool.isGradle()) {
+            return dependencies;
+        }
+        List<Dependency> result = new ArrayList<>();
+
+        Set<MavenCoordinate> coordinatesAdded = new HashSet<>();
+        for (Dependency d : dependencies) {
+            MavenCoordinate coord = new MavenCoordinate(d.getGroupId(), d.getArtifactId(), d.getVersion());
+            if (d.getScope() == Scope.RUNTIME &&
+                    dependencies.stream().anyMatch(dep ->
+                            dep.getScope() == Scope.TEST &&
+                                    dep.getGroupId().equals(d.getGroupId()) &&
+                                    dep.getArtifactId().equals(d.getArtifactId()))) {
+                result.add(Dependency.of(d, Scope.COMPILE));
+                coordinatesAdded.add(coord);
+            } else if (d.getScope() == Scope.TEST &&
+                    d.getGroupId().equals(d.getGroupId()) &&
+                    d.getArtifactId().equals(d.getArtifactId())) {
+                if (!coordinatesAdded.contains(coord)) {
+                    result.add(d);
+                }
+            } else {
+                result.add(d);
+            }
+        }
+        return result;
     }
 
     private static List<Dependency> filterDuplicates(List<Dependency> dependencies) {

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/FeatureWithDuplicatesSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/FeatureWithDuplicatesSpec.groovy
@@ -32,7 +32,7 @@ class FeatureWithDuplicatesSpec extends BeanContextSpec implements CommandOutput
             assert verifier.hasDependency("org.seleniumhq.selenium", "selenium-firefox-driver", Scope.RUNTIME)
             assert verifier.hasDependency("org.seleniumhq.selenium", "selenium-firefox-driver", Scope.TEST)
         } else if(buildTool == BuildTool.MAVEN) {
-            assert verifier.hasDependency("org.seleniumhq.selenium", "selenium-firefox-driver", Scope.COMPILE)
+            assert verifier.hasDependency("org.seleniumhq.selenium", "selenium-firefox-driver", Scope.RUNTIME)
         }
 
         where:

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/FeatureWithDuplicatesSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/dependencies/FeatureWithDuplicatesSpec.groovy
@@ -28,8 +28,12 @@ class FeatureWithDuplicatesSpec extends BeanContextSpec implements CommandOutput
         verifier.hasDependency("org.gebish", "geb-core", Scope.COMPILE)
 
         and: 'for a dependency in runtime and test, both runtime and test should be added'
-        verifier.hasDependency("org.seleniumhq.selenium", "selenium-firefox-driver", Scope.RUNTIME)
-        verifier.hasDependency("org.seleniumhq.selenium", "selenium-firefox-driver", Scope.TEST)
+        if (buildTool.isGradle()) {
+            assert verifier.hasDependency("org.seleniumhq.selenium", "selenium-firefox-driver", Scope.RUNTIME)
+            assert verifier.hasDependency("org.seleniumhq.selenium", "selenium-firefox-driver", Scope.TEST)
+        } else if(buildTool == BuildTool.MAVEN) {
+            assert verifier.hasDependency("org.seleniumhq.selenium", "selenium-firefox-driver", Scope.COMPILE)
+        }
 
         where:
         [language, buildTool] << [Language.values(), BuildTool.values()].combinations()

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/maven/MavenDependencySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/maven/MavenDependencySpec.groovy
@@ -30,14 +30,27 @@ class MavenDependencySpec  extends BeanContextSpec implements CommandOutputFixtu
         dependencies == List.of(
                 Dependency.builder().scope(Scope.COMPILE).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build())
 
-        dependencyContext.removeDuplicates(List.of(
+        when:
+        dependencies = dependencyContext.removeDuplicates(List.of(
+                Dependency.builder().scope(Scope.TEST).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build(),
+                Dependency.builder().scope(Scope.RUNTIME).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build(),
+        ), Language.JAVA, BuildTool.GRADLE)
+
+        then:
+        dependencies == List.of(
+                Dependency.builder().scope(Scope.RUNTIME).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build(),
+                Dependency.builder().scope(Scope.TEST).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build(),
+        )
+
+        when:
+        dependencies = dependencyContext.removeDuplicates(List.of(
                 Dependency.builder().scope(Scope.TEST).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build(),
                 Dependency.builder().scope(Scope.RUNTIME).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build(),
         ), Language.JAVA, BuildTool.MAVEN)
 
         then:
         dependencies == List.of(
-                Dependency.builder().scope(Scope.COMPILE).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build())
+                Dependency.builder().scope(Scope.RUNTIME).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build())
 
         when:
         dependencies = dependencyContext.removeDuplicates(List.of(

--- a/starter-core/src/test/groovy/io/micronaut/starter/build/maven/MavenDependencySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/build/maven/MavenDependencySpec.groovy
@@ -1,0 +1,52 @@
+package io.micronaut.starter.build.maven
+
+import io.micronaut.starter.BeanContextSpec
+import io.micronaut.starter.application.generator.DependencyContextImpl
+import io.micronaut.starter.build.dependencies.CoordinateResolver
+import io.micronaut.starter.build.dependencies.Dependency
+import io.micronaut.starter.build.dependencies.DependencyContext
+import io.micronaut.starter.build.dependencies.Scope
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+
+class MavenDependencySpec  extends BeanContextSpec implements CommandOutputFixture {
+
+    public static final String ARTIFACT_ID_LOGBACK_CLASSIC = "logback-classic"
+    public static final String GROUP_ID_LOGBACK = "ch.qos.logback"
+
+    void "maven dependency in test and runtime should be only in compile"() {
+        given:
+        CoordinateResolver coordinateResolver = beanContext.getBean(CoordinateResolver)
+        DependencyContext dependencyContext = new DependencyContextImpl(coordinateResolver)
+
+        when:
+        List<Dependency> dependencies = dependencyContext.removeDuplicates(List.of(
+                Dependency.builder().scope(Scope.COMPILE).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build(),
+                Dependency.builder().scope(Scope.RUNTIME).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build(),
+        ), Language.JAVA, BuildTool.MAVEN)
+
+        then:
+        dependencies == List.of(
+                Dependency.builder().scope(Scope.COMPILE).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build())
+
+        dependencyContext.removeDuplicates(List.of(
+                Dependency.builder().scope(Scope.TEST).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build(),
+                Dependency.builder().scope(Scope.RUNTIME).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build(),
+        ), Language.JAVA, BuildTool.MAVEN)
+
+        then:
+        dependencies == List.of(
+                Dependency.builder().scope(Scope.COMPILE).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build())
+
+        when:
+        dependencies = dependencyContext.removeDuplicates(List.of(
+                Dependency.builder().scope(Scope.COMPILE).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build(),
+                Dependency.builder().scope(Scope.RUNTIME).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build(),
+        ), Language.JAVA, BuildTool.MAVEN)
+
+        then:
+        dependencies == List.of(
+                Dependency.builder().scope(Scope.COMPILE).groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).build())
+    }
+}

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/LogbackInTestAndRuntimeSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/LogbackInTestAndRuntimeSpec.groovy
@@ -35,8 +35,7 @@ class LogbackInTestAndRuntimeSpec  extends ApplicationContextSpec implements Com
         BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, language, template)
 
         then:
-        verifier.hasDependency(GROUP_ID_LOGBACK, ARTIFACT_ID_LOGBACK_CLASSIC, Scope.COMPILE)
-        !verifier.hasDependency(GROUP_ID_LOGBACK, ARTIFACT_ID_LOGBACK_CLASSIC, Scope.RUNTIME)
+        verifier.hasDependency(GROUP_ID_LOGBACK, ARTIFACT_ID_LOGBACK_CLASSIC, Scope.RUNTIME)
         !verifier.hasDependency(GROUP_ID_LOGBACK, ARTIFACT_ID_LOGBACK_CLASSIC, Scope.TEST)
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/LogbackInTestAndRuntimeSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/LogbackInTestAndRuntimeSpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.starter.feature.logging
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.starter.ApplicationContextSpec
+import io.micronaut.starter.BuildBuilder
+import io.micronaut.starter.application.ApplicationType
+import io.micronaut.starter.application.generator.GeneratorContext
+import io.micronaut.starter.build.BuildTestUtil
+import io.micronaut.starter.build.BuildTestVerifier
+import io.micronaut.starter.build.dependencies.Dependency
+import io.micronaut.starter.build.dependencies.Scope
+import io.micronaut.starter.feature.Feature
+import io.micronaut.starter.fixture.CommandOutputFixture
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.Language
+import jakarta.inject.Singleton
+
+class LogbackInTestAndRuntimeSpec  extends ApplicationContextSpec implements CommandOutputFixture {
+    private static final String ARTIFACT_ID_LOGBACK_CLASSIC = "logback-classic"
+    private static final String GROUP_ID_LOGBACK = "ch.qos.logback"
+
+    Map<String, Object> getConfiguration() {
+        return super.getConfiguration() + ["spec.name": "LogbackInTestAndRuntimeSpec"]
+    }
+
+    void "compile if runtime and test dependency"() {
+        given:
+        BuildTool buildTool = BuildTool.MAVEN
+        Language language = Language.JAVA
+        when:
+        String template = new BuildBuilder(beanContext, buildTool)
+                .language(language)
+                .features(["test-logback"])
+                .render()
+        BuildTestVerifier verifier = BuildTestUtil.verifier(buildTool, language, template)
+
+        then:
+        verifier.hasDependency(GROUP_ID_LOGBACK, ARTIFACT_ID_LOGBACK_CLASSIC, Scope.COMPILE)
+        !verifier.hasDependency(GROUP_ID_LOGBACK, ARTIFACT_ID_LOGBACK_CLASSIC, Scope.RUNTIME)
+        !verifier.hasDependency(GROUP_ID_LOGBACK, ARTIFACT_ID_LOGBACK_CLASSIC, Scope.TEST)
+    }
+
+    @Requires(property = "spec.name", value = "LogbackInTestAndRuntimeSpec")
+    @Singleton
+    static class TestLogback implements Feature {
+
+        @Override
+        String getName() {
+            return "test-logback"
+        }
+
+        @Override
+        String getTitle() {
+            return "Test Logback"
+        }
+
+        @Override
+        void apply(GeneratorContext generatorContext) {
+            generatorContext.addDependency(Dependency.builder().groupId(GROUP_ID_LOGBACK).artifactId(ARTIFACT_ID_LOGBACK_CLASSIC).scope(Scope.TEST).build())
+        }
+
+        @Override
+        boolean supports(ApplicationType applicationType) {
+            true
+        }
+    }
+}


### PR DESCRIPTION
if a dependency is added to the scopes runtime and test in maven. The dependency should be in compile only for maven.

We should not generate this: 

```xml
<dependency>
  <groupId>ch.qos.logback</groupId>
  <artifactId>logback-classic</artifactId>
  <scope>runtime</scope>
</dependency>
<dependency>
  <groupId>ch.qos.logback</groupId>
  <artifactId>logback-classic</artifactId>
  <scope>test</scope>
</dependency>
```

But this: 

```xml
<dependency>
  <groupId>ch.qos.logback</groupId>
  <artifactId>logback-classic</artifactId>
  <scope>compile</scope>
</dependency>
```