### PR TITLE
Fix Log4j2 SLF4J binding compatibility for Micronaut 4.x (SLF4J 2.0)

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/logging/Log4j2.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/logging/Log4j2.java
@@ -73,7 +73,7 @@ public class Log4j2 implements LoggingFeature {
                 .runtime());
         generatorContext.addDependency(Dependency.builder()
                 .groupId(GROUP_ID)
-                .artifactId("log4j-slf4j-impl")
+                .artifactId("log4j-slf4j2-impl")
                 .runtime());
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/Log4j2Spec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/logging/Log4j2Spec.groovy
@@ -24,7 +24,7 @@ class Log4j2Spec extends ApplicationContextSpec {
         verifier.hasBom("org.apache.logging.log4j", "log4j-bom", Scope.COMPILE)
         verifier.hasDependency("org.apache.logging.log4j", "log4j-api", Scope.COMPILE)
         verifier.hasDependency("org.apache.logging.log4j", "log4j-core", Scope.RUNTIME)
-        verifier.hasDependency("org.apache.logging.log4j", "log4j-slf4j-impl", Scope.RUNTIME)
+        verifier.hasDependency("org.apache.logging.log4j", "log4j-slf4j2-impl", Scope.RUNTIME)
 
         where:
         buildTool << BuildTool.values()


### PR DESCRIPTION
Close: #2686 
Resolve SLF4J provider warnings when generating and running a Micronaut application with the Log4j2 feature.
- The Log4j2 feature was adding the legacy `log4j-slf4j-impl` dependency, which targets SLF4J 1.7.x.
- Micronaut 4.x uses SLF4J 2.0.x, causing the binding to be ignored (with warnings about no providers and defaulting to NOP logger).
fix :
 Updated `Log4j2` to add `log4j-slf4j2-impl` (the SLF4J 2.0-compatible binding) as a runtime dependency instead of `log4j-slf4j-impl`.
Reference:
https://logging.apache.org/log4j/2.12.x/log4j-slf4j-impl/