### PR TITLE
Enable Rocker optimize flag for build cache compatibility

### DIFF
--- a/starter-cli/build.gradle
+++ b/starter-cli/build.gradle
@@ -113,6 +113,7 @@ rocker {
     version = rockerVersion
     configurations {
         main {
+            optimize = true
             discardLogicWhitespace = true
             templateDir = file('src/rocker')
             outputDir = file('src/generated/rocker')

--- a/starter-core/build.gradle
+++ b/starter-core/build.gradle
@@ -45,6 +45,7 @@ rocker {
     version = rockerVersion
     configurations{
         main {
+            optimize = true
             discardLogicWhitespace = true
             templateDir = file('src/rocker')
             outputDir = file('src/generated/rocker')

--- a/test-features/build.gradle
+++ b/test-features/build.gradle
@@ -20,6 +20,7 @@ rocker {
     version = rockerVersion
     configurations {
         main {
+            optimize = true
             discardLogicWhitespace = true
             templateDir = file('src/rocker')
             outputDir = file('src/generated/rocker')


### PR DESCRIPTION
## Summary
- Enables `optimize = true` in Rocker template configurations across `starter-cli`, `starter-core`, and `test-features` modules
- The optimize flag ensures Rocker generates deterministic output, making it compatible with Gradle build cache