### PR TITLE
Scope SharedArenaSupport native-image unlock

### DIFF
--- a/starter-core/src/rocker/io/micronaut/starter/rocker/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/starter-core/src/rocker/io/micronaut/starter/rocker/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -193,7 +193,11 @@ graalvmNative.toolchainDetection = false
 graalvmNative {
     binaries {
         all {
-            buildArgs.add("-H:+SharedArenaSupport")
+            buildArgs.addAll(
+                    "-H:+UnlockExperimentalVMOptions",
+                    "-H:+SharedArenaSupport",
+                    "-H:-UnlockExperimentalVMOptions",
+            )
 @if (features.contains("oracle-function") && !features.contains("oracle-function-http")) {
             buildArgs.addAll(
                          "-H:+StaticExecutableWithDynamicLibC",
@@ -349,5 +353,4 @@ sourceSets {
 @gradleBuild.renderExtensions()
 @io.micronaut.starter.rocker.feature.test.template.failOnNoDiscoveredTests.template(gradleBuild.getDsl())
 @gradleBuild.renderSubstitutions()
-
 


### PR DESCRIPTION
## Summary

- Wrap the generated `-H:+SharedArenaSupport` native-image argument with `-H:+UnlockExperimentalVMOptions` and `-H:-UnlockExperimentalVMOptions`.
- Keep the Netty/JDK 25 workaround while avoiding a globally unlocked native-image invocation.

Fixes #3121.

## Motivation

This failed in GraalVM CI in `Weekly Micronaut Tests (--future-defaults=all)`, job `call-template / Native Tests`:

https://github.com/oracle/graal/actions/runs/27521563569

That run generated a JDK 25 Micronaut Gradle app from Launch and ran `./gradlew nativeTest` with `NATIVE_IMAGE_EXPERIMENTAL_OPTIONS_ARE_FATAL=true`. Native Image failed with:

```text
Warning: The option '-H:+SharedArenaSupport' is experimental and must be enabled via '-H:+UnlockExperimentalVMOptions' in the future.
Error: Not all experimental options were unlocked.
```

## Testing

- `git diff --check`
