### PR TITLE
Migrate distributed config features to config import

### DIFF
--- a/starter-core/src/main/java/io/micronaut/starter/feature/awsparameterstore/AwsParameterStore.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awsparameterstore/AwsParameterStore.java
@@ -33,14 +33,10 @@ public class AwsParameterStore implements DistributedConfigFeature {
     private static final Dependency.Builder DEPENDNCY_MICRONAUT_AWS_PARAMETER_STORE = MicronautDependencyUtils.awsDependency()
             .artifactId(ARTIFACT_ID_MICRONAUT_AWS_PARAMETER_STORE)
             .compile();
-    private static final String PROPERTY_AWS_CLIENT_SYSTEM_MANAGER_PARAMETERSTORE_ENABLED = "aws.client.system-manager.parameterstore.enabled";
-    private static final String PROPERTY_AWS_DISTRIBUTED_CONFIGURATION_SEARCH_ACTIVE_ENVIRONMENTS = "aws.distributed-configuration.search-active-environments";
-    private static final String PROPERTY_AWS_DISTRIBUTED_CONFIGURATION_SEARCH_COMMON_APPLICATION = "aws.distributed-configuration.search-common-application";
+    private static final String PROPERTY_MICRONAUT_CONFIG_IMPORT = "micronaut.config.import";
 
     public static final Map<String, Object> PROPERTIES_AWS_DISTRIBUTED_CONFIGURATION = Map.of(
-            PROPERTY_AWS_CLIENT_SYSTEM_MANAGER_PARAMETERSTORE_ENABLED, true,
-        PROPERTY_AWS_DISTRIBUTED_CONFIGURATION_SEARCH_ACTIVE_ENVIRONMENTS, false,
-        PROPERTY_AWS_DISTRIBUTED_CONFIGURATION_SEARCH_COMMON_APPLICATION, false);
+            PROPERTY_MICRONAUT_CONFIG_IMPORT, "optional:parameterstore:///config/" + "${micronaut.application.name}");
 
     @Override
     public String getTitle() {
@@ -60,7 +56,7 @@ public class AwsParameterStore implements DistributedConfigFeature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         addDependencies(generatorContext);
-        addBootstrapProperties(generatorContext);
+        addConfigurationProperties(generatorContext);
     }
 
     @Override
@@ -73,8 +69,8 @@ public class AwsParameterStore implements DistributedConfigFeature {
         return "https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html";
     }
 
