### PR TITLE
Fix views-react feature failing in native CLI due to classpath directory lookup

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/view/React.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/view/React.java
@@ -35,8 +35,7 @@ import io.micronaut.starter.template.RockerWritable;
 import io.micronaut.starter.template.URLTemplate;
 import jakarta.inject.Singleton;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.util.Objects;
 
 @Requires(property = "micronaut.starter.feature.views.react.enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
 @Singleton
@@ -85,8 +84,7 @@ public class React implements ViewFeature, MicronautServerDependent {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        try {
-            generatorContext.addDependency(MicronautDependencyUtils.viewsDependency().artifactId(ARTIFACT_ID).compile());
+        generatorContext.addDependency(MicronautDependencyUtils.viewsDependency().artifactId(ARTIFACT_ID).compile());
 
             if (generatorContext.getBuildTool().isGradle()) {
                 generatorContext.addDependency(Dependency.builder()
@@ -158,11 +156,16 @@ public class React implements ViewFeature, MicronautServerDependent {
 
             // Set up the frontend project. These are *not* resources under views/ because they're raw inputs that will
             // be minified and transpiled as part of the build pipeline.
-            var ourResourceURL = Thread.currentThread().getContextClassLoader().getResource("views/react").toString();
+            var classLoader = Thread.currentThread().getContextClassLoader();
             for (var fileName : FRONTEND_FILES) {
+                var resourceName = "views/react/" + fileName;
+                var resourceUrl = Objects.requireNonNull(
+                        classLoader.getResource(resourceName),
+                        () -> "Missing bundled resource " + resourceName
+                );
                 generatorContext.addTemplate(
                         fileName,
-                        new URLTemplate("src/main/js/" + fileName, new URL(ourResourceURL + "/" + fileName))
+                        new URLTemplate("src/main/js/" + fileName, resourceUrl)
                 );
             }
             var sourceFile = generatorContext.getSourcePath("/{packagePath}/AppController");
@@ -179,11 +182,8 @@ public class React implements ViewFeature, MicronautServerDependent {
                 generatorContext.addTemplate(unitTestSource, new RockerTemplate(unitTestSource, reactTestKotlin.template(generatorContext.getProject())));
             }
 
-            // This is technically no longer necessary, but as of Truffle 24.2 still prints a scary warning about it
-            // being experimental to the console. So we disable virtual threads in Micronaut by default.
-            generatorContext.getConfiguration().addNested("micronaut.executors.blocking.virtual", "false");
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);   // Cannot happen.
-        }
+        // This is technically no longer necessary, but as of Truffle 24.2 still prints a scary warning about it
+        // being experimental to the console. So we disable virtual threads in Micronaut by default.
+        generatorContext.getConfiguration().addNested("micronaut.executors.blocking.virtual", "false");
     }
 }


### PR DESCRIPTION
#### Summary
Fixes a `NullPointerException` when using the `views-react` feature with the native `mn` CLI. The issue was caused by relying on classpath **directory lookup**, which does not work reliably in GraalVM native images.

#### Problem

Running:

```bash
mn create-app --features=views-react demo1
```

resulted in:

```
| Error null
java.lang.NullPointerException
    at io.micronaut.starter.feature.view.React.apply(...)
```

This occurred in:

* installed `mn` CLI
* native image build

#### Root Cause

The implementation used:

```java
getResource("views/react")
```

to resolve a directory and then built child URLs from it.

While this works on the JVM, in GraalVM native image:

* individual resources are included
* but **directory resources are not accessible via `getResource`**

As a result:

```java
getResource("views/react") == null
```

leading to the NPE.

---

#### Solution

Replace directory-based lookup with **per-file resource resolution**:

```java
var resourceUrl = Objects.requireNonNull(
    classLoader.getResource("views/react/" + fileName),
    () -> "Missing bundled resource " + resourceName
);
```

This ensures:

* compatibility with native image
* explicit failure if a resource is missing
* no reliance on directory classpath behavior

---

#### Changes

* Removed directory-based resource resolution
* Switched to per-file lookup for all frontend templates
* Added clear error messages using `Objects.requireNonNull`
* Removed unused `URL` / `MalformedURLException` logic

---

#### Validation

Tested successfully with:

```bash
./gradlew clean :starter-core:build 
./gradlew micronaut-cli:nativeCompile --no-daemon
./starter-cli/build/native/nativeCompile/mn create-app --stacktrace --features=views-react demo1nativecheck
```

Closes: #2709 