### PR TITLE
 Fix missing Gradle dependency between JTE and KSP tasks

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/view/JTE.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/view/JTE.java
@@ -26,6 +26,7 @@ import io.micronaut.starter.build.gradle.GradleDsl;
 import java.util.Optional;
 import io.micronaut.starter.build.maven.MavenPlugin;
 import io.micronaut.starter.build.BuildPlugin;
+import io.micronaut.starter.feature.KotlinSymbolProcessing;
 import io.micronaut.starter.feature.build.Kapt;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.feature.server.MicronautServerDependent;
@@ -92,10 +93,13 @@ public class JTE implements ViewFeature, MicronautServerDependent {
         boolean patchKapt = generatorContext.getBuildTool().isGradle()
                 && generatorContext.getLanguage() == Language.KOTLIN
                 && generatorContext.hasFeature(Kapt.class);
+        boolean patchKsp = generatorContext.getBuildTool().isGradle()
+                && generatorContext.getLanguage() == Language.KOTLIN
+                && generatorContext.hasFeature(KotlinSymbolProcessing.class);
 
         GradlePlugin.Builder builder = GradlePlugin.builder()
                 .id("gg.jte.gradle")
-                .extension(new RockerWritable(gradlePluginJTE.template(patchKapt, JTE_SRC_DIR)))
+                .extension(new RockerWritable(gradlePluginJTE.template(patchKapt, patchKsp, JTE_SRC_DIR)))
                 .lookupArtifactId("jte-gradle-plugin");
         return builder.build();
     }

--- a/starter-core/src/rocker/io/micronaut/starter/rocker/feature/view/gradlePluginJTE.rocker.raw
+++ b/starter-core/src/rocker/io/micronaut/starter/rocker/feature/view/gradlePluginJTE.rocker.raw
@@ -1,4 +1,4 @@
-@args(boolean patchKaptOutputs, String path)
+@args(boolean patchKaptOutputs, boolean patchKspOutputs, String path)
 
 jte {
     sourceDirectory = file("@path").toPath()
@@ -7,7 +7,7 @@ jte {
 
 // Gradle requires that generateJte is run before some tasks
 tasks.configureEach {
-    if (@if (patchKaptOutputs) {name == "kaptGenerateStubsKotlin" || }name == "inspectRuntimeClasspath") {
-        mustRunAfter("generateJte")
+    if (@if (patchKaptOutputs) {name == "kaptGenerateStubsKotlin" || }@if (patchKspOutputs) {name == "kspKotlin" || }name == "inspectRuntimeClasspath") {
+        dependsOn("generateJte")
     }
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/view/JTESpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/view/JTESpec.groovy
@@ -58,6 +58,23 @@ jte {
         language << Language.values().toList()
     }
 
+    void 'test gradle views-jte feature with ksp adds generateJte dependency for kspKotlin'() {
+        when:
+        String template = new BuildBuilder(beanContext, BuildTool.GRADLE)
+                .language(Language.KOTLIN)
+                .features(['views-jte', 'ksp'])
+                .render()
+
+        then:
+        template.contains('''\
+// Gradle requires that generateJte is run before some tasks
+tasks.configureEach {
+    if (name == "kspKotlin" || name == "inspectRuntimeClasspath") {
+        dependsOn("generateJte")
+    }
+}''')
+    }
+
     @Unroll
     void 'test maven views-jte feature for language=#language'() {
         when:


### PR DESCRIPTION
Add explicit generateJte task wiring for Kotlin projects using views-jte with ksp.                                                                                                                                                                                                                                                                                                                                                          This fixes Gradle’s implicit dependency validation error where kspKotlin consumed JTE-generated sources without depending on generateJte.        
Closes: #2744