### PR TITLE
Adds micronaut-core-reactive for openapi feature

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/other/OpenApi.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/other/OpenApi.java
@@ -70,6 +70,12 @@ public class OpenApi implements Feature, MicronautServerDependent {
     public void apply(GeneratorContext generatorContext) {
         generatorContext.addDependency(micronautOpenApiProcessor(generatorContext));
         generatorContext.addDependency(DEPENDENCY_OPENAPI_ANNOTATIONS);
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
+            generatorContext.addDependency(MicronautDependencyUtils.coreDependency()
+                    .artifactId("micronaut-core-reactive")
+                    .runtime()
+                    .build());
+        }
         if (generatorContext.getBuildTool() == BuildTool.MAVEN && generatorContext.getLanguage() == Language.GROOVY) {
             generatorContext.addDependency(MicronautDependencyUtils.openapi()
                     .artifactId(ARTIFACT_ID_MICRONAUT_OPENAPI)

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/other/OpenApiSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/other/OpenApiSpec.groovy
@@ -46,6 +46,7 @@ class OpenApiSpec extends ApplicationContextSpec  implements CommandOutputFixtur
         if (buildTool == BuildTool.MAVEN) {
             // property is not defined it is inherited via the bom
             assert !parsePropertySemanticVersion(template, "micronaut.openapi.version").isPresent()
+            assert verifier.hasDependency("io.micronaut", "micronaut-core-reactive", Scope.RUNTIME)
         }
 
         where:


### PR DESCRIPTION
 * Adds micronaut-core-reactive explicitly for Maven builds to ensure async publisher utilities
Closes: https://github.com/micronaut-projects/micronaut-openapi/issues/2564
cc @altro3 