### PR TITLE
update OS X Intel build image to macos-15-intel

### DIFF
--- a/.github/workflows/mn-macos-snapshot.yml
+++ b/.github/workflows/mn-macos-snapshot.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   intel:
     name: Builds OS X Intel Native CLI
-    runs-on: macos-14
+    runs-on: macos-15-intel
     steps:
       - name: "⬇ Checkout the repository"
         uses: actions/checkout@v5


### PR DESCRIPTION
OS X builds are generating ARM binaries

see: https://github.com/micronaut-projects/micronaut-starter/issues/2999

Updated OS X Intel build image to macos-15-intel