### PR TITLE
Fix gradle runner: feature mn update

### DIFF
--- a/starter-cli/src/main/java/io/micronaut/starter/cli/util/openrewrite/gradle/GradleOpenRewriteRecipesRunner.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/util/openrewrite/gradle/GradleOpenRewriteRecipesRunner.java
@@ -30,9 +30,7 @@ import java.util.ArrayList;
 import java.io.InputStream;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 
 @Named("gradle")
@@ -58,11 +56,6 @@ public class GradleOpenRewriteRecipesRunner implements OpenRewriteRecipesRunner 
                 Files.writeString(initScript, new String(is.readAllBytes(), StandardCharsets.UTF_8), StandardCharsets.UTF_8);
             }
 
-            Map<String, String> sysProps = systemProperties(configuration);
-            List<String> args = new ArrayList<>();
-            args.add("-Duser.dir=" + folder.getAbsolutePath());
-            args.add("--init-script");
-            args.add(initScript.toString());
 
             List<String> cmd = new ArrayList<>();
             File wrapper = new File(folder, System.getProperty("os.name").toLowerCase().contains("win") ? "gradlew.bat" : "gradlew");
@@ -123,18 +116,6 @@ public class GradleOpenRewriteRecipesRunner implements OpenRewriteRecipesRunner 
         }
     }
 
-    private Map<String, String> systemProperties(OpenRewriteConfiguration configuration) {
-        Map<String, String> systemProperties = new HashMap<>();
-        Map<String, Object> configurationSystemProperties = configuration.getSystemProperties();
-        for (String k : configurationSystemProperties.keySet()) {
-            Object value = configurationSystemProperties.get(k);
-            if (value != null) {
-                systemProperties.put(k, value.toString());
-            }
-
-        }
-        return systemProperties;
-    }
 
     private void pump(InputStream in, Consumer<String> consumer) {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/util/openrewrite/gradle/GradleOpenRewriteRecipesRunner.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/util/openrewrite/gradle/GradleOpenRewriteRecipesRunner.java
@@ -16,6 +16,7 @@
 package io.micronaut.starter.cli.util.openrewrite.gradle;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.OperatingSystem;
 import io.micronaut.starter.cli.util.openrewrite.OpenRewriteConfiguration;
 import io.micronaut.starter.cli.util.openrewrite.OpenRewriteRecipesRunner;
 import jakarta.inject.Named;
@@ -58,9 +59,10 @@ public class GradleOpenRewriteRecipesRunner implements OpenRewriteRecipesRunner 
 
 
             List<String> cmd = new ArrayList<>();
-            File wrapper = new File(folder, System.getProperty("os.name").toLowerCase().contains("win") ? "gradlew.bat" : "gradlew");
+            boolean isWindows = configuration.operatingSystem() == OperatingSystem.WINDOWS;
+            File wrapper = new File(folder, isWindows ? "gradlew.bat" : "gradlew");
             if (wrapper.isFile()) {
-                if (wrapper.getName().endsWith(".bat")) {
+                if (isWindows) {
                     cmd.add("cmd");
                     cmd.add("/c");
                     cmd.add(wrapper.getAbsolutePath());
@@ -69,7 +71,7 @@ public class GradleOpenRewriteRecipesRunner implements OpenRewriteRecipesRunner 
                     cmd.add(wrapper.getAbsolutePath());
                 }
             } else {
-                if (System.getProperty("os.name").toLowerCase().contains("win")) {
+                if (isWindows) {
                     cmd.add("cmd");
                     cmd.add("/c");
                     cmd.add("gradle.bat");

--- a/starter-cli/src/main/java/io/micronaut/starter/cli/util/openrewrite/gradle/GradleOpenRewriteRecipesRunner.java
+++ b/starter-cli/src/main/java/io/micronaut/starter/cli/util/openrewrite/gradle/GradleOpenRewriteRecipesRunner.java
@@ -16,13 +16,12 @@
 package io.micronaut.starter.cli.util.openrewrite.gradle;
 
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.starter.cli.util.openrewrite.ConsumerOutputStream;
 import io.micronaut.starter.cli.util.openrewrite.OpenRewriteConfiguration;
 import io.micronaut.starter.cli.util.openrewrite.OpenRewriteRecipesRunner;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
-import org.gradle.tooling.GradleConnector;
-import org.gradle.tooling.ProjectConnection;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -65,16 +64,51 @@ public class GradleOpenRewriteRecipesRunner implements OpenRewriteRecipesRunner 
             args.add("--init-script");
             args.add(initScript.toString());
 
-            try (ProjectConnection connection = GradleConnector.newConnector()
-                    .forProjectDirectory(folder)
-                    .connect()) {
-                connection.newBuild()
-                        .forTasks(TASK_REWRITE_RUN)
-                        .withArguments(args.toArray(new String[0]))
-                        .withSystemProperties(sysProps)
-                        .setStandardOutput(new ConsumerOutputStream(out))
-                        .setStandardError(new ConsumerOutputStream(err))
-                        .run();
+            List<String> cmd = new ArrayList<>();
+            File wrapper = new File(folder, System.getProperty("os.name").toLowerCase().contains("win") ? "gradlew.bat" : "gradlew");
+            if (wrapper.isFile()) {
+                if (wrapper.getName().endsWith(".bat")) {
+                    cmd.add("cmd");
+                    cmd.add("/c");
+                    cmd.add(wrapper.getAbsolutePath());
+                } else {
+                    wrapper.setExecutable(true);
+                    cmd.add(wrapper.getAbsolutePath());
+                }
+            } else {
+                if (System.getProperty("os.name").toLowerCase().contains("win")) {
+                    cmd.add("cmd");
+                    cmd.add("/c");
+                    cmd.add("gradle.bat");
+                } else {
+                    cmd.add("gradle");
+                }
+            }
+            cmd.add("--init-script");
+            cmd.add(initScript.toString());
+            cmd.addAll(configuration.getSystemPropertiesList());
+            cmd.add(TASK_REWRITE_RUN);
+
+            ProcessBuilder pb = new ProcessBuilder(cmd);
+            pb.directory(folder);
+            Process process = pb.start();
+
+            Thread outPump = new Thread(() -> pump(process.getInputStream(), out));
+            Thread errPump = new Thread(() -> pump(process.getErrorStream(), err));
+            outPump.start();
+            errPump.start();
+
+            int exit;
+            try {
+                exit = process.waitFor();
+                outPump.join();
+                errPump.join();
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(ie);
+            }
+            if (exit != 0) {
+                throw new IllegalStateException("Gradle exited with code " + exit + " while running " + TASK_REWRITE_RUN);
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -100,5 +134,16 @@ public class GradleOpenRewriteRecipesRunner implements OpenRewriteRecipesRunner 
 
         }
         return systemProperties;
+    }
+
+    private void pump(InputStream in, Consumer<String> consumer) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                consumer.accept(line);
+            }
+        } catch (IOException ioe) {
+            consumer.accept(ioe.getMessage() != null ? ioe.getMessage() : ioe.toString());
+        }
     }
 }


### PR DESCRIPTION
Replaced Gradle Tooling API usage (GradleConnector/ProjectConnection) with external Gradle execution via ProcessBuilder for native-image compatibility.
