### PR TITLE
Add Python Flyway version regression

### DIFF
--- a/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/FlywaySpec.groovy
+++ b/starter-core/src/test/groovy/io/micronaut/starter/feature/migration/FlywaySpec.groovy
@@ -50,6 +50,14 @@ flyway:
         buildTool << BuildToolUtils.jvmBuildTools()
     }
 
+    void "test Pyronaut uses the native-compatible Flyway version"() {
+        when:
+        BuildTestVerifier verifier = verifier(BuildTool.PYRONAUT, ['flyway'])
+
+        then:
+        verifier.hasDependency("io.micronaut.flyway", "micronaut-flyway", Scope.COMPILE, "8.1.1", false)
+    }
+
     private BuildTestVerifier verifier(BuildTool buildTool, List<String> features) {
         String template = new BuildBuilder(beanContext, buildTool)
                 .features(features)


### PR DESCRIPTION
## Summary

- Verify that Python projects resolve the native-compatible Micronaut Flyway 8.1.1 version.
- Keep the existing JVM build-tool coverage unchanged.

The upstream `python-support-5.2.x` branch already contains the Pyronaut defaults and Flyway pin; this adds focused regression coverage for the Python dependency output.

Tested with:

    ./gradlew :starter-core:test --tests io.micronaut.starter.feature.migration.FlywaySpec --no-daemon --console plain

Result: 24 Flyway tests passed. The related Python and Python-validator specs
also pass: 28 tests total with

    ./gradlew :starter-core:test --tests io.micronaut.starter.feature.build.pyronaut.PyronautSpec --tests io.micronaut.starter.feature.validation.PythonFeatureValidatorSpec --no-daemon --console plain
