### PR TITLE
fix azure functions dependency scope

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
@@ -55,6 +55,13 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
 
     public static final String GROUP_ID_COM_MICROSOFT_AZURE_FUNCTIONS = "com.microsoft.azure.functions";
     public static final String ARTIFACT_ID_AZURE_FUNCTIONS_JAVA_LIBRARY = "azure-functions-java-library";
+    public static final String AZURE_FUNCTIONS_EXTENSION_VERSION = "~4";
+
+    public static final Dependency DEPENDENCY_AZURE_FUNCTIONS_JAVA_LIBRARY = Dependency.builder()
+            .groupId(GROUP_ID_COM_MICROSOFT_AZURE_FUNCTIONS)
+            .artifactId(ARTIFACT_ID_AZURE_FUNCTIONS_JAVA_LIBRARY)
+            .compile()
+            .build();
 
     public static final String NAME = "azure-function";
     private final CoordinateResolver coordinateResolver;
@@ -103,7 +110,7 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
             String mavenPluginArtifactId = "azure-functions-maven-plugin";
             generatorContext.addBuildPlugin(MavenPlugin.builder()
                     .artifactId(mavenPluginArtifactId)
-                    .extension(new RockerWritable(azureFunctionMavenPlugin.template()))
+                    .extension(new RockerWritable(azureFunctionMavenPlugin.template(AZURE_FUNCTIONS_EXTENSION_VERSION)))
                     .build());
             BuildProperties props = generatorContext.getBuildProperties();
             coordinateResolver.resolve(mavenPluginArtifactId)
@@ -112,6 +119,7 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
             props.put("functionResourceGroup", "java-functions-group");
             props.put("functionAppRegion", "westus");
             props.put("functionRuntimeOs", "windows");
+            props.put("functionAppServicePlanName", "java-functions-app-service-plan");
             javaVersionValue(generatorContext).ifPresent(value -> props.put("functionRuntimeJavaVersion", value));
             props.put("stagingDirectory", "${project.build.directory}/azure-functions/${functionAppName}");
         }
@@ -187,17 +195,6 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
     }
 
     protected void addDependencies(GeneratorContext generatorContext) {
-        addAzureFunctionsJavaLibraryDependency(generatorContext);
-    }
-
-    protected void addAzureFunctionsJavaLibraryDependency(GeneratorContext generatorContext) {
-        Dependency.Builder builder = Dependency.builder()
-                .groupId(GROUP_ID_COM_MICROSOFT_AZURE_FUNCTIONS)
-                .artifactId(ARTIFACT_ID_AZURE_FUNCTIONS_JAVA_LIBRARY);
-        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
-            generatorContext.addDependency(builder.developmentOnly());
-        } else if (generatorContext.getBuildTool().isGradle()) {
-            generatorContext.addDependency(builder.compile());
-        }
+        generatorContext.addDependency(DEPENDENCY_AZURE_FUNCTIONS_JAVA_LIBRARY);
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionMavenPlugin.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/azure/template/azureFunctionMavenPlugin.rocker.raw
@@ -1,3 +1,4 @@
+@args(String version)
 <plugin>
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-functions-maven-plugin</artifactId>
@@ -8,7 +9,7 @@
     <!-- function app resource group -->
     <resourceGroup>${functionResourceGroup}</resourceGroup>
     <!-- function app service plan name -->
-    <appServicePlanName>java-functions-app-service-plan</appServicePlanName>
+    <appServicePlanName>${functionAppServicePlanName}</appServicePlanName>
     <!-- function app region-->
     <!-- refers https://github.com/microsoft/azure-maven-plugins/wiki/Azure-Functions:-Configuration-Details#supported-regions for all valid values -->
     <region>${functionAppRegion}</region>
@@ -26,7 +27,7 @@
     <appSettings>
       <property>
         <name>FUNCTIONS_EXTENSION_VERSION</name>
-        <value>~3</value>
+        <value>@version</value>
       </property>
     </appSettings>
   </configuration>

--- a/starter-core/src/main/java/io/micronaut/starter/feature/function/template/http/httpFunctionJavaController.rocker.raw
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/function/template/http/httpFunctionJavaController.rocker.raw
@@ -10,7 +10,10 @@ package @project.getPackageName();
 }
 
 
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.MediaType;
 @if (useSerde) {

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureHttpFunctionSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/function/azure/AzureHttpFunctionSpec.groovy
@@ -7,7 +7,11 @@ import io.micronaut.starter.build.BuildTestUtil
 import io.micronaut.starter.build.BuildTestVerifier
 import io.micronaut.starter.build.dependencies.Scope
 import io.micronaut.starter.fixture.CommandOutputFixture
-import io.micronaut.starter.options.*
+import io.micronaut.starter.options.BuildTool
+import io.micronaut.starter.options.JdkVersion
+import io.micronaut.starter.options.Language
+import io.micronaut.starter.options.Options
+import io.micronaut.starter.options.TestFramework
 
 class AzureHttpFunctionSpec extends BeanContextSpec  implements CommandOutputFixture {
 
@@ -77,13 +81,12 @@ class AzureHttpFunctionSpec extends BeanContextSpec  implements CommandOutputFix
         if (buildTool.isGradle()) {
             assert !verifier.hasDependency("io.micronaut.azure", "micronaut-azure-function-http", Scope.COMPILE)
             assert !verifier.hasDependency("io.micronaut.azure", "micronaut-azure-function-http-test", Scope.TEST)
-            assert verifier.hasDependency("com.microsoft.azure.functions", "azure-functions-java-library", Scope.COMPILE)
-
         } else if (buildTool == BuildTool.MAVEN) {
             assert verifier.hasDependency("io.micronaut.azure", "micronaut-azure-function-http", Scope.COMPILE)
             assert verifier.hasDependency("io.micronaut.azure", "micronaut-azure-function-http-test", Scope.TEST)
-            assert verifier.hasDependency("com.microsoft.azure.functions", "azure-functions-java-library", Scope.DEVELOPMENT_ONLY)
         }
+
+        assert verifier.hasDependency("com.microsoft.azure.functions", "azure-functions-java-library", Scope.COMPILE)
 
         where:
         [language, buildTool] << [Language.values().toList(), BuildTool.values().toList()].combinations()


### PR DESCRIPTION
- Set the `azure-functions-java-library` Maven dependency scope to `compile` so it’s packaged into the build and available at runtime, preventing `NoClassDefFoundError`.
