### PR TITLE
enable agora related tests

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/AgoraPulseFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/agorapulse/AgoraPulseFeature.java
@@ -31,7 +31,7 @@ public interface AgoraPulseFeature extends MicronautCommunityFeature {
 
     @Override
     default MicronautVersion builtWithMicronautVersion() {
-        return MicronautVersion.THREE;
+        return MicronautVersion.FOUR;
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/console/ConsoleSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/console/ConsoleSpec.groovy
@@ -7,7 +7,6 @@ import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Feature
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import spock.lang.PendingFeature
 
 class ConsoleSpec extends ApplicationContextSpec {
 
@@ -42,7 +41,6 @@ class ConsoleSpec extends ApplicationContextSpec {
         }
     }
 
-    @PendingFeature(reason = "agora community features do not support Micronaut Framework 4 yet")
     void "#buildTool with feature agorapulse-micronaut-console adds dependency #groupId:#artifactId for #language"(Language language, BuildTool buildTool, String groupId, String artifactId) {
         given:
         List<String> features = ['agorapulse-micronaut-console']
@@ -81,7 +79,6 @@ class ConsoleSpec extends ApplicationContextSpec {
         Language.KOTLIN | BuildTool.MAVEN           | 'org.jetbrains.kotlin'    | 'kotlin-scripting-jsr223'
     }
 
-    @PendingFeature(reason = "agora community features do not support Micronaut Framework 4 yet")
     void 'verify agorapulse-micronaut-console configuration'() {
         when:
             GeneratorContext commandContext = buildGeneratorContext(['agorapulse-micronaut-console'])

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/gru/GruHttpSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/gru/GruHttpSpec.groovy
@@ -5,7 +5,6 @@ import io.micronaut.starter.BuildBuilder
 import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Feature
 import io.micronaut.starter.options.BuildTool
-import spock.lang.PendingFeature
 
 class GruHttpSpec extends ApplicationContextSpec {
 
@@ -40,7 +39,6 @@ class GruHttpSpec extends ApplicationContextSpec {
         }
     }
 
-    @PendingFeature(reason = "agora community features do not support Micronaut Framework 4 yet")
     void "#buildTool with feature agorapulse-gru-http adds dependency for #buildTool"(BuildTool buildTool) {
         given:
         String groupId = 'com.agorapulse'

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/permissions/PermissionsSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/permissions/PermissionsSpec.groovy
@@ -6,7 +6,6 @@ import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Feature
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import spock.lang.PendingFeature
 
 class PermissionsSpec extends ApplicationContextSpec {
 
@@ -35,7 +34,6 @@ class PermissionsSpec extends ApplicationContextSpec {
         }
     }
 
-    @PendingFeature(reason = "agora community features do not support Micronaut Framework 4 yet")
     void "#buildTool with feature micronaut-permissions adds dependency #groupId:#artifactId for #language"(Language language, BuildTool buildTool, String groupId, String artifactId) {
         given:
         List<String> features = ['agorapulse-micronaut-permissions']

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/slack/SlackSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/slack/SlackSpec.groovy
@@ -7,7 +7,6 @@ import io.micronaut.starter.application.generator.GeneratorContext
 import io.micronaut.starter.feature.Feature
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import spock.lang.PendingFeature
 
 class SlackSpec extends ApplicationContextSpec {
 
@@ -34,7 +33,6 @@ class SlackSpec extends ApplicationContextSpec {
         assert feature.supports(ApplicationType.DEFAULT)
     }
 
-    @PendingFeature(reason = "agora community features do not support Micronaut Framework 4 yet")
     void "#buildTool with feature micronaut-slack adds dependency #groupId:#artifactId for #language"(Language language, BuildTool buildTool, String groupId, String artifactId) {
         given:
         List<String> features = ['agorapulse-micronaut-slack']
@@ -67,7 +65,6 @@ class SlackSpec extends ApplicationContextSpec {
         Language.KOTLIN | BuildTool.MAVEN           | 'com.agorapulse'          | 'micronaut-slack-http'
     }
 
-    @PendingFeature(reason = "agora community features do not support Micronaut Framework 4 yet")
     void 'verify micronaut-slack configuration'() {
         when:
         GeneratorContext commandContext = buildGeneratorContext(['agorapulse-micronaut-slack'])
@@ -76,7 +73,6 @@ class SlackSpec extends ApplicationContextSpec {
         commandContext.configuration.get('slack.bot-token').toString().startsWith('xoxb-')
     }
 
-    @PendingFeature(reason = "agora community features do not support Micronaut Framework 4 yet")
     void 'verify micronaut-slack configuration with caffeine'() {
         when:
             GeneratorContext commandContext = buildGeneratorContext(['agorapulse-micronaut-slack', 'cache-caffeine'])
@@ -84,7 +80,6 @@ class SlackSpec extends ApplicationContextSpec {
             commandContext.configuration.get('micronaut.caches.slack-events.expire-after-write') == '10m'
     }
 
-    @PendingFeature(reason = "agora community features do not support Micronaut Framework 4 yet")
     void 'verify micronaut-slack configuration with redis'() {
         when:
             GeneratorContext commandContext = buildGeneratorContext(['agorapulse-micronaut-slack', 'redis-lettuce'])
@@ -92,7 +87,6 @@ class SlackSpec extends ApplicationContextSpec {
             commandContext.configuration.get('redis.caches.slack-events.expire-after-write') == '10m'
     }
 
-    @PendingFeature(reason = "agora community features do not support Micronaut Framework 4 yet")
     void 'verify micronaut-slack configuration with ehcache'() {
         when:
             GeneratorContext commandContext = buildGeneratorContext(['agorapulse-micronaut-slack', 'cache-ehcache'])

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/worker/WorkerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/agorapulse/worker/WorkerSpec.groovy
@@ -6,7 +6,6 @@ import io.micronaut.starter.application.ApplicationType
 import io.micronaut.starter.feature.Feature
 import io.micronaut.starter.options.BuildTool
 import io.micronaut.starter.options.Language
-import spock.lang.PendingFeature
 
 class WorkerSpec extends ApplicationContextSpec {
 
@@ -41,7 +40,6 @@ class WorkerSpec extends ApplicationContextSpec {
         }
     }
 
-    @PendingFeature(reason = "agora community features do not support Micronaut Framework 4 yet")
     void "#buildTool with feature agorapulse-micronaut-worker adds dependency #groupId:#artifactId for #language"(Language language, BuildTool buildTool, String groupId, String artifactId) {
         given:
         List<String> features = ['agorapulse-micronaut-worker']

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/console/ConsoleSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/console/ConsoleSpec.groovy
@@ -6,11 +6,8 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.CommandSpec
 import org.gradle.testkit.runner.BuildResult
-import spock.lang.Ignore
-import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
-@Ignore("agora community features do not support Micronaut Framework 4 yet")
 class ConsoleSpec extends CommandSpec {
 
     @Override

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/gru/GruHttpSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/gru/GruHttpSpec.groovy
@@ -6,11 +6,8 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.CommandSpec
 import org.gradle.testkit.runner.BuildResult
-import spock.lang.Ignore
-import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
-@Ignore("agora community features do not support Micronaut Framework 4 yet")
 class GruHttpSpec extends CommandSpec {
 
     @Override

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/permissions/PermissionsSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/permissions/PermissionsSpec.groovy
@@ -6,10 +6,8 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.CommandSpec
 import org.gradle.testkit.runner.BuildResult
-import spock.lang.Ignore
 import spock.lang.Unroll
 
-@Ignore("agora community features do not support Micronaut Framework 4 yet")
 class PermissionsSpec extends CommandSpec {
 
     @Override

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/slack/SlackSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/slack/SlackSpec.groovy
@@ -7,13 +7,10 @@ import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.CommandSpec
 import org.gradle.testkit.runner.BuildResult
 import org.yaml.snakeyaml.Yaml
-import spock.lang.Ignore
-import spock.lang.IgnoreIf
 
 import java.nio.file.Files
 import java.nio.file.Paths
 
-@Ignore("agora community features do not support Micronaut Framework 4 yet")
 class SlackSpec extends CommandSpec {
 
     @Override

--- a/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/worker/WorkerSpec.groovy
+++ b/test-features/src/test/groovy/io/micronaut/starter/core/test/feature/agorapulse/worker/WorkerSpec.groovy
@@ -6,11 +6,8 @@ import io.micronaut.starter.options.Language
 import io.micronaut.starter.options.TestFramework
 import io.micronaut.starter.test.CommandSpec
 import org.gradle.testkit.runner.BuildResult
-import spock.lang.Ignore
-import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
-@Ignore("agora community features do not support Micronaut Framework 4 yet")
 class WorkerSpec extends CommandSpec {
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-starter/issues/2763

Agora now supports Micronaut 4, so this PR re-enables the tests that were disabled in [#2180](https://github.com/micronaut-projects/micronaut-starter/pull/2180).