-    protected void addBootstrapProperties(@NonNull GeneratorContext generatorContext) {
-        populateBootstrapForDistributedConfiguration(generatorContext).putAll(PROPERTIES_AWS_DISTRIBUTED_CONFIGURATION);
+    protected void addConfigurationProperties(@NonNull GeneratorContext generatorContext) {
+        populateConfigurationForDistributedConfiguration(generatorContext).putAll(PROPERTIES_AWS_DISTRIBUTED_CONFIGURATION);
     }
 
     protected void addDependencies(@NonNull GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/awssecretsmanager/AwsSecretsManager.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/awssecretsmanager/AwsSecretsManager.java
@@ -21,7 +21,6 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
-import io.micronaut.starter.feature.awsparameterstore.AwsParameterStore;
 import io.micronaut.starter.feature.distributedconfig.DistributedConfigFeature;
 import jakarta.inject.Singleton;
 
@@ -37,6 +36,7 @@ public class AwsSecretsManager implements DistributedConfigFeature {
     private static final Dependency.Builder DEPENDENCY_MICRONAUT_AWS_SECRETSMANAGER = MicronautDependencyUtils.awsDependency()
             .artifactId(ARTIFACT_ID_MICRONAUT_AWS_SECRETSMANAGER)
             .compile();
+    private static final String PROPERTY_MICRONAUT_CONFIG_IMPORT = "micronaut.config.import";
 
     @Override
     public String getTitle() {
@@ -56,7 +56,7 @@ public class AwsSecretsManager implements DistributedConfigFeature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         addDependencies(generatorContext);
-        addBootstrapProperties(generatorContext);
+        addConfigurationProperties(generatorContext);
     }
 
     @Override
@@ -69,8 +69,9 @@ public class AwsSecretsManager implements DistributedConfigFeature {
         return "https://aws.amazon.com/secrets-manager/";
     }
 
-    protected void addBootstrapProperties(@NonNull GeneratorContext generatorContext) {
-        populateBootstrapForDistributedConfiguration(generatorContext).putAll(AwsParameterStore.PROPERTIES_AWS_DISTRIBUTED_CONFIGURATION);
+    protected void addConfigurationProperties(@NonNull GeneratorContext generatorContext) {
+        populateConfigurationForDistributedConfiguration(generatorContext)
+                .put(PROPERTY_MICRONAUT_CONFIG_IMPORT, "optional:aws-secretsmanager:///config/" + "${micronaut.application.name}");
     }
 
     protected static void addDependencies(@NonNull GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/azure/AzureKeyVaultFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/azure/AzureKeyVaultFeature.java
@@ -25,6 +25,8 @@ import io.micronaut.starter.feature.discovery.DiscoveryClient;
 import io.micronaut.starter.feature.distributedconfig.DistributedConfigFeature;
 import jakarta.inject.Singleton;
 
+import java.util.Map;
+
 /**
  * Azure Key Vault Feature.
  *
@@ -80,7 +82,13 @@ public class AzureKeyVaultFeature implements DistributedConfigFeature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         addDependencies(generatorContext);
-        populateBootstrapForDistributedConfiguration(generatorContext);
+        Map<String, Object> configuration = populateConfigurationForDistributedConfiguration(generatorContext);
+        configuration.put("micronaut.config.import.provider", "azure-key-vault");
+        configuration.put("micronaut.config.import.vault-url", "${AZURE_VAULT_URI}");
+        configuration.put("micronaut.config.import.credential-mode", "client-secret");
+        configuration.put("micronaut.config.import.client-id", "${AZURE_CLIENT_ID}");
+        configuration.put("micronaut.config.import.tenant-id", "${AZURE_TENANT_ID}");
+        configuration.put("micronaut.config.import.client-secret", "${AZURE_SECRET_VALUE}");
     }
 
     protected void addDependencies(GeneratorContext generatorContext) {

--- a/starter-core/src/main/java/io/micronaut/starter/feature/discovery/DiscoveryKubernetes.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/discovery/DiscoveryKubernetes.java
@@ -50,8 +50,8 @@ public class DiscoveryKubernetes implements DiscoveryFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.getBootstrapConfiguration().put("kubernetes.client.discovery.mode", "endpoint");
-        generatorContext.getBootstrapConfiguration().put("kubernetes.client.discovery.mode-configuration.endpoint.watch.enabled", true);
+        generatorContext.getConfiguration().put("kubernetes.client.discovery.mode", "endpoint");
+        generatorContext.getConfiguration().put("kubernetes.client.discovery.mode-configuration.endpoint.watch.enabled", true);
         generatorContext.addDependency(DEPENDENCY_MICRONAUT_DISCOVERY_K8S);
     }
 

--- a/starter-core/src/main/java/io/micronaut/starter/feature/distributedconfig/DistributedConfigFeature.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/distributedconfig/DistributedConfigFeature.java
@@ -36,10 +36,15 @@ public interface DistributedConfigFeature extends Feature {
     }
 
     @NonNull
-    default Map<String, Object> populateBootstrapForDistributedConfiguration(@NonNull GeneratorContext generatorContext) {
-        Map<String, Object> config = generatorContext.getBootstrapConfiguration();
+    default Map<String, Object> populateConfigurationForDistributedConfiguration(@NonNull GeneratorContext generatorContext) {
+        Map<String, Object> config = generatorContext.getConfiguration();
         config.put("micronaut.application.name", generatorContext.getProject().getPropertyName());
-        config.put("micronaut.config-client.enabled", true);
         return config;
+    }
+
+    @NonNull
+    @Deprecated(forRemoval = true)
+    default Map<String, Object> populateBootstrapForDistributedConfiguration(@NonNull GeneratorContext generatorContext) {
+        return populateConfigurationForDistributedConfiguration(generatorContext);
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/distributedconfig/KubernetesConfig.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/distributedconfig/KubernetesConfig.java
@@ -71,7 +71,8 @@ public class KubernetesConfig implements DistributedConfigFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        populateBootstrapForDistributedConfiguration(generatorContext);
+        populateConfigurationForDistributedConfiguration(generatorContext)
+                .put("micronaut.config.import", "optional:kubernetes://configmap");
         generatorContext.addDependency(Dependency.builder()
                 .groupId(KubernetesClient.MICRONAUT_KUBERNETES_GROUP_ID)
                 .artifactId("micronaut-kubernetes-discovery-client")

--- a/starter-core/src/main/java/io/micronaut/starter/feature/gcp/secretsmanager/GoogleSecretManager.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/gcp/secretsmanager/GoogleSecretManager.java
@@ -47,7 +47,8 @@ public class GoogleSecretManager implements DistributedConfigFeature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         generatorContext.addDependency(gcpSecretManagerDependency());
-        populateBootstrapForDistributedConfiguration(generatorContext);
+        populateConfigurationForDistributedConfiguration(generatorContext)
+                .put("micronaut.config.import", "gcp-secret-manager://application");
     }
 
     @NonNull

--- a/starter-core/src/main/java/io/micronaut/starter/feature/oraclecloud/OracleCloudAutonomousDatabase.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/oraclecloud/OracleCloudAutonomousDatabase.java
@@ -44,6 +44,10 @@ public class OracleCloudAutonomousDatabase extends DatabaseDriverFeature {
             .artifactId("micronaut-oraclecloud-atp")
             .compile();
 
+    private static final Dependency.Builder DEPENDENCY_MICRONAUT_SERDE_ORACLE_JDBC_JSON = MicronautDependencyUtils.serdeDependency()
+            .artifactId("micronaut-serde-oracle-jdbc-json")
+            .compile();
+
     private final OracleCloudSdk oracleCloudSdkFeature;
 
     public OracleCloudAutonomousDatabase(JdbcFeature jdbcFeature,
@@ -158,5 +162,6 @@ public class OracleCloudAutonomousDatabase extends DatabaseDriverFeature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         generatorContext.addDependency(DEPENDENCY_MICRONAUT_ORACLECLOUD_ATP);
+        generatorContext.addDependency(DEPENDENCY_MICRONAUT_SERDE_ORACLE_JDBC_JSON);
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/oraclecloud/OracleCloudVault.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/oraclecloud/OracleCloudVault.java
@@ -24,8 +24,6 @@ import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.feature.distributedconfig.DistributedConfigFeature;
 import jakarta.inject.Singleton;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 @Requires(property = "micronaut.starter.feature.oracle.cloud.vault.enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
@@ -68,11 +66,10 @@ public class OracleCloudVault implements DistributedConfigFeature {
                 .compile());
         generatorContext.getConfiguration().put("oci.config.profile", "DEFAULT");
 
-        Map<String, Object> bootstrapConfiguration = populateBootstrapForDistributedConfiguration(generatorContext);
-        bootstrapConfiguration.put("oci.vault.config.enabled", true);
-        Map<String, String> map = new HashMap<>();
-        map.put("ocid", "");
-        map.put("compartment-ocid", "");
-        bootstrapConfiguration.put("oci.vault.vaults", Collections.singletonList(map));
+        Map<String, Object> configuration = populateConfigurationForDistributedConfiguration(generatorContext);
+        configuration.put("micronaut.config.import.provider", "oraclecloud-vault");
+        configuration.put("micronaut.config.import.config-profile", "DEFAULT");
+        configuration.put("micronaut.config.import.ocid", "");
+        configuration.put("micronaut.config.import.compartment-id", "");
     }
 }

--- a/starter-core/src/main/java/io/micronaut/starter/feature/other/AppName.java
+++ b/starter-core/src/main/java/io/micronaut/starter/feature/other/AppName.java
@@ -22,11 +22,9 @@ import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.DefaultFeature;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeaturePhase;
-import io.micronaut.starter.feature.distributedconfig.DistributedConfigFeature;
 import io.micronaut.starter.options.Options;
 import jakarta.inject.Singleton;
 
-import java.util.Map;
 import java.util.Set;
 
 @Requires(property = "micronaut.starter.feature.app.name.enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
@@ -55,13 +53,7 @@ public class AppName implements DefaultFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        Map<String, Object> appNameConfig;
-        if (generatorContext.isFeaturePresent(DistributedConfigFeature.class)) {
-            appNameConfig = generatorContext.getBootstrapConfiguration();
-        } else {
-            appNameConfig = generatorContext.getConfiguration();
-        }
-        appNameConfig.put("micronaut.application.name", generatorContext.getProject().getPropertyName());
+        generatorContext.getConfiguration().put("micronaut.application.name", generatorContext.getProject().getPropertyName());
     }
 
     @Override

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/awsparameterstore/AwsParameterStoreSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/awsparameterstore/AwsParameterStoreSpec.groovy
@@ -23,23 +23,21 @@ class AwsParameterStoreSpec extends ApplicationContextSpec implements CommandOut
         readme.contains('https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html')
     }
 
-    void 'test src/main/resources/boostrap.yml with feature aws-parameter-store contains config'() {
+    void 'test src/main/resources/application.yml with feature aws-parameter-store contains config import'() {
         when:
         Map<String, String> output = generate([Yaml.NAME, 'aws-parameter-store'])
-        String bootstrap = output["src/main/resources/bootstrap.yml"]
+        String application = output["src/main/resources/application.yml"]
 
         then:
-        bootstrap
+        application
+        !output.containsKey("src/main/resources/bootstrap.yml")
 
         when:
-        Map<String, Object> bootstrapYml = new org.yaml.snakeyaml.Yaml().load(bootstrap)
+        Map<String, Object> applicationYml = new org.yaml.snakeyaml.Yaml().load(application)
 
         then:
-        'foo' == bootstrapYml['micronaut']['application']['name']
-        true == bootstrapYml['micronaut']['config-client']['enabled']
-        true == bootstrapYml['aws']['client']['system-manager']['parameterstore']['enabled']
-        false == bootstrapYml['aws']['distributed-configuration']['search-active-environments']
-        false == bootstrapYml['aws']['distributed-configuration']['search-common-application']
+        'foo' == applicationYml['micronaut']['application']['name']
+        'optional:parameterstore:///config/${micronaut.application.name}' == applicationYml['micronaut']['config']['import']
     }
 
     @Unroll

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/awssecretsmanager/AwsSecretsManagerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/awssecretsmanager/AwsSecretsManagerSpec.groovy
@@ -23,22 +23,21 @@ class AwsSecretsManagerSpec extends ApplicationContextSpec implements CommandOut
         readme.contains('https://aws.amazon.com/secrets-manager/')
     }
 
-    void 'test src/main/resources/boostrap.yml with feature aws-secrets-manager contains config'() {
+    void 'test src/main/resources/application.yml with feature aws-secrets-manager contains config import'() {
         when:
         Map<String, String> output = generate([Yaml.NAME, 'aws-secrets-manager'])
-        String bootstrap = output["src/main/resources/bootstrap.yml"]
+        String application = output["src/main/resources/application.yml"]
 
         then:
-        bootstrap
+        application
+        !output.containsKey("src/main/resources/bootstrap.yml")
+
         when:
-        Map<String, Object> bootstrapYml = new org.yaml.snakeyaml.Yaml().load(bootstrap)
+        Map<String, Object> applicationYml = new org.yaml.snakeyaml.Yaml().load(application)
 
         then:
-        'foo' == bootstrapYml['micronaut']['application']['name']
-        true == bootstrapYml['micronaut']['config-client']['enabled']
-        true == bootstrapYml['aws']['client']['system-manager']['parameterstore']['enabled']
-        false == bootstrapYml['aws']['distributed-configuration']['search-active-environments']
-        false == bootstrapYml['aws']['distributed-configuration']['search-common-application']
+        'foo' == applicationYml['micronaut']['application']['name']
+        'optional:aws-secretsmanager:///config/${micronaut.application.name}' == applicationYml['micronaut']['config']['import']
     }
 
     @Unroll

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/azure/AzureKeyVaultFeatureSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/azure/AzureKeyVaultFeatureSpec.groovy
@@ -38,11 +38,18 @@ class AzureKeyVaultFeatureSpec extends ApplicationContextSpec implements Command
     void "test azure-key-vault feature configuration"() {
         when:
         AzureKeyVaultFeature feature = beanContext.getBean(AzureKeyVaultFeature)
-        def config = buildGeneratorContext([feature.name]).bootstrapConfiguration
+        def context = buildGeneratorContext([feature.name])
+        def config = context.configuration
 
         then:
         config.containsKey("micronaut.application.name")
-        config.containsKey("micronaut.config-client.enabled")
+        config["micronaut.config.import.provider"] == "azure-key-vault"
+        config["micronaut.config.import.vault-url"] == '${AZURE_VAULT_URI}'
+        config["micronaut.config.import.credential-mode"] == 'client-secret'
+        config["micronaut.config.import.client-id"] == '${AZURE_CLIENT_ID}'
+        config["micronaut.config.import.tenant-id"] == '${AZURE_TENANT_ID}'
+        config["micronaut.config.import.client-secret"] == '${AZURE_SECRET_VALUE}'
+        !context.bootstrapConfiguration.containsKey("micronaut.config-client.enabled")
     }
 
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/coherence/CoherenceDistributedConfigurationSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/coherence/CoherenceDistributedConfigurationSpec.groovy
@@ -30,14 +30,13 @@ class CoherenceDistributedConfigurationSpec extends BeanContextSpec implements C
         String configuration = output['src/main/resources/bootstrap.yml']
 
         then:
-        configuration
-        configuration.contains("""
+        configuration.trim() == """
 coherence:
   client:
     enabled: true
     host: \${COHERENCE_HOST:localhost}
     port: \${COHERENCE_PORT:1408}
-""")
+""".trim()
     }
 
     @Unroll

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryKubernetesSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/discovery/DiscoveryKubernetesSpec.groovy
@@ -47,8 +47,8 @@ class DiscoveryKubernetesSpec extends ApplicationContextSpec implements CommandO
         GeneratorContext commandContext = buildGeneratorContext(['discovery-kubernetes'])
 
         then:
-        commandContext.bootstrapConfiguration.get('kubernetes.client.discovery.mode-configuration.endpoint.watch.enabled'.toString()) == true
-        commandContext.bootstrapConfiguration.get('kubernetes.client.discovery.mode') == 'endpoint'
+        commandContext.configuration.get('kubernetes.client.discovery.mode-configuration.endpoint.watch.enabled'.toString()) == true
+        commandContext.configuration.get('kubernetes.client.discovery.mode') == 'endpoint'
     }
 
 }

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/distributedconfig/DistributedConfigConsulSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/distributedconfig/DistributedConfigConsulSpec.groovy
@@ -101,8 +101,8 @@ class DistributedConfigConsulSpec extends ApplicationContextSpec  implements Com
         GeneratorContext commandContext = buildGeneratorContext(['config-consul'])
 
         then:
-        commandContext.bootstrapConfiguration.get('micronaut.application.name'.toString()) == 'foo'
-        commandContext.bootstrapConfiguration.get('micronaut.config-client.enabled'.toString()) == true
+        commandContext.configuration.get('micronaut.application.name'.toString()) == 'foo'
+        !commandContext.bootstrapConfiguration.containsKey('micronaut.config-client.enabled'.toString())
         commandContext.bootstrapConfiguration.get('consul.client.defaultZone') == '${CONSUL_HOST:localhost}:${CONSUL_PORT:8500}'
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/distributedconfig/KubernetesConfigSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/distributedconfig/KubernetesConfigSpec.groovy
@@ -75,8 +75,9 @@ class KubernetesConfigSpec extends ApplicationContextSpec  implements CommandOut
         GeneratorContext commandContext = buildGeneratorContext(['config-kubernetes'])
 
         then:
-        commandContext.bootstrapConfiguration.get('micronaut.application.name'.toString()) == 'foo'
-        commandContext.bootstrapConfiguration.get('micronaut.config-client.enabled'.toString()) == true
+        commandContext.configuration.get('micronaut.application.name'.toString()) == 'foo'
+        commandContext.configuration.get('micronaut.config.import'.toString()) == 'optional:kubernetes://configmap'
+        commandContext.bootstrapConfiguration.get('micronaut.config-client.enabled'.toString()) == null
         commandContext.templates.get('k8sYaml')
     }
 

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/oracecloud/OracleCloudAutonomousDatabaseSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/oracecloud/OracleCloudAutonomousDatabaseSpec.groovy
@@ -29,6 +29,7 @@ class OracleCloudAutonomousDatabaseSpec extends ApplicationContextSpec implement
                 .render()
         then:
         template.contains('implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-atp")')
+        template.contains('implementation("io.micronaut.serde:micronaut-serde-oracle-jdbc-json")')
 
         and:
         template.contains("additionalModules.add(\"jdbc-oracle-free\")")
@@ -48,6 +49,7 @@ class OracleCloudAutonomousDatabaseSpec extends ApplicationContextSpec implement
 
         then:
         verifier.hasDependency("io.micronaut.oraclecloud", "micronaut-oraclecloud-atp", Scope.COMPILE)
+        verifier.hasDependency("io.micronaut.serde", "micronaut-serde-oracle-jdbc-json", Scope.COMPILE)
         where:
         language << supportedLanguages(BuildTool.MAVEN)
     }
@@ -89,9 +91,12 @@ class OracleCloudAutonomousDatabaseSpec extends ApplicationContextSpec implement
                 new Options(Language.JAVA, TestFramework.SPOCK, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [Yaml.NAME, 'oracle-cloud-atp', "data-jdbc"])
         String config = output["src/main/resources/application.yml"]
+        String pom = output["pom.xml"]
 
         then:
         !config.contains('dialect: H2')
+        pom.contains('<artifactId>micronaut-serde-oracle-jdbc-json</artifactId>')
+        !pom.contains('<artifactId>micronaut-serde-oracle-jdbc-json</artifactId>\n      <version>')
     }
 
     void 'test config with a driver config feature'() {
@@ -100,8 +105,11 @@ class OracleCloudAutonomousDatabaseSpec extends ApplicationContextSpec implement
                 new Options(Language.JAVA, TestFramework.SPOCK, BuildTool.MAVEN, MicronautJdkVersionConfiguration.DEFAULT_OPTION),
                 [Yaml.NAME, 'oracle-cloud-atp', "data-jdbc"])
         String config = output["src/main/resources/application.yml"]
+        String pom = output["pom.xml"]
 
         then:
+        pom.contains('<artifactId>micronaut-serde-oracle-jdbc-json</artifactId>')
+        !pom.contains('<artifactId>micronaut-serde-oracle-jdbc-json</artifactId>\n      <version>')
         config.contains("""
     ocid: ''
     walletPassword: ''

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/oracecloud/OracleCloudVaultSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/oracecloud/OracleCloudVaultSpec.groovy
@@ -24,40 +24,25 @@ class OracleCloudVaultSpec extends ApplicationContextSpec implements CommandOutp
         readme.contains("https://docs.oracle.com/en-us/iaas/Content/KeyManagement/home.htm")
     }
 
-    void 'test src/main/resources/boostrap.yml with feature oracle-cloud-vault contains config'() {
+    void 'test src/main/resources/application.yml with feature oracle-cloud-vault contains config import'() {
         when:
         Map<String, String> output = generate([Yaml.NAME, 'oracle-cloud-vault'])
-        String bootstrap = output["src/main/resources/bootstrap.yml"]
+        String application = output["src/main/resources/application.yml"]
 
         then:
-        bootstrap
-        bootstrap.contains('''\
-micronaut:
-  application:
-    name: foo
-  config-client:
-    enabled: true
-''')
-        bootstrap.contains('''\
-oci:
-  vault:
-    config:
-      enabled: true
-    vaults:
-    - compartment-ocid: ''
-      ocid: ''
-''')
+        application
+        !output.containsKey("src/main/resources/bootstrap.yml")
 
         when: 'verify YAML types are correct'
 
-        Map<String, Object> bootstrapYml = new org.yaml.snakeyaml.Yaml().load(bootstrap)
+        Map<String, Object> applicationYml = new org.yaml.snakeyaml.Yaml().load(application)
 
         then:
-        bootstrapYml.oci.vault.config.enabled
-        bootstrapYml.oci.vault.vaults instanceof List
-        bootstrapYml.oci.vault.vaults.size() == 1
-        bootstrapYml.oci.vault.vaults[0].'compartment-ocid' == ''
-        bootstrapYml.oci.vault.vaults[0].ocid == ''
+        applicationYml.micronaut.config.import.provider == 'oraclecloud-vault'
+        applicationYml.micronaut.config.import.'config-profile' == 'DEFAULT'
+        applicationYml.micronaut.config.import.ocid == ''
+        applicationYml.micronaut.config.import.'compartment-id' == ''
+        applicationYml.'oci.config.profile' == 'DEFAULT'
     }
 
     @Unroll

--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/secretsmanager/GoogleSecretManagerSpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/secretsmanager/GoogleSecretManagerSpec.groovy
@@ -21,19 +21,20 @@ class GoogleSecretManagerSpec extends ApplicationContextSpec implements CommandO
         readme.contains('https://cloud.google.com/secret-manager')
     }
 
-    void 'test src/main/resources/boostrap.yml with feature gcp-secrets-manager contains config'() {
+    void 'test src/main/resources/application.yml with feature gcp-secrets-manager contains config import'() {
         when:
         Map<String, String> output = generate([Yaml.NAME, 'gcp-secrets-manager'])
-        String bootstrap = output["src/main/resources/bootstrap.yml"]
+        String application = output["src/main/resources/application.yml"]
 
         then:
-        bootstrap
-        bootstrap.contains('''\
+        application
+        !output.containsKey("src/main/resources/bootstrap.yml")
+        application.contains('''\
 micronaut:
   application:
     name: foo
-  config-client:
-    enabled: true
+  config:
+    import: gcp-secret-manager://application
 ''')
     }
 


### PR DESCRIPTION
This migrates the distributed configuration Starter features that now use Micronaut config import away from generated bootstrap configuration.

Changes:
- write distributed config imports to normal application configuration
- keep `micronaut.application.name` in application configuration even when distributed config features are selected
- update AWS Parameter Store, AWS Secrets Manager, Kubernetes config, GCP Secret Manager, Azure Key Vault, and OCI Vault feature defaults
- preserve the legacy bootstrap helper as deprecated for existing features that still use it
- update feature specs to assert `application.yml` output and absence of generated bootstrap config for migrated providers

Verification:
- `./gradlew --no-daemon starter-core:test --tests '*AwsParameterStoreSpec' --tests '*AwsSecretsManagerSpec' --tests '*KubernetesConfigSpec' --tests '*GoogleSecretManagerSpec' --tests '*AzureKeyVaultFeatureSpec' --tests '*OracleCloudVaultSpec' --stacktrace -PmicronautVersion=5.0.0 -PmicronautCoreVersion=5.0.0`
- `git diff --check`
